### PR TITLE
Fix learned kanji not being saved: stale closure in handleFinishSession

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -156,8 +156,14 @@ export default function App() {
     const totalExp = sessionData.earnedExp + (additionalResults.exp || 0); const coinBonus = Math.floor(totalExp / 2) + (additionalResults.coins || 0); const rareChance = 0.1 + (stats.streak * 0.01); let rareDrop = additionalResults.rareDrop || null;
     if (!rareDrop && Math.random() < Math.min(rareChance, 0.5)) { const rares = ['t_torii', 't_temple', 't_castle', 't_dragon', 't_kakejiku']; rareDrop = rares[Math.floor(Math.random() * rares.length)]; }
     const finalSessionData = { ...sessionData, earnedExp: totalExp, rareDrop, perfectCount: sessionData.perfectCount + (additionalResults.perfectCount || 0) };
-    setSessionData(finalSessionData); let newStats = StorageAPI.updateDaily(stats, totalExp, finalSessionData); newStats.coins = (newStats.coins || 0) + coinBonus;
-    StorageAPI.saveStats(newStats); setStats(newStats); setView('result');
+    setSessionData(finalSessionData);
+    setStats(prevStats => {
+      const newStats = StorageAPI.updateDaily({ ...prevStats }, totalExp, finalSessionData);
+      newStats.coins = (newStats.coins || 0) + coinBonus;
+      StorageAPI.saveStatsImmediate(newStats);
+      return newStats;
+    });
+    setView('result');
   };
 
   const GlobalStyle = () => {


### PR DESCRIPTION
handleFinishSession was reading the stale `stats` closure value instead of the latest React state. Since handleUpdateStat uses functional setStats updates (s => ...) but handleFinishSession used direct setStats(newStats), the final direct set overwrote all kanjiStats changes from the session.

This caused:
- Dictionary showing all kanji as "未学習" after completing study
- Villagers not being added (population stayed at 0)
- All SRS progress lost on each session

Fix: Use functional setStats updater in handleFinishSession to read prevStats (the latest state including all kanjiStats updates), and use saveStatsImmediate instead of debounced save to ensure persistence.

https://claude.ai/code/session_01VuCDzV2N6mjjvV4Lo4JKWZ