### PR TITLE
Fix dictionary showing 'review' kanji as unlearned + safe state copy

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -158,7 +158,8 @@ export default function App() {
     const finalSessionData = { ...sessionData, earnedExp: totalExp, rareDrop, perfectCount: sessionData.perfectCount + (additionalResults.perfectCount || 0) };
     setSessionData(finalSessionData);
     setStats(prevStats => {
-      const newStats = StorageAPI.updateDaily({ ...prevStats }, totalExp, finalSessionData);
+      const copy = JSON.parse(JSON.stringify(prevStats));
+      const newStats = StorageAPI.updateDaily(copy, totalExp, finalSessionData);
       newStats.coins = (newStats.coins || 0) + coinBonus;
       StorageAPI.saveStatsImmediate(newStats);
       return newStats;

--- a/src/components/pages/DictionaryView.jsx
+++ b/src/components/pages/DictionaryView.jsx
@@ -11,8 +11,8 @@ const DictionaryView = ({ kanjiStats, onBack, onSelectKanji }) => {
     const matchSearch = search === '' || k.char.includes(search) || k.on.some(o => o.includes(search.toUpperCase())) || k.kun.some(ku => ku.includes(search));
     return matchGrade && matchSearch;
   });
-  const getStatusColor = (id) => { const s = kanjiStats?.[id]?.status; if (s === 'mastered') return 'bg-emerald-100 border-emerald-400'; if (s === 'learning') return 'bg-sky-100 border-sky-400'; return 'bg-gray-100 border-gray-300'; };
-  const getStatusLabel = (id) => { const s = kanjiStats?.[id]?.status; if (s === 'mastered') return '習得'; if (s === 'learning') return '学習中'; return '未学習'; };
+  const getStatusColor = (id) => { const s = kanjiStats?.[id]?.status; if (s === 'mastered') return 'bg-emerald-100 border-emerald-400'; if (s === 'review') return 'bg-violet-100 border-violet-400'; if (s === 'learning') return 'bg-sky-100 border-sky-400'; return 'bg-gray-100 border-gray-300'; };
+  const getStatusLabel = (id) => { const s = kanjiStats?.[id]?.status; if (s === 'mastered') return '習得'; if (s === 'review') return '復習中'; if (s === 'learning') return '学習中'; return '未学習'; };
 
   return (
     <div className="flex flex-col gap-4 pb-8">


### PR DESCRIPTION
Two bugs fixed:

1. DictionaryView only recognized 'mastered' and 'learning' statuses. Kanji with 'review' status (graduated from learning but not yet mastered) were displayed as '未学習'. Added 'review' → '復習中' with violet styling.

2. handleFinishSession's functional updater used a shallow copy ({...prevStats}) which shared nested object references with React state. updateDaily mutates its input, so this could corrupt React's internal state. Now uses JSON deep copy for safety.

https://claude.ai/code/session_01VuCDzV2N6mjjvV4Lo4JKWZ