### PR TITLE
Phase 2: マップ拡張 20×20→50×50、バイオーム・新地形実装

### DIFF
--- a/src/components/pages/HomeView.jsx
+++ b/src/components/pages/HomeView.jsx
@@ -33,7 +33,7 @@ const HomeView = ({ setView, stats, setStats, startSession, startFlashcard, star
         </div>
         <div className="w-full h-4 bg-gray-200 rounded-full overflow-hidden border-2 border-[var(--text)]"><motion.div initial={{ width: 0 }} animate={{ width: `${progress}%` }} className="h-full bg-[var(--secondary)]"></motion.div></div>
         <div className="w-full h-[150px] relative">
-          <DraggableTownMap mapData={stats.townMap} isDanger={isReviewNeeded} isEditing={false} reviewCount={reviewTargetsCount} kakejikuImg={stats.kakejiku} villagers={stats.villagers || []} exploredRadius={stats.exploredRadius || 2} />
+          <DraggableTownMap mapData={stats.townMap} biomeMap={stats.biomeMap} isDanger={isReviewNeeded} isEditing={false} reviewCount={reviewTargetsCount} kakejikuImg={stats.kakejiku} villagers={stats.villagers || []} exploredRadius={stats.exploredRadius || 3} />
         </div>
         {(() => {
           const masteredCount = Object.values(stats.kanjiStats || {}).filter(s => s.status === 'mastered').length;

--- a/src/components/town/DraggableTownMap.jsx
+++ b/src/components/town/DraggableTownMap.jsx
@@ -1,19 +1,49 @@
 import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { CloudRain, Sun } from 'lucide-react';
-import { TOWN_ITEMS, SvgBedrock, SvgRoughland, SvgWeed } from '../../data/town-items';
+import { TOWN_ITEMS, SvgBedrock, SvgRoughland, SvgWeed, SvgGrassland, SvgForestFloor, SvgSand, SvgShallowWater, SvgHighland } from '../../data/town-items';
+import { BIOME_TYPES } from '../../data/biomes';
 import VillagerDot from './VillagerDot';
 
-const DraggableTownMap = ({ mapData, isDanger, isEditing, onCellTap, reviewCount, kakejikuImg, villagers = [], exploredRadius = 11 }) => {
-  const GRID_SIZE = 20; const CELL_SIZE = 48; const MAP_SIZE = GRID_SIZE * CELL_SIZE;
+// Terrain SVG lookup for fast access
+const TERRAIN_SVG_MAP = {
+  t_bedrock: SvgBedrock,
+  t_roughland: SvgRoughland,
+  t_weed: SvgWeed,
+  t_grassland: SvgGrassland,
+  t_forest_floor: SvgForestFloor,
+  t_sand: SvgSand,
+  t_shallow_water: SvgShallowWater,
+  t_highland: SvgHighland,
+};
+
+// Cultivatable terrain types (can be cleared for building)
+const CULTIVATABLE_TERRAIN = new Set(['t_roughland', 't_grassland', 't_forest_floor', 't_sand', 't_highland']);
+
+const DraggableTownMap = ({ mapData, biomeMap, isDanger, isEditing, onCellTap, reviewCount, kakejikuImg, villagers = [], exploredRadius = 3 }) => {
+  const GRID_SIZE = 50; const CELL_SIZE = 48; const MAP_SIZE = GRID_SIZE * CELL_SIZE;
   const containerRef = useRef(null);
-  const [offset, setOffset] = useState({ x: -MAP_SIZE / 2 + 150, y: -MAP_SIZE / 2 + 100 });
+  const [containerSize, setContainerSize] = useState({ w: 400, h: 300 });
+  const C = 25; // center of 50x50 map
+  // Start centered on the town center
+  const [offset, setOffset] = useState({ x: -(C * CELL_SIZE) + 150, y: -(C * CELL_SIZE) + 100 });
   const isDragging = useRef(false); const lastPos = useRef({ x: 0, y: 0 });
   const onCellTapRef = useRef(onCellTap);
   useEffect(() => { onCellTapRef.current = onCellTap; }, [onCellTap]);
 
+  // Track container size for viewport culling
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const ro = new ResizeObserver((entries) => {
+      const { width, height } = entries[0].contentRect;
+      setContainerSize({ w: width, h: height });
+    });
+    ro.observe(containerRef.current);
+    return () => ro.disconnect();
+  }, []);
+
   const safeMapData = mapData || {};
-  const C = 10;
+  const safeBiomeMap = biomeMap || {};
 
   const handlePointerDown = (e) => { isDragging.current = false; lastPos.current = { x: e.clientX || e.touches?.[0].clientX, y: e.clientY || e.touches?.[0].clientY }; };
   const handlePointerMove = (e) => { if (!lastPos.current.x) return; const clientX = e.clientX || e.touches?.[0].clientX; const clientY = e.clientY || e.touches?.[0].clientY; const dx = clientX - lastPos.current.x; const dy = clientY - lastPos.current.y; if (Math.abs(dx) > 5 || Math.abs(dy) > 5) isDragging.current = true; if (isDragging.current) { setOffset(prev => ({ x: Math.max(Math.min(prev.x + dx, 200), -MAP_SIZE + 200), y: Math.max(Math.min(prev.y + dy, 200), -MAP_SIZE + 200) })); lastPos.current = { x: clientX, y: clientY }; } };
@@ -21,6 +51,16 @@ const DraggableTownMap = ({ mapData, isDanger, isEditing, onCellTap, reviewCount
     if (!isDragging.current && onCellTapRef.current) onCellTapRef.current(cx, cy);
     lastPos.current = { x: 0, y: 0 };
   }, []);
+
+  // Calculate visible cell range (viewport culling)
+  const viewRange = useMemo(() => {
+    const margin = 2; // extra cells for smooth scrolling
+    const startX = Math.max(0, Math.floor(-offset.x / CELL_SIZE) - margin);
+    const startY = Math.max(0, Math.floor(-offset.y / CELL_SIZE) - margin);
+    const endX = Math.min(GRID_SIZE - 1, Math.ceil((-offset.x + containerSize.w) / CELL_SIZE) + margin);
+    const endY = Math.min(GRID_SIZE - 1, Math.ceil((-offset.y + containerSize.h) / CELL_SIZE) + margin);
+    return { startX, startY, endX, endY };
+  }, [offset.x, offset.y, containerSize.w, containerSize.h]);
 
   const ghosts = useMemo(() => {
     if (!isDanger || isEditing) return [];
@@ -35,12 +75,15 @@ const DraggableTownMap = ({ mapData, isDanger, isEditing, onCellTap, reviewCount
       const k = exploredKeys[Math.floor(seededRand(i) * exploredKeys.length)];
       const [x, y] = k.split(',').map(Number); return { x, y };
     });
-  }, [isDanger, isEditing, reviewCount, exploredRadius, Object.keys(safeMapData).join(',')]);
+  }, [isDanger, isEditing, reviewCount, exploredRadius, safeMapData]);
 
+  // Only render visible cells (viewport culling for 50×50 performance)
   const cells = useMemo(() => {
     const result = [];
-    for (let y = 0; y < GRID_SIZE; y++) {
-      for (let x = 0; x < GRID_SIZE; x++) {
+    const { startX, startY, endX, endY } = viewRange;
+
+    for (let y = startY; y <= endY; y++) {
+      for (let x = startX; x <= endX; x++) {
         const key = `${x},${y}`;
         const dist = Math.max(Math.abs(x - C), Math.abs(y - C));
         const isVisible = dist <= exploredRadius;
@@ -48,36 +91,53 @@ const DraggableTownMap = ({ mapData, isDanger, isEditing, onCellTap, reviewCount
         const item = itemId ? TOWN_ITEMS.find(i => i.id === itemId) : null;
         const hasGhost = ghosts.some(g => g.x === x && g.y === y);
         const isTerrain = item && item.type === 'terrain';
+        const biome = safeBiomeMap[key];
 
-        // 未探索 → 暗黒のフォグ
+        const cellStyle = {
+          position: 'absolute',
+          left: x * CELL_SIZE,
+          top: y * CELL_SIZE,
+          width: CELL_SIZE,
+          height: CELL_SIZE,
+        };
+
+        // 未探索 → フォグ
         if (!isVisible) {
-          result.push(<div key={key} className="w-[48px] h-[48px] bg-[#0f172a]" />);
+          result.push(<div key={key} style={cellStyle} className="bg-[#0f172a]" />);
           continue;
         }
 
-        // 岩盤（探索済みだが開拓不可）
+        // 岩盤
         if (itemId === 't_bedrock') {
-          result.push(<div key={key} className="w-[48px] h-[48px] flex items-center justify-center"><SvgBedrock /></div>);
+          result.push(<div key={key} style={cellStyle} className="flex items-center justify-center"><SvgBedrock /></div>);
           continue;
         }
 
-        // 荒れ地（タップで開拓できると示すヒント）
-        if (itemId === 't_roughland') {
+        // 開拓可能な地形（荒れ地・草地・森林・砂地・高台）
+        const TerrainSvg = TERRAIN_SVG_MAP[itemId];
+        if (CULTIVATABLE_TERRAIN.has(itemId)) {
+          const terrainItem = TOWN_ITEMS.find(i => i.id === itemId);
           result.push(
-            <div key={key} onPointerUp={(e) => handlePointerUp(e, x, y)}
-              className={`w-[48px] h-[48px] flex items-center justify-center relative select-none group ${isEditing ? 'cursor-pointer' : ''}`}>
-              <SvgRoughland />
+            <div key={key} style={cellStyle} onPointerUp={(e) => handlePointerUp(e, x, y)}
+              className={`flex items-center justify-center relative select-none group ${isEditing ? 'cursor-pointer' : ''}`}>
+              {TerrainSvg ? <TerrainSvg /> : <SvgRoughland />}
               {isEditing && <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 bg-amber-500/40 transition-opacity rounded-sm"><span className="text-[9px] font-black text-white text-center leading-tight">開拓<br/>(-1💰)</span></div>}
             </div>
           );
           continue;
         }
 
+        // 浅瀬（建設不可、表示のみ）
+        if (itemId === 't_shallow_water') {
+          result.push(<div key={key} style={cellStyle} className="flex items-center justify-center"><SvgShallowWater /></div>);
+          continue;
+        }
+
         // 通常セル（更地・設置物・雑草）
         const bgClass = item ? item.bg : 'bg-[#d4a96a]';
         result.push(
-          <div key={key} onPointerUp={(e) => handlePointerUp(e, x, y)}
-            className={`w-[48px] h-[48px] border-[1px] border-black/5 flex items-center justify-center relative select-none ${bgClass} ${isEditing ? 'hover:brightness-110 cursor-pointer border-black/20' : ''} ${isDanger && !isEditing ? 'brightness-75' : ''}`}>
+          <div key={key} style={cellStyle} onPointerUp={(e) => handlePointerUp(e, x, y)}
+            className={`border-[1px] border-black/5 flex items-center justify-center relative select-none ${bgClass} ${isEditing ? 'hover:brightness-110 cursor-pointer border-black/20' : ''} ${isDanger && !isEditing ? 'brightness-75' : ''}`}>
             <AnimatePresence mode="popLayout">
               {item && item.id === 't_kakejiku' ? (
                 <motion.div key="kk" initial={{ scale: 0 }} animate={{ scale: 1 }} exit={{ scale: 0 }} className="relative w-[80%] h-[90%] bg-[#f5e6d3] border-x-[4px] border-y-2 border-amber-900 rounded-sm shadow-sm flex items-center justify-center z-10">
@@ -97,7 +157,15 @@ const DraggableTownMap = ({ mapData, isDanger, isEditing, onCellTap, reviewCount
       }
     }
     return result;
-  }, [safeMapData, ghosts, isDanger, isEditing, kakejikuImg, exploredRadius]);
+  }, [safeMapData, safeBiomeMap, ghosts, isDanger, isEditing, kakejikuImg, exploredRadius, viewRange]);
+
+  // Biome indicator for current view center
+  const centerBiome = useMemo(() => {
+    const cx = Math.floor((-offset.x + containerSize.w / 2) / CELL_SIZE);
+    const cy = Math.floor((-offset.y + containerSize.h / 2) / CELL_SIZE);
+    const biomeId = safeBiomeMap[`${cx},${cy}`];
+    return biomeId ? BIOME_TYPES[biomeId] : null;
+  }, [offset.x, offset.y, containerSize.w, containerSize.h, safeBiomeMap]);
 
   return (
     <div ref={containerRef} onPointerDown={handlePointerDown} onPointerMove={handlePointerMove}
@@ -110,12 +178,19 @@ const DraggableTownMap = ({ mapData, isDanger, isEditing, onCellTap, reviewCount
           : <motion.div key="sun" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className="absolute top-4 right-4 animate-spin-slow pointer-events-none z-30"><Sun size={60} className="text-amber-400 drop-shadow-md" fill="currentColor" /></motion.div>
         }
       </AnimatePresence>
-      {/* グリッド */}
-      <div style={{ width: MAP_SIZE, height: MAP_SIZE, transform: `translate(${offset.x}px, ${offset.y}px)`, gridTemplateColumns: `repeat(${GRID_SIZE}, 48px)`, gridTemplateRows: `repeat(${GRID_SIZE}, 48px)` }}
-        className="grid absolute top-0 left-0 transition-transform duration-75 ease-out">
+      {/* バイオーム表示 */}
+      {centerBiome && !isEditing && (
+        <div className="absolute top-2 left-2 bg-[var(--panel)]/80 border-[2px] border-[var(--text)] rounded-xl px-3 py-1 text-[10px] font-bold text-[var(--text)] pointer-events-none z-40 flex items-center gap-1">
+          <span>{centerBiome.emoji}</span>
+          <span>{centerBiome.name}</span>
+        </div>
+      )}
+      {/* グリッド (absolute positioned cells for viewport culling) */}
+      <div style={{ width: MAP_SIZE, height: MAP_SIZE, transform: `translate(${offset.x}px, ${offset.y}px)`, position: 'relative' }}
+        className="absolute top-0 left-0 transition-transform duration-75 ease-out">
         {cells}
       </div>
-      {/* 住民オーバーレイ（グリッドの外でoffset適用） */}
+      {/* 住民オーバーレイ */}
       {villagers.slice(0, 20).map(v => (
         <VillagerDot key={v.id} villager={v} cellSize={CELL_SIZE} offset={offset} />
       ))}
@@ -123,4 +198,5 @@ const DraggableTownMap = ({ mapData, isDanger, isEditing, onCellTap, reviewCount
   );
 };
 
+export { CULTIVATABLE_TERRAIN };
 export default DraggableTownMap;

--- a/src/components/town/TownEditorView.jsx
+++ b/src/components/town/TownEditorView.jsx
@@ -3,7 +3,7 @@ import { AnimatePresence } from 'framer-motion';
 import { Map, Coins, Eraser, Undo2, ArrowLeft } from 'lucide-react';
 import MotionButton from '../ui/MotionButton';
 import { TOWN_ITEMS } from '../../data/town-items';
-import DraggableTownMap from './DraggableTownMap';
+import DraggableTownMap, { CULTIVATABLE_TERRAIN } from './DraggableTownMap';
 import { StorageAPI } from '../../systems/storage';
 import { audioCtrl } from '../../systems/audio';
 
@@ -41,8 +41,8 @@ const TownEditorView = ({ setView, stats, setStats }) => {
     const key = `${x},${y}`;
     const currentTile = localMap[key];
 
-    // 荒れ地 → コイン1枚で更地に開拓
-    if (currentTile === 't_roughland') {
+    // 開拓可能地形 → コイン1枚で更地に開拓
+    if (CULTIVATABLE_TERRAIN.has(currentTile)) {
       if ((stats.coins || 0) < 1) { audioCtrl.playSE('stamp_bad'); return; }
       const newMap = { ...localMap, [key]: 't_cleared' };
       setLocalMap(newMap); pushHistory(newMap);
@@ -96,10 +96,10 @@ const TownEditorView = ({ setView, stats, setStats }) => {
       </div>
 
       <div className="flex-1 min-h-0 relative">
-        <DraggableTownMap mapData={localMap} isDanger={false} isEditing={true} onCellTap={handleCellTap} reviewCount={0} kakejikuImg={stats.kakejiku} villagers={stats.villagers || []} exploredRadius={stats.exploredRadius || 2} />
+        <DraggableTownMap mapData={localMap} biomeMap={stats.biomeMap} isDanger={false} isEditing={true} onCellTap={handleCellTap} reviewCount={0} kakejikuImg={stats.kakejiku} villagers={stats.villagers || []} exploredRadius={stats.exploredRadius || 3} />
         {/* 操作ヒント */}
         <div className="absolute top-2 left-2 bg-[var(--panel)]/90 border-[2px] border-[var(--text)] rounded-xl px-3 py-1.5 text-[10px] font-bold text-[var(--text)] pointer-events-none z-40 leading-relaxed">
-          🟫 荒れ地タップ → 開拓（🪙1枚）<br/>
+          🟫 地形タップ → 開拓（🪙1枚）<br/>
           👥 人口 {stats.population}人
         </div>
         {selectedItem && (

--- a/src/data/biomes.js
+++ b/src/data/biomes.js
@@ -1,0 +1,139 @@
+// ==========================================
+// バイオーム定義 — Phase 2: マップ拡張
+// 50×50マップを6バイオーム + 中央に分割
+// ==========================================
+
+/**
+ * Biome layout on a 50×50 map (center at 25,25):
+ *
+ *    NW: forest  |  NE: coast
+ *    W:  mountain |  E:  plains
+ *    SW: hills   |  SE: volcano
+ *    Center: town core (all grades)
+ */
+
+export const BIOME_TYPES = {
+  center:   { id: 'center',   name: '街の中心',       emoji: '🏘️', grade: 0, color: '#d4a96a', desc: '全学年共通の拠点エリア' },
+  forest:   { id: 'forest',   name: '森林バイオーム', emoji: '🌲', grade: 1, color: '#166534', desc: '1年生・基礎建築の地' },
+  coast:    { id: 'coast',    name: '海岸バイオーム', emoji: '🏖️', grade: 2, color: '#0ea5e9', desc: '2年生・商業港の地' },
+  mountain: { id: 'mountain', name: '山岳バイオーム', emoji: '⛰️', grade: 3, color: '#78716c', desc: '3年生・文化と神社仏閣の地' },
+  plains:   { id: 'plains',   name: '平野バイオーム', emoji: '🌾', grade: 4, color: '#84cc16', desc: '4年生・産業と農業の地' },
+  hills:    { id: 'hills',    name: '丘陵バイオーム', emoji: '🏔️', grade: 5, color: '#a16207', desc: '5年生・政治と学術の地' },
+  volcano:  { id: 'volcano',  name: '火山バイオーム', emoji: '🌋', grade: 6, color: '#dc2626', desc: '6年生・伝説建築の地' },
+};
+
+/**
+ * Determine biome for a given (x, y) on a 50×50 grid.
+ * Center = 25,25. Uses angle + distance to assign biome.
+ */
+export function getBiomeAt(x, y) {
+  const C = 25;
+  const dx = x - C;
+  const dy = y - C;
+  const dist = Math.max(Math.abs(dx), Math.abs(dy)); // Chebyshev distance
+
+  // Center zone: radius <= 5
+  if (dist <= 5) return 'center';
+
+  // Use angle to determine biome sector
+  const angle = Math.atan2(dy, dx); // -PI to PI
+  const deg = ((angle * 180 / Math.PI) + 360) % 360; // 0-360
+
+  // Sector assignments (60 degrees each):
+  //   0-60:   NE (coast)   → grade 2
+  //   60-120: E  (plains)  → grade 4
+  //   120-180: SE (volcano) → grade 6
+  //   180-240: SW (hills)   → grade 5
+  //   240-300: W  (mountain)→ grade 3
+  //   300-360: NW (forest)  → grade 1
+  if (deg < 60)  return 'coast';
+  if (deg < 120) return 'plains';
+  if (deg < 180) return 'volcano';
+  if (deg < 240) return 'hills';
+  if (deg < 300) return 'mountain';
+  return 'forest';
+}
+
+/**
+ * Get the terrain base tile for a given position based on biome and distance.
+ * Returns one of the terrain tile IDs.
+ */
+export function getTerrainForBiome(x, y, biome) {
+  const C = 25;
+  const dist = Math.max(Math.abs(x - C), Math.abs(y - C));
+
+  // Seeded pseudo-random for consistent terrain generation
+  const seed = (x * 7919 + y * 104729) % 1000;
+  const rand = seed / 1000;
+
+  // Center zone - cleared / grassland mix
+  if (biome === 'center') {
+    if (dist <= 2) return 't_cleared';
+    if (dist <= 4) return rand < 0.6 ? 't_cleared' : 't_grassland';
+    return rand < 0.3 ? 't_cleared' : 't_grassland';
+  }
+
+  // Edge of map → bedrock border
+  if (x <= 0 || y <= 0 || x >= 49 || y >= 49) return 't_bedrock';
+
+  // Outer ring → more bedrock/roughland
+  if (dist >= 23) return rand < 0.4 ? 't_bedrock' : 't_roughland';
+  if (dist >= 20) return rand < 0.2 ? 't_bedrock' : 't_roughland';
+
+  // Biome-specific terrain distribution
+  switch (biome) {
+    case 'forest':
+      if (rand < 0.35) return 't_forest_floor';
+      if (rand < 0.65) return 't_grassland';
+      if (rand < 0.80) return 't_roughland';
+      return 't_cleared';
+
+    case 'coast':
+      if (rand < 0.25) return 't_sand';
+      if (rand < 0.45) return 't_shallow_water';
+      if (rand < 0.65) return 't_grassland';
+      if (rand < 0.80) return 't_roughland';
+      return 't_cleared';
+
+    case 'mountain':
+      if (rand < 0.30) return 't_highland';
+      if (rand < 0.55) return 't_roughland';
+      if (rand < 0.70) return 't_grassland';
+      return 't_cleared';
+
+    case 'plains':
+      if (rand < 0.45) return 't_grassland';
+      if (rand < 0.65) return 't_cleared';
+      if (rand < 0.80) return 't_roughland';
+      return 't_forest_floor';
+
+    case 'hills':
+      if (rand < 0.30) return 't_highland';
+      if (rand < 0.55) return 't_grassland';
+      if (rand < 0.75) return 't_roughland';
+      return 't_cleared';
+
+    case 'volcano':
+      if (rand < 0.35) return 't_roughland';
+      if (rand < 0.55) return 't_highland';
+      if (rand < 0.70) return 't_grassland';
+      return 't_cleared';
+
+    default:
+      return 't_roughland';
+  }
+}
+
+/**
+ * Biome-specific background color for terrain tiles.
+ * Each biome tints the base terrain slightly different.
+ */
+export const BIOME_TERRAIN_COLORS = {
+  center:   { cleared: '#d4a96a', grassland: '#86efac', roughland: '#92400e' },
+  forest:   { cleared: '#c4a05a', grassland: '#4ade80', roughland: '#713f12', forest_floor: '#14532d' },
+  coast:    { cleared: '#e8d5a0', grassland: '#86efac', roughland: '#92400e', sand: '#fde68a', shallow_water: '#7dd3fc' },
+  mountain: { cleared: '#c8b898', grassland: '#6ee7b7', roughland: '#78716c', highland: '#a8a29e' },
+  plains:   { cleared: '#ddb870', grassland: '#a3e635', roughland: '#854d0e', forest_floor: '#166534' },
+  hills:    { cleared: '#c9a058', grassland: '#84cc16', roughland: '#92400e', highland: '#a16207' },
+  volcano:  { cleared: '#c49080', grassland: '#86efac', roughland: '#7f1d1d', highland: '#991b1b' },
+};

--- a/src/data/story-stages.js
+++ b/src/data/story-stages.js
@@ -1,16 +1,16 @@
 // ストーリーステージ — マイ漢字タウン
 // 割合ベースの進行（学年の漢字数に依存しない設計）
+// Phase 2: 50×50マップ対応 — 最大半径25で全マップ開放
 //
 // percentage: その学年の漢字のうち何%習得すればこのステージに到達するか
-// minKanji / minPop: 旧互換フィールド（既存コードが参照している）
 
 export const STORY_STAGES = [
   { id: 0, percentage: 0,    minKanji: 0,  minPop: 0,  radius: 3,  title: '荒野の旅人',  emoji: '🏕️', desc: 'ここは何もない荒野。だが、あなたの挑戦が今はじまる。' },
-  { id: 1, percentage: 0.05, minKanji: 2,  minPop: 2,  radius: 5,  title: '開拓者',       emoji: '⛺',  desc: '最初の仲間が集まった。小さな集落が生まれようとしている。' },
-  { id: 2, percentage: 0.15, minKanji: 5,  minPop: 5,  radius: 8,  title: '村の創設者',   emoji: '🏘️', desc: '村人たちの笑い声が聞こえる。あなたは村長と呼ばれるようになった。' },
-  { id: 3, percentage: 0.30, minKanji: 9,  minPop: 9,  radius: 12, title: '町の領主',     emoji: '🏙️', desc: '商人や職人が集まり、町に活気があふれてきた。' },
-  { id: 4, percentage: 0.50, minKanji: 13, minPop: 13, radius: 17, title: '城主',         emoji: '🏯',  desc: 'あなたの名声は遠く広まった。城を建て、都を守れ。' },
-  { id: 5, percentage: 0.75, minKanji: 16, minPop: 16, radius: 20, title: '大名',         emoji: '⚔️', desc: '領土は広がり、民は豊かに暮らしている。' },
+  { id: 1, percentage: 0.05, minKanji: 2,  minPop: 2,  radius: 6,  title: '開拓者',       emoji: '⛺',  desc: '最初の仲間が集まった。小さな集落が生まれようとしている。' },
+  { id: 2, percentage: 0.15, minKanji: 5,  minPop: 5,  radius: 10, title: '村の創設者',   emoji: '🏘️', desc: '村人たちの笑い声が聞こえる。あなたは村長と呼ばれるようになった。' },
+  { id: 3, percentage: 0.30, minKanji: 9,  minPop: 9,  radius: 14, title: '町の領主',     emoji: '🏙️', desc: '商人や職人が集まり、町に活気があふれてきた。' },
+  { id: 4, percentage: 0.50, minKanji: 13, minPop: 13, radius: 18, title: '城主',         emoji: '🏯',  desc: 'あなたの名声は遠く広まった。城を建て、都を守れ。' },
+  { id: 5, percentage: 0.75, minKanji: 16, minPop: 16, radius: 22, title: '大名',         emoji: '⚔️', desc: '領土は広がり、民は豊かに暮らしている。' },
   { id: 6, percentage: 1.00, minKanji: 20, minPop: 20, radius: 25, title: '天下人',       emoji: '👑',  desc: 'すべての漢字を習得した。この街は永遠に語り継がれるだろう。' },
 ];
 

--- a/src/data/town-items.jsx
+++ b/src/data/town-items.jsx
@@ -27,7 +27,14 @@ const SvgTemple = () => <svg viewBox="0 0 100 100" className="w-[90%] h-[90%] dr
 const SvgDragon = () => <svg viewBox="0 0 100 100" className="w-[100%] h-[100%] drop-shadow-[0_0_8px_rgba(16,185,129,0.5)]"><path d="M20 80 Q10 50 50 20 T90 50 Q80 80 50 80" fill="none" stroke="#10b981" strokeWidth="8" strokeLinecap="round" /><circle cx="30" cy="40" r="5" fill="#ef4444" /><circle cx="70" cy="40" r="5" fill="#ef4444" /></svg>;
 const SvgGhostBoss = () => <svg viewBox="0 0 100 100" className="w-[100%] h-[100%] drop-shadow-[0_0_15px_rgba(225,29,72,0.8)]"><path d="M20 90 Q10 50 50 10 T80 90 Q70 80 50 90 Q30 80 20 90" fill="#0f172a" /><circle cx="35" cy="45" r="8" fill="#e11d48" /><circle cx="65" cy="45" r="8" fill="#e11d48" /><path d="M40 70 Q50 60 60 70" fill="none" stroke="#e11d48" strokeWidth="4" strokeLinecap="round" /></svg>;
 
-export { SvgBedrock, SvgRoughland, SvgCleared, SvgWeed, SvgGrass, SvgFlower, SvgTree, SvgSakura, SvgPine, SvgRock, SvgRoad, SvgWater, SvgWall, SvgBridge, SvgHouse1, SvgShop, SvgSchool, SvgCastle, SvgGoldCastle, SvgTorii, SvgTemple, SvgDragon, SvgGhostBoss, SvgVillager };
+// Phase 2: 新地形タイル
+const SvgGrassland = () => <svg viewBox="0 0 100 100" className="w-full h-full"><rect width="100" height="100" fill="#86efac"/><path d="M15 85 Q15 70 20 65 M30 90 Q30 72 35 67 M55 88 Q55 74 60 68 M75 85 Q75 70 80 64 M45 92 Q45 78 48 72" fill="none" stroke="#22c55e" strokeWidth="2.5" strokeLinecap="round" opacity="0.6"/></svg>;
+const SvgForestFloor = () => <svg viewBox="0 0 100 100" className="w-full h-full"><rect width="100" height="100" fill="#14532d"/><circle cx="25" cy="30" r="18" fill="#166534" opacity="0.7"/><circle cx="70" cy="25" r="22" fill="#15803d" opacity="0.6"/><circle cx="50" cy="70" r="20" fill="#166534" opacity="0.7"/><circle cx="15" cy="75" r="14" fill="#15803d" opacity="0.5"/><circle cx="85" cy="65" r="16" fill="#166534" opacity="0.6"/></svg>;
+const SvgSand = () => <svg viewBox="0 0 100 100" className="w-full h-full"><rect width="100" height="100" fill="#fde68a"/><circle cx="20" cy="40" r="3" fill="#fbbf24" opacity="0.4"/><circle cx="60" cy="70" r="4" fill="#fbbf24" opacity="0.3"/><circle cx="80" cy="30" r="2" fill="#fbbf24" opacity="0.4"/><path d="M5 80 Q25 70 50 78 Q75 86 95 75" fill="none" stroke="#f59e0b" strokeWidth="1.5" opacity="0.3"/></svg>;
+const SvgShallowWater = () => <svg viewBox="0 0 100 100" className="w-full h-full"><rect width="100" height="100" fill="#7dd3fc"/><path d="M5 25 Q20 15 35 25 T65 25 T95 25" fill="none" stroke="#bae6fd" strokeWidth="3" strokeLinecap="round" opacity="0.6"/><path d="M10 55 Q30 45 50 55 T90 55" fill="none" stroke="#bae6fd" strokeWidth="3" strokeLinecap="round" opacity="0.6"/><path d="M0 80 Q20 70 40 80 T80 80" fill="none" stroke="#bae6fd" strokeWidth="2" strokeLinecap="round" opacity="0.4"/></svg>;
+const SvgHighland = () => <svg viewBox="0 0 100 100" className="w-full h-full"><rect width="100" height="100" fill="#a8a29e"/><path d="M10 90 L30 50 L50 70 L70 40 L90 80" fill="none" stroke="#78716c" strokeWidth="4" strokeLinecap="round" opacity="0.5"/><path d="M0 95 L25 65 L45 80 L65 55 L85 75 L100 90" fill="#9ca3af" opacity="0.3"/></svg>;
+
+export { SvgBedrock, SvgRoughland, SvgCleared, SvgWeed, SvgGrass, SvgFlower, SvgTree, SvgSakura, SvgPine, SvgRock, SvgRoad, SvgWater, SvgWall, SvgBridge, SvgHouse1, SvgShop, SvgSchool, SvgCastle, SvgGoldCastle, SvgTorii, SvgTemple, SvgDragon, SvgGhostBoss, SvgVillager, SvgGrassland, SvgForestFloor, SvgSand, SvgShallowWater, SvgHighland };
 
 const TOWN_ITEMS = [
   // 地形（内部管理用・パレット非表示）
@@ -35,6 +42,12 @@ const TOWN_ITEMS = [
   { id: 't_roughland', svg: SvgRoughland, name: '荒れ地', price: 0,     pros: -2,   type: 'terrain', bg: 'bg-[#92400e]' },
   { id: 't_cleared',   svg: SvgCleared,   name: '更地',   price: 0,     pros: 0,    type: 'terrain', bg: 'bg-[#d4a96a]' },
   { id: 't_weed',      svg: SvgWeed,      name: 'ざっそう', price: 0,   pros: -5,   type: 'terrain', bg: 'bg-[#a3e635]' },
+  // Phase 2: 新地形タイル
+  { id: 't_grassland',     svg: SvgGrassland,    name: '草地',     price: 0, pros: 1,  type: 'terrain', bg: 'bg-[#86efac]' },
+  { id: 't_forest_floor',  svg: SvgForestFloor,  name: '森林',     price: 0, pros: 2,  type: 'terrain', bg: 'bg-[#14532d]' },
+  { id: 't_sand',          svg: SvgSand,         name: '砂地',     price: 0, pros: 0,  type: 'terrain', bg: 'bg-[#fde68a]' },
+  { id: 't_shallow_water', svg: SvgShallowWater, name: '浅瀬',     price: 0, pros: 1,  type: 'terrain', bg: 'bg-[#7dd3fc]' },
+  { id: 't_highland',      svg: SvgHighland,     name: '高台',     price: 0, pros: 1,  type: 'terrain', bg: 'bg-[#a8a29e]' },
   // 自然・建物・特別（既存）
   { id: 't_grass',      svg: SvgGrass,      name: 'くさ',       price: 10,    pros: 1,    type: 'nature',   bg: 'bg-[#86efac]' },
   { id: 't_flower',     svg: SvgFlower,     name: '花壇',       price: 30,    pros: 5,    type: 'nature',   bg: 'bg-[#86efac]' },

--- a/src/systems/storage.js
+++ b/src/systems/storage.js
@@ -6,6 +6,7 @@ import { TOWN_ITEMS } from '../data/town-items.jsx';
 import { KANJI_DATA } from '../data/kanji-data.js';
 import { ACHIEVEMENTS } from '../data/achievements.js';
 import { migrateCard } from './srs.js';
+import { getBiomeAt, getTerrainForBiome } from '../data/biomes.js';
 
 let _saveDebounceTimer = null;
 
@@ -21,14 +22,30 @@ const StorageAPI = {
     if (_saveDebounceTimer) { clearTimeout(_saveDebounceTimer); _saveDebounceTimer = null; }
     StorageAPI.safeSet('kanji_town_v7', stats);
   },
-  // 初期マップ生成: 中央2×2=更地、その外=荒れ地、端=岩盤
+  GRID_SIZE: 50,
+  // Phase 2: 50×50マップ生成（バイオーム対応）
   buildInitialMap: () => {
+    const SIZE = 50; const C = 25; const map = {}; const biomeMap = {};
+    for (let y = 0; y < SIZE; y++) for (let x = 0; x < SIZE; x++) {
+      const biome = getBiomeAt(x, y);
+      biomeMap[`${x},${y}`] = biome;
+      map[`${x},${y}`] = getTerrainForBiome(x, y, biome);
+    }
+    // 初期拠点: 中央3×3を更地に
+    for (let dy = -1; dy <= 1; dy++) for (let dx = -1; dx <= 1; dx++) {
+      map[`${C + dx},${C + dy}`] = 't_cleared';
+    }
+    map[`${C},${C}`] = 't_house1'; // 最初の家
+    return { map, biomeMap };
+  },
+  // 旧20×20マップ生成（マイグレーション用）
+  buildLegacyMap: () => {
     const C = 10; const map = {};
     for (let y = 0; y < 20; y++) for (let x = 0; x < 20; x++) {
       const dist = Math.max(Math.abs(x - C), Math.abs(y - C));
       map[`${x},${y}`] = dist <= 1 ? 't_cleared' : dist <= 4 ? 't_roughland' : 't_bedrock';
     }
-    map['10,10'] = 't_house1'; // 最初の家
+    map['10,10'] = 't_house1';
     return map;
   },
   getStats: () => {
@@ -36,22 +53,23 @@ const StorageAPI = {
               || StorageAPI.safeGet('kanji_mega_builder_final_v6', null)
               || StorageAPI.safeGet('kanji_mega_builder_final_v5', null);
     if (!stats || !stats.targetGrade) {
+      const { map, biomeMap } = StorageAPI.buildInitialMap();
       stats = {
         totalExp: 0, streak: 0, lastDate: '', coins: 500, targetGrade: 1,
-        townMap: StorageAPI.buildInitialMap(),
+        townMap: map,
+        biomeMap: biomeMap,
         townItems: { 't_grass': 5, 't_road': 5, 't_tree': 3 },
         daily: {}, kanjiStats: {}, unlockedKanji: [],
         kakejiku: null, achievements: {}, perfectCountTotal: 0, myDrills: [],
-        // 新フィールド
         population: 0,
-        villagers: [],        // [{id, x, y, kanjiChar, born}]
-        exploredRadius: 2,    // 現在の探索半径
-        schemaVersion: 7,
+        villagers: [],
+        exploredRadius: 3,
+        schemaVersion: 8,
+        mapSize: 50,
       };
     }
     // フィールド補完
     if (!stats.myDrills) stats.myDrills = [];
-    if (!stats.townMap) stats.townMap = StorageAPI.buildInitialMap();
     if (!stats.townItems) stats.townItems = {};
     if (!stats.kanjiStats) stats.kanjiStats = {};
     if (!stats.unlockedKanji) stats.unlockedKanji = [];
@@ -59,18 +77,60 @@ const StorageAPI = {
     if (stats.coins === undefined) stats.coins = 0;
     if (!stats.population) stats.population = 0;
     if (!stats.villagers) stats.villagers = [];
-    if (!stats.exploredRadius) stats.exploredRadius = 2;
+    if (!stats.exploredRadius) stats.exploredRadius = 3;
 
-    // 旧データ移行：地形なしのマップに地形タイルを注入
-    if (!Object.values(stats.townMap).some(v => v === 't_bedrock' || v === 't_roughland' || v === 't_cleared')) {
-      const freshMap = StorageAPI.buildInitialMap();
-      // 旧配置アイテムを更地の上に重ねる
-      Object.entries(stats.townMap).forEach(([key, val]) => {
+    // ── 20×20 → 50×50 マイグレーション ──
+    if (!stats.mapSize || stats.mapSize < 50) {
+      const oldMap = stats.townMap || {};
+      const { map: freshMap, biomeMap } = StorageAPI.buildInitialMap();
+      // 旧マップの建物を新マップ中央に移植 (旧center=10,10 → 新center=25,25, offset=+15)
+      Object.entries(oldMap).forEach(([key, val]) => {
         const item = TOWN_ITEMS.find(i => i.id === val);
-        if (item && item.type !== 'terrain') freshMap[key] = val;
+        if (item && item.type !== 'terrain') {
+          const [ox, oy] = key.split(',').map(Number);
+          const nx = ox + 15;
+          const ny = oy + 15;
+          if (nx >= 0 && nx < 50 && ny >= 0 && ny < 50) {
+            freshMap[`${nx},${ny}`] = val;
+          }
+        }
+      });
+      // 旧更地タイルも移植
+      Object.entries(oldMap).forEach(([key, val]) => {
+        if (val === 't_cleared') {
+          const [ox, oy] = key.split(',').map(Number);
+          const nx = ox + 15;
+          const ny = oy + 15;
+          if (nx >= 0 && nx < 50 && ny >= 0 && ny < 50 && freshMap[`${nx},${ny}`] !== 't_cleared') {
+            const item = TOWN_ITEMS.find(i => i.id === freshMap[`${nx},${ny}`]);
+            if (!item || item.type === 'terrain') freshMap[`${nx},${ny}`] = 't_cleared';
+          }
+        }
       });
       stats.townMap = freshMap;
-      stats.exploredRadius = 6; // 旧データは広めに開放
+      stats.biomeMap = biomeMap;
+      stats.mapSize = 50;
+      stats.schemaVersion = 8;
+      // 旧データは少し広めに探索済みにする
+      if (stats.exploredRadius < 6) stats.exploredRadius = 6;
+      // 旧住民座標もオフセット
+      if (stats.villagers) {
+        stats.villagers = stats.villagers.map(v => ({ ...v, x: (v.x || 0) + 15, y: (v.y || 0) + 15 }));
+      }
+    }
+
+    if (!stats.townMap) {
+      const { map, biomeMap } = StorageAPI.buildInitialMap();
+      stats.townMap = map;
+      stats.biomeMap = biomeMap;
+    }
+    if (!stats.biomeMap) {
+      // Generate biome map for existing save
+      const biomeMap = {};
+      for (let y = 0; y < 50; y++) for (let x = 0; x < 50; x++) {
+        biomeMap[`${x},${y}`] = getBiomeAt(x, y);
+      }
+      stats.biomeMap = biomeMap;
     }
 
     // データ整合性チェック


### PR DESCRIPTION
- 50×50マップ生成（6バイオーム＋中央エリア）
- 新地形5種追加: 草地・森林・砂地・浅瀬・高台（SVG付き）
- バイオーム定義: 森林/海岸/山岳/平野/丘陵/火山（方角ベース配置）
- DraggableTownMap: ビューポートカリングで50×50パフォーマンス最適化
- 20×20→50×50自動マイグレーション（建物・住民座標を中央にオフセット）
- ストーリーステージの探索半径を50×50マップスケールに調整
- バイオーム表示インジケータ追加
- 全開拓可能地形の統一処理（荒れ地・草地・森林・砂地・高台）

https://claude.ai/code/session_016HELAiNxKukswpe42izsi4