### PR TITLE
ストーリーステージ称号（町の領主など）を上部ヘッダーに復元

### DIFF
--- a/src/components/pages/HomeView.jsx
+++ b/src/components/pages/HomeView.jsx
@@ -6,6 +6,7 @@ import DraggableTownMap from '../town/DraggableTownMap';
 import DailyMissionsPanel from '../tutorial/DailyMissionsPanel';
 import { KANJI_DATA } from '../../data/kanji-data';
 import { MATERIALS } from '../../data/materials';
+import { STORY_STAGES } from '../../data/story-stages';
 import { StorageAPI, calculateProsperity, getLevelInfo } from '../../systems/storage';
 import { audioCtrl } from '../../systems/audio';
 import { calculateSatisfaction, getSatisfactionLabel } from '../../systems/residents';
@@ -23,6 +24,9 @@ const HomeView = ({ setView, stats, setStats, startSession, startFlashcard, star
   const satisfaction = calculateSatisfaction(stats);
   const satLabel = getSatisfactionLabel(satisfaction);
 
+  const masteredCount = Object.values(stats.kanjiStats || {}).filter(s => s.status === 'mastered').length;
+  const stage = STORY_STAGES.slice().reverse().find(s => masteredCount >= s.minKanji && (stats.population || 0) >= s.minPop) || STORY_STAGES[0];
+
   const isCraftUnlocked = learnedCount >= 3;
   const isTownEditorUnlocked = learnedCount >= 1;
   const isResidentsUnlocked = (stats.population || 0) >= 1;
@@ -37,6 +41,7 @@ const HomeView = ({ setView, stats, setStats, startSession, startFlashcard, star
           <div className="flex items-center gap-2 min-w-0">
             <span className="text-sm font-bold text-[var(--text)] opacity-60">{badge} {title}</span>
             <span className="text-lg font-black text-[var(--text)]">Lv.{level}</span>
+            <span className="text-xs font-bold text-[var(--text)] opacity-50">{stage.emoji} {stage.title}</span>
           </div>
           <div className="flex items-center gap-2 shrink-0">
             <span className="text-xs font-bold text-[var(--text)] opacity-60 flex items-center gap-0.5"><Users size={12} />{stats.population || 0}人</span>


### PR DESCRIPTION
前回の統合でSTORY_STAGESベースの称号表示が削除されていた。
STORY_STAGESのインポートとstage計算を復元し、上部ヘッダーの
レベル表示の右側に称号を表示するよう修正。

https://claude.ai/code/session_013YkYo6qMRp2MtFyAEQ9gLr