### PR TITLE
声にだそうの例文にrubyタグを使ったふりがな表示を実装

### DIFF
--- a/src/components/session/ReadMode.jsx
+++ b/src/components/session/ReadMode.jsx
@@ -3,7 +3,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { Volume2, ChevronRight } from 'lucide-react';
 import MotionButton from '../ui/MotionButton';
 import ModeLayout from '../ui/ModeLayout';
-import { FormatKun } from '../ui/FormatKun';
+import { FormatKun, RubyText } from '../ui/FormatKun';
 import { audioCtrl } from '../../systems/audio';
 
 const ReadMode = ({ kanji, onNext, commonSidebar }) => {
@@ -16,7 +16,7 @@ const ReadMode = ({ kanji, onNext, commonSidebar }) => {
       <div className="flex flex-col gap-4 bg-[var(--panel)] p-4 rounded-2xl border-[4px] border-[var(--text)] shadow-[4px_4px_0_var(--text)] mt-4">
         <div className="bg-[var(--accent)] text-[var(--text)] px-4 py-1.5 rounded-full text-sm font-black border-[3px] border-[var(--text)] text-center shadow-sm -mt-8 mx-auto w-max">声にだそう！</div>
         <div className="relative min-h-[80px] flex items-center justify-center">
-          <AnimatePresence mode="wait"><motion.p key={exampleIdx} initial={{ opacity: 0, x: 10 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: -10 }} className="text-xl md:text-2xl font-bold text-[var(--text)] leading-relaxed text-center py-2">{kanji.examples[exampleIdx]}</motion.p></AnimatePresence>
+          <AnimatePresence mode="wait"><motion.p key={exampleIdx} initial={{ opacity: 0, x: 10 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: -10 }} className="ruby-text text-xl md:text-2xl font-bold text-[var(--text)] text-center py-2"><RubyText text={kanji.examples[exampleIdx]} /></motion.p></AnimatePresence>
           {kanji.examples.length > 1 && (<button onClick={handleNextExample} className="absolute -right-2 top-1/2 -translate-y-1/2 bg-[var(--bg)] border-2 border-[var(--text)] rounded-full p-1 hover:bg-[var(--text)] hover:text-white transition-colors shadow-sm"><ChevronRight size={20} /></button>)}
         </div>
         {kanji.examples.length > 1 && (<div className="flex justify-center gap-1.5">{kanji.examples.map((_, i) => (<div key={i} className={`w-2 h-2 rounded-full border border-[var(--text)] ${i === exampleIdx ? 'bg-[var(--text)]' : 'bg-transparent'}`} />))}</div>)}

--- a/src/components/ui/FormatKun.jsx
+++ b/src/components/ui/FormatKun.jsx
@@ -5,4 +5,20 @@ const FormatKun = ({ text }) => {
   return <>{text}</>;
 };
 
-export { R, FormatKun };
+/** 「漢字（ふりがな）」形式のテキストを <ruby> タグに変換して表示 */
+const RubyText = ({ text }) => {
+  if (!text) return null;
+  const parts = [];
+  const re = /([^\s（）]+?)（([^）]+)）/g;
+  let last = 0;
+  let m;
+  while ((m = re.exec(text)) !== null) {
+    if (m.index > last) parts.push(text.slice(last, m.index));
+    parts.push(<ruby key={m.index}>{m[1]}<rt>{m[2]}</rt></ruby>);
+    last = re.lastIndex;
+  }
+  if (last < text.length) parts.push(text.slice(last));
+  return <>{parts}</>;
+};
+
+export { R, FormatKun, RubyText };

--- a/src/index.css
+++ b/src/index.css
@@ -42,5 +42,5 @@ ruby rt {
 }
 
 .ruby-text {
-  line-height: 1.8;
+  line-height: 2.2;
 }


### PR DESCRIPTION
括弧付きのふりがな表示（例：礼（れい））を、漢字の上にふりがなが
表示されるrubyタグ形式に変換するRubyTextコンポーネントを追加。
ベースラインを揃えるためline-heightを調整し、ルビ付き文字と
通常文字の高さの凸凹を解消。

https://claude.ai/code/session_01XF9w1EjCj5u7rY5T5SLCbq