### PR TITLE
サバイバルモードの例文をrubyタグでふりがな表示に改善

### DIFF
--- a/src/components/training/SurvivalView.jsx
+++ b/src/components/training/SurvivalView.jsx
@@ -4,7 +4,7 @@ import { Flame } from 'lucide-react';
 import MotionButton from '../ui/MotionButton';
 import TestMode from '../session/TestMode';
 import { audioCtrl } from '../../systems/audio';
-import { F } from '../ui/FormatKun';
+import { F, SurvivalRubyText } from '../ui/FormatKun';
 
 const SurvivalView = ({ queue, onUpdateStat, onFinish }) => {
   const [currentQueue, setCurrentQueue] = useState([...queue]); const [idx, setIdx] = useState(0); const [timeLeft, setTimeLeft] = useState(60);
@@ -25,7 +25,7 @@ const SurvivalView = ({ queue, onUpdateStat, onFinish }) => {
     } else { setTimeLeft(t => Math.max(t - 10, 0)); audioCtrl.playSE('stamp_bad'); }
     setTimeout(() => { if (idx + 1 >= currentQueue.length) { setCurrentQueue(prev => [...prev, ...queue].sort(() => Math.random() - 0.5)); } setIdx(prev => prev + 1); }, 1000);
   };
-  if (!kanji) return null; const ex = kanji.examples[0]; const blankText = ex ? ex.replace(new RegExp(kanji.char, 'g'), '〇') : '〇';
+  if (!kanji) return null; const ex = kanji.examples[0];
   const sidebar = (
     <div className="flex flex-col gap-4 w-full">
       <div className="bg-[var(--panel)] border-[4px] border-[var(--text)] rounded-2xl p-4 shadow-sm text-center">
@@ -36,7 +36,7 @@ const SurvivalView = ({ queue, onUpdateStat, onFinish }) => {
       </div>
       <div className="bg-[var(--panel)] border-[4px] border-[var(--text)] rounded-2xl p-6 shadow-[4px_4px_0_var(--text)]">
         <div className="text-sm font-bold bg-[var(--text)] text-[var(--panel)] px-4 py-1.5 rounded-full mx-auto w-max mb-4">この「〇」は{F("何","なん")}の{F("漢字","かんじ")}？</div>
-        <p className="text-2xl md:text-3xl font-bold text-[var(--text)] leading-relaxed text-center">{blankText}</p>
+        <p className="text-2xl md:text-3xl font-bold text-[var(--text)] text-center ruby-text">{ex ? <SurvivalRubyText text={ex} targetChar={kanji.char} /> : '◯'}</p>
       </div>
     </div>
   );

--- a/src/components/ui/FormatKun.jsx
+++ b/src/components/ui/FormatKun.jsx
@@ -26,4 +26,51 @@ const RubyText = ({ text }) => {
   return <>{parts}</>;
 };
 
-export { R, F, FormatKun, RubyText };
+/** 例文を ruby 表示し、対象漢字を ◯ に置換する（ベースライン統一） */
+const SurvivalRubyText = ({ text, targetChar }) => {
+  if (!text) return null;
+  const parts = [];
+  const re = /([^\s（）]+?)（([^）]+)）/g;
+  let last = 0;
+  let m;
+  let key = 0;
+  while ((m = re.exec(text)) !== null) {
+    // ルビ外のテキスト（空 rt で高さを揃える）
+    if (m.index > last) {
+      const plain = text.slice(last, m.index);
+      for (const ch of plain) {
+        if (ch === targetChar) {
+          parts.push(<ruby key={key++} className="survival-blank">{'◯'}<rt></rt></ruby>);
+        } else {
+          parts.push(<ruby key={key++}>{ch}<rt></rt></ruby>);
+        }
+      }
+    }
+    // ルビ付きセグメント：対象漢字を ◯ に
+    const base = m[1];
+    const reading = m[2];
+    const replaced = base.includes(targetChar)
+      ? base.replaceAll(targetChar, '◯')
+      : base;
+    parts.push(
+      <ruby key={key++} className={base.includes(targetChar) ? 'survival-blank' : ''}>
+        {replaced}<rt>{reading}</rt>
+      </ruby>
+    );
+    last = re.lastIndex;
+  }
+  // 末尾の残りテキスト
+  if (last < text.length) {
+    const plain = text.slice(last);
+    for (const ch of plain) {
+      if (ch === targetChar) {
+        parts.push(<ruby key={key++} className="survival-blank">{'◯'}<rt></rt></ruby>);
+      } else {
+        parts.push(<ruby key={key++}>{ch}<rt></rt></ruby>);
+      }
+    }
+  }
+  return <>{parts}</>;
+};
+
+export { R, F, FormatKun, RubyText, SurvivalRubyText };

--- a/src/index.css
+++ b/src/index.css
@@ -46,3 +46,11 @@ ruby rt {
 .ruby-text {
   line-height: 2.5;
 }
+
+ruby.survival-blank {
+  color: var(--primary);
+}
+ruby.survival-blank rt {
+  color: var(--primary);
+  font-weight: 700;
+}


### PR DESCRIPTION
- SurvivalRubyText コンポーネントを追加し、例文の漢字の上にふりがなを表示
- 出題漢字を◯に置換しつつ、その読みをふりがなとして上に表示
- 全文字を ruby 要素で統一しベースラインの凸凹を解消
- survival-blank クラスで出題箇所を赤色ハイライト

https://claude.ai/code/session_01XF9w1EjCj5u7rY5T5SLCbq