### PR TITLE
フラッシュモードを陰山式フラッシュカードに刷新

### DIFF
--- a/src/components/training/FlashcardView.jsx
+++ b/src/components/training/FlashcardView.jsx
@@ -1,36 +1,46 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Timer } from 'lucide-react';
 import MotionButton from '../ui/MotionButton';
 import { audioCtrl } from '../../systems/audio';
-import { F } from '../ui/FormatKun';
 import { migrateCard, calculateNextReview } from '../../systems/srs';
 import { StorageAPI } from '../../systems/storage';
 
 const FlashcardView = ({ queue, stats, setStats, onFinish }) => {
   const [idx, setIdx] = useState(0);
-  const [timeLeft, setTimeLeft] = useState(30);
-  // FIX: earned を ref で管理してタイマーの再起動バグを防ぐ
+  const [elapsed, setElapsed] = useState(0);
+  const [revealed, setRevealed] = useState(false);
   const earnedRef = useRef({ exp: 0, coins: 0, perfectCount: 0 });
   const [displayEarned, setDisplayEarned] = useState({ exp: 0, coins: 0 });
   const isDoneRef = useRef(false);
-  // スワイプ検出用
   const touchStartX = useRef(0);
 
-  // タイマーは idx と timeLeft だけに依存させる（earnedを除外）
+  // カウントアップタイマー
   useEffect(() => {
-    if (timeLeft <= 0 || idx >= queue.length) {
-      if (!isDoneRef.current) { isDoneRef.current = true; onFinish(earnedRef.current); }
-      return;
-    }
-    const timer = setInterval(() => setTimeLeft(t => t - 1), 1000);
+    if (idx >= queue.length) return;
+    const timer = setInterval(() => setElapsed(t => t + 1), 1000);
     return () => clearInterval(timer);
-  }, [timeLeft, idx, queue.length, onFinish]);
+  }, [idx, queue.length]);
+
+  // 完了判定
+  useEffect(() => {
+    if (idx >= queue.length && !isDoneRef.current) {
+      isDoneRef.current = true;
+      onFinish(earnedRef.current);
+    }
+  }, [idx, queue.length, onFinish]);
 
   const kanji = queue[idx];
 
-  const handleAnswer = (isKnown) => {
-    if (!kanji) return;
+  const handleReveal = useCallback(() => {
+    if (!revealed && kanji) {
+      setRevealed(true);
+      audioCtrl.playSE('click');
+    }
+  }, [revealed, kanji]);
+
+  const handleAnswer = useCallback((isKnown) => {
+    if (!kanji || !revealed) return;
     if (!isKnown) {
       let newStats = { ...stats };
       const cur = migrateCard(newStats.kanjiStats[kanji.id]);
@@ -41,45 +51,112 @@ const FlashcardView = ({ queue, stats, setStats, onFinish }) => {
       setDisplayEarned({ ...earnedRef.current });
       audioCtrl.playSE('stamp_good');
     }
+    setRevealed(false);
     setIdx(prev => prev + 1);
-  };
+  }, [kanji, revealed, stats, setStats]);
 
-  // スワイプ操作
+  // スワイプ操作（読み表示後のみ）
   const handleTouchStart = (e) => { touchStartX.current = e.touches[0].clientX; };
   const handleTouchEnd = (e) => {
     const dx = e.changedTouches[0].clientX - touchStartX.current;
-    if (Math.abs(dx) > 60) { handleAnswer(dx > 0); } // 右スワイプ→わかる、左→忘れた
+    if (!revealed && Math.abs(dx) < 30) { handleReveal(); return; }
+    if (revealed && Math.abs(dx) > 60) { handleAnswer(dx > 0); }
   };
 
+  // キーボード操作
+  useEffect(() => {
+    const onKey = (e) => {
+      if (e.key === ' ' || e.key === 'Enter') { e.preventDefault(); if (!revealed) handleReveal(); else handleAnswer(true); }
+      else if (e.key === 'ArrowRight') { e.preventDefault(); handleAnswer(true); }
+      else if (e.key === 'ArrowLeft') { e.preventDefault(); handleAnswer(false); }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [revealed, handleReveal, handleAnswer]);
+
+  const formatTime = (s) => `${Math.floor(s / 60)}:${String(s % 60).padStart(2, '0')}`;
+
   if (!kanji) return null;
+
+  const readings = [];
+  if (kanji.on?.length) readings.push({ label: '音', items: kanji.on });
+  if (kanji.kun?.length) readings.push({ label: '訓', items: kanji.kun });
+
   return (
     <div className="flex flex-col h-[85vh] items-center justify-center p-4 relative w-full max-w-md mx-auto">
       <div className="absolute top-0 w-full flex justify-between items-center p-4">
         <span className="font-bold flex items-center gap-1 text-[var(--text)] bg-[var(--panel)] px-3 py-1 rounded-full border-[3px] border-[var(--text)] shadow-sm">
-          <Timer size={16} className={timeLeft <= 10 ? 'text-rose-500 animate-pulse' : ''} /> {timeLeft}s
+          <Timer size={16} /> {formatTime(elapsed)}
         </span>
         <span className="font-bold flex items-center gap-1 text-[var(--text)] bg-[var(--panel)] px-3 py-1 rounded-full border-[3px] border-[var(--text)] shadow-sm">
           {idx + 1} / {queue.length}
         </span>
       </div>
-      <div className="w-full bg-[var(--panel)] border-[4px] border-[var(--text)] rounded-[24px] p-6 flex flex-col items-center gap-6 shadow-[8px_8px_0_var(--text)]"
-        onTouchStart={handleTouchStart} onTouchEnd={handleTouchEnd}>
-        <div className="text-sm font-bold bg-[var(--bg)] px-4 py-1.5 rounded-full border-[3px] border-[var(--text)] flex items-center gap-2">
-          わかるかな？ <span className="text-[10px] opacity-50">← {F("忘","わす")}れた ／ わかる →</span>
-        </div>
+
+      <div
+        className="w-full bg-[var(--panel)] border-[4px] border-[var(--text)] rounded-[24px] p-6 flex flex-col items-center gap-4 shadow-[8px_8px_0_var(--text)] cursor-pointer select-none"
+        onClick={!revealed ? handleReveal : undefined}
+        onTouchStart={handleTouchStart}
+        onTouchEnd={handleTouchEnd}
+      >
+        {!revealed ? (
+          <div className="text-sm font-bold bg-[var(--bg)] px-4 py-1.5 rounded-full border-[3px] border-[var(--text)] flex items-center gap-2">
+            タップで読みを表示 <span className="text-[10px] opacity-50">Space / Enter</span>
+          </div>
+        ) : (
+          <div className="text-sm font-bold bg-[var(--bg)] px-4 py-1.5 rounded-full border-[3px] border-[var(--text)] flex items-center gap-2">
+            ← 読めなかった ／ 読めた → <span className="text-[10px] opacity-50">矢印キー</span>
+          </div>
+        )}
+
         <AnimatePresence mode="wait">
-          <motion.div key={kanji.id} initial={{ scale: 0.8, opacity: 0, x: 30 }} animate={{ scale: 1, opacity: 1, x: 0 }} exit={{ scale: 1.1, opacity: 0, x: -30 }} transition={{ type: 'spring', stiffness: 300, damping: 25 }} className="text-[10rem] md:text-[14rem] font-black leading-none select-none" style={{ fontFamily: "'Klee One', serif" }}>
+          <motion.div
+            key={kanji.id}
+            initial={{ scale: 0.8, opacity: 0, x: 30 }}
+            animate={{ scale: 1, opacity: 1, x: 0 }}
+            exit={{ scale: 1.1, opacity: 0, x: -30 }}
+            transition={{ type: 'spring', stiffness: 300, damping: 25 }}
+            className="text-[10rem] md:text-[14rem] font-black leading-none"
+            style={{ fontFamily: "'Klee One', serif" }}
+          >
             {kanji.char}
           </motion.div>
         </AnimatePresence>
-        <div className="text-xs font-bold text-[var(--text)] opacity-40 flex items-center gap-2">
-          <span className="bg-[var(--bg)] px-2 py-1 rounded">+{displayEarned.exp} EXP</span>
-          <span className="bg-[var(--bg)] px-2 py-1 rounded">🪙 {displayEarned.coins}</span>
-        </div>
-        <div className="flex w-full gap-4 mt-2">
-          <MotionButton variant="danger" onClick={() => handleAnswer(false)} className="flex-1 py-8 text-2xl border-[4px] border-[var(--text)] shadow-[0_6px_0_#334155]">{F("忘","わす")}れた💦</MotionButton>
-          <MotionButton variant="success" onClick={() => handleAnswer(true)} className="flex-1 py-8 text-2xl border-[4px] border-[var(--text)] shadow-[0_6px_0_#065f46]">わかる👍</MotionButton>
-        </div>
+
+        <AnimatePresence>
+          {revealed && (
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -10 }}
+              transition={{ duration: 0.2 }}
+              className="flex flex-col items-center gap-2 w-full"
+            >
+              {readings.map(({ label, items }) => (
+                <div key={label} className="flex items-center gap-2 flex-wrap justify-center">
+                  <span className="text-xs font-bold bg-[var(--text)] text-[var(--panel)] px-2 py-0.5 rounded">{label}</span>
+                  <span className="text-xl md:text-2xl font-bold" style={{ fontFamily: "'Klee One', serif" }}>
+                    {items.join('・')}
+                  </span>
+                </div>
+              ))}
+            </motion.div>
+          )}
+        </AnimatePresence>
+
+        {!revealed && (
+          <div className="text-xs font-bold text-[var(--text)] opacity-40 flex items-center gap-2">
+            <span className="bg-[var(--bg)] px-2 py-1 rounded">+{displayEarned.exp} EXP</span>
+            <span className="bg-[var(--bg)] px-2 py-1 rounded">{displayEarned.coins}</span>
+          </div>
+        )}
+
+        {revealed && (
+          <div className="flex w-full gap-4 mt-2">
+            <MotionButton variant="danger" onClick={() => handleAnswer(false)} className="flex-1 py-6 text-xl border-[4px] border-[var(--text)] shadow-[0_6px_0_#334155]">読めなかった</MotionButton>
+            <MotionButton variant="success" onClick={() => handleAnswer(true)} className="flex-1 py-6 text-xl border-[4px] border-[var(--text)] shadow-[0_6px_0_#065f46]">読めた！</MotionButton>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
- 2段階フロー: 漢字表示 → タップで読み表示 → 読めた/読めなかった判定
- タイマーをカウントダウン30秒からカウントアップ（経過時間計測）に変更
- キーボード操作対応: Space/Enter=めくる, →=読めた, ←=読めなかった
- スワイプ: タップでめくり、左右スワイプで判定
- 読み特化: 音読み・訓読みを表示
- ボタンラベルを「読めた！/読めなかった」に変更

https://claude.ai/code/session_016Kt2jMy3FrFSv7yNh9Wb8e