### PR TITLE
fix: セッション直後にお化けが出るバグを修正

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -267,6 +267,18 @@ export default function App() {
       newStats.coins = (newStats.coins || 0) + coinBonus;
       // セッション数カウント更新
       newStats.sessionCount = (newStats.sessionCount || 0) + 1;
+
+      // learningフェーズの漢字がセッション直後にお化けとして出ないよう、
+      // nextReviewに最低30分の猶予を持たせる
+      const gracePeriod = 30 * 60 * 1000; // 30分
+      const minNextReview = Date.now() + gracePeriod;
+      sessionData.queue.forEach(k => {
+        const ks = newStats.kanjiStats?.[k.id];
+        if (ks && !ks.graduated && ks.status !== 'new' && ks.nextReview < minNextReview) {
+          ks.nextReview = minNextReview;
+        }
+      });
+
       StorageAPI.saveStatsImmediate(newStats);
       return newStats;
     });


### PR DESCRIPTION
learningフェーズの漢字は正解してもnextReviewが1〜10分後に設定されるため、
セッション終了直後にお化けが出現していた。セッション完了時に未卒業の漢字に
最低30分の猶予を持たせることで、正解したのにすぐお化けが出る問題を解消。

https://claude.ai/code/session_01Y7akxY6zQ5bz6peLF1MM3S