### PR TITLE
fix: 消しゴムでアイテムが2つ増殖するバグを修正

### DIFF
--- a/src/components/town/TownEditorView.jsx
+++ b/src/components/town/TownEditorView.jsx
@@ -113,7 +113,6 @@ const TownEditorView = ({ setView, stats, setStats, onCraft }) => {
           }
         }
         setLocalMap(newMap); pushHistory(newMap);
-        setStats(s => ({ ...s, townItems: { ...s.townItems, [item.id]: (s.townItems?.[item.id] || 0) + 1 } }));
         audioCtrl.playSE('click');
         return;
       }
@@ -122,7 +121,6 @@ const TownEditorView = ({ setView, stats, setStats, onCraft }) => {
       if (item && item.type !== 'terrain') {
         const newMap = { ...localMap, [key]: 't_cleared' };
         setLocalMap(newMap); pushHistory(newMap);
-        setStats(s => ({ ...s, townItems: { ...s.townItems, [currentTile]: (s.townItems?.[currentTile] || 0) + 1 } }));
         audioCtrl.playSE('click');
       }
       return;


### PR DESCRIPTION
インベントリは「所持数 - 配置数 = 手持ち数」で管理されているため、
マップからアイテムを除去するだけで手持ちに戻る。
消去時に townItems を +1 していたのが二重加算の原因だったため、
setStats による townItems インクリメントを削除。

https://claude.ai/code/session_019tHJpqwbP7zeqwUtqzrYK4