### PR TITLE
feat: P2P通信のIDを4桁数字に変更、QRコード送受信機能を追加

### DIFF
--- a/src/components/social/StudentClientView.jsx
+++ b/src/components/social/StudentClientView.jsx
@@ -1,79 +1,333 @@
-import React, { useState, useRef } from 'react';
-import { Download, Wifi, Gift, ArrowLeft } from 'lucide-react';
+import React, { useState, useRef, useCallback, useEffect } from 'react';
+import { Download, Wifi, Gift, ArrowLeft, Camera, X, Delete } from 'lucide-react';
+import { motion, AnimatePresence } from 'framer-motion';
 import MotionButton from '../ui/MotionButton';
 import { usePeerJS } from '../../hooks/usePeerJS';
+import { useJsQR } from '../../hooks/useQRCode';
 import { KANJI_DATA } from '../../data/kanji-data';
 import { StorageAPI } from '../../systems/storage';
 import { audioCtrl } from '../../systems/audio';
 import { F } from '../ui/FormatKun';
+
+const PEER_ID_PREFIX = 'kanji-town-';
+
+// ソフトウェア数字キーボード
+const NumericKeypad = ({ value, onChange, onSubmit, disabled }) => {
+  const handleKey = (digit) => {
+    if (value.length >= 4) return;
+    audioCtrl.playSE('click');
+    onChange(value + digit);
+  };
+
+  const handleDelete = () => {
+    if (value.length === 0) return;
+    audioCtrl.playSE('click');
+    onChange(value.slice(0, -1));
+  };
+
+  const keys = [
+    ['1', '2', '3'],
+    ['4', '5', '6'],
+    ['7', '8', '9'],
+    ['del', '0', 'ok'],
+  ];
+
+  return (
+    <div className="flex flex-col gap-2">
+      {/* 入力表示エリア - 4桁のドット */}
+      <div className="flex justify-center gap-4 mb-2">
+        {[0, 1, 2, 3].map(i => (
+          <div key={i} className={`w-14 h-16 rounded-xl border-[4px] flex items-center justify-center text-3xl font-black transition-all ${
+            value[i]
+              ? 'border-[var(--primary)] bg-[var(--bg)] text-[var(--text)] scale-105'
+              : i === value.length
+                ? 'border-[var(--primary)] bg-[var(--bg)] animate-pulse'
+                : 'border-[var(--text)] opacity-30 bg-[var(--bg)]'
+          }`}>
+            {value[i] || ''}
+          </div>
+        ))}
+      </div>
+
+      {/* キーパッド */}
+      <div className="grid grid-cols-3 gap-2">
+        {keys.flat().map((key) => {
+          if (key === 'del') {
+            return (
+              <button key={key} onClick={handleDelete} disabled={value.length === 0}
+                className="h-14 rounded-xl border-[3px] border-[var(--text)] bg-[var(--bg)] font-bold text-[var(--text)] flex items-center justify-center active:scale-95 transition-transform disabled:opacity-30 touch-manipulation">
+                <Delete size={24} />
+              </button>
+            );
+          }
+          if (key === 'ok') {
+            return (
+              <button key={key} onClick={onSubmit} disabled={disabled || value.length !== 4}
+                className={`h-14 rounded-xl border-[3px] font-black text-lg flex items-center justify-center active:scale-95 transition-all touch-manipulation ${
+                  value.length === 4 && !disabled
+                    ? 'border-[var(--text)] bg-[var(--primary)] text-white shadow-[0_3px_0_#9f1239]'
+                    : 'border-[var(--text)] bg-[var(--bg)] text-[var(--text)] opacity-30'
+                }`}>
+                OK
+              </button>
+            );
+          }
+          return (
+            <button key={key} onClick={() => handleKey(key)} disabled={value.length >= 4}
+              className="h-14 rounded-xl border-[3px] border-[var(--text)] bg-[var(--panel)] font-black text-2xl text-[var(--text)] flex items-center justify-center active:scale-95 active:bg-[var(--accent)] transition-all disabled:opacity-30 touch-manipulation shadow-[0_3px_0_var(--text)]">
+              {key}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+// QRコードスキャナー
+const QRScanner = ({ onScan, onClose }) => {
+  const videoRef = useRef(null);
+  const canvasRef = useRef(null);
+  const streamRef = useRef(null);
+  const animFrameRef = useRef(null);
+  const isJsQRLoaded = useJsQR();
+  const [error, setError] = useState('');
+
+  const stopCamera = useCallback(() => {
+    if (animFrameRef.current) cancelAnimationFrame(animFrameRef.current);
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach(t => t.stop());
+      streamRef.current = null;
+    }
+  }, []);
+
+  const scan = useCallback(() => {
+    if (!videoRef.current || !canvasRef.current || !window.jsQR) return;
+    const video = videoRef.current;
+    const canvas = canvasRef.current;
+    if (video.readyState !== video.HAVE_ENOUGH_DATA) {
+      animFrameRef.current = requestAnimationFrame(scan);
+      return;
+    }
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+    const ctx = canvas.getContext('2d');
+    ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+    const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+    const code = window.jsQR(imageData.data, canvas.width, canvas.height);
+    if (code && code.data) {
+      // kanji-town- プレフィックスを含むID、または4桁の数字を検出
+      let peerId = code.data;
+      if (peerId.startsWith(PEER_ID_PREFIX)) {
+        peerId = peerId.replace(PEER_ID_PREFIX, '');
+      }
+      if (/^\d{4}$/.test(peerId)) {
+        audioCtrl.playSE('success');
+        stopCamera();
+        onScan(peerId);
+        return;
+      }
+    }
+    animFrameRef.current = requestAnimationFrame(scan);
+  }, [onScan, stopCamera]);
+
+  useEffect(() => {
+    if (!isJsQRLoaded) return;
+    navigator.mediaDevices?.getUserMedia({ video: { facingMode: 'environment' } })
+      .then(stream => {
+        streamRef.current = stream;
+        if (videoRef.current) {
+          videoRef.current.srcObject = stream;
+          videoRef.current.play();
+          animFrameRef.current = requestAnimationFrame(scan);
+        }
+      })
+      .catch(() => setError('カメラをつかえません'));
+    return stopCamera;
+  }, [isJsQRLoaded, scan, stopCamera]);
+
+  return (
+    <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
+      className="fixed inset-0 z-50 bg-black/80 flex flex-col items-center justify-center p-4">
+      <div className="relative w-full max-w-sm">
+        <button onClick={() => { stopCamera(); onClose(); }}
+          className="absolute -top-12 right-0 text-white p-2 rounded-full bg-white/20 z-10">
+          <X size={28} />
+        </button>
+        {error ? (
+          <div className="bg-white rounded-2xl p-8 text-center">
+            <div className="text-4xl mb-3">📷</div>
+            <p className="font-bold text-gray-700">{error}</p>
+            <p className="text-sm text-gray-400 mt-2">すうじをにゅうりょくしてください</p>
+          </div>
+        ) : (
+          <>
+            <div className="relative rounded-2xl overflow-hidden border-4 border-white/50">
+              <video ref={videoRef} className="w-full" playsInline muted />
+              <canvas ref={canvasRef} className="hidden" />
+              {/* スキャンエリアガイド */}
+              <div className="absolute inset-0 flex items-center justify-center">
+                <div className="w-48 h-48 border-4 border-white/70 rounded-2xl" />
+              </div>
+            </div>
+            <p className="text-white text-center mt-3 font-bold text-sm">
+              QRコードをうつしてください
+            </p>
+            {!isJsQRLoaded && (
+              <p className="text-white/50 text-center mt-1 text-xs">スキャナーをよみこみ中...</p>
+            )}
+          </>
+        )}
+      </div>
+    </motion.div>
+  );
+};
 
 const StudentClientView = ({ setView, stats, setStats }) => {
   const isPeerLoaded = usePeerJS();
   const [hostId, setHostId] = useState('');
   const [status, setStatus] = useState('');
   const [receivedDrill, setReceivedDrill] = useState(null);
+  const [showScanner, setShowScanner] = useState(false);
   const peerRef = useRef(null);
 
-  const handleConnect = () => {
-    if (!isPeerLoaded || !hostId.trim()) return;
+  const handleConnect = useCallback(() => {
+    if (!isPeerLoaded || hostId.length !== 4) return;
+    const fullId = PEER_ID_PREFIX + hostId;
     try {
       if (peerRef.current) peerRef.current.destroy();
       const peer = new window.Peer();
       peerRef.current = peer;
-      setStatus('接続中...');
+      setStatus('つないでいます...');
       peer.on('open', () => {
-        const conn = peer.connect(hostId.trim());
-        conn.on('open', () => setStatus('接続しました！データを待っています'));
+        const conn = peer.connect(fullId);
+        conn.on('open', () => setStatus('つながりました！まっています...'));
         conn.on('data', data => {
           try {
             const parsed = JSON.parse(data);
             if (parsed.type === 'drill') {
               setReceivedDrill(parsed.data);
-              setStatus('ドリルを受け取りました！');
+              setStatus('ドリルをうけとりました！');
               audioCtrl.playSE('chest_open');
             }
-          } catch (e) { setStatus('データの受け取りに失敗しました'); }
+          } catch (e) { setStatus('データのうけとりにしっぱいしました'); }
         });
-        conn.on('error', () => setStatus('接続エラーが発生しました'));
+        conn.on('error', () => setStatus('せつぞくエラーがおきました'));
       });
-      peer.on('error', () => setStatus('接続に失敗しました。IDを確認してください'));
-    } catch (e) { setStatus('PeerJS の初期化に失敗しました'); }
-  };
+      peer.on('error', () => setStatus('つなげませんでした。IDをかくにんしてください'));
+    } catch (e) { setStatus('PeerJS のじゅんびにしっぱいしました'); }
+  }, [isPeerLoaded, hostId]);
+
+  // 4桁入力完了で自動接続
+  useEffect(() => {
+    if (hostId.length === 4 && isPeerLoaded && !receivedDrill) {
+      // 少し待ってから接続（キーパッドアニメーション用）
+      const timer = setTimeout(handleConnect, 300);
+      return () => clearTimeout(timer);
+    }
+  }, [hostId, isPeerLoaded, receivedDrill, handleConnect]);
 
   const handleSaveDrill = () => {
     if (!receivedDrill) return;
     const newStats = { ...stats, myDrills: [...(stats.myDrills || []), { ...receivedDrill, createdAt: Date.now() }] };
-    setStats(newStats); StorageAPI.saveStats(newStats); audioCtrl.playSE('success'); setView('myDrills');
+    setStats(newStats);
+    StorageAPI.saveStats(newStats);
+    audioCtrl.playSE('success');
+    setView('myDrills');
+  };
+
+  const handleQRScan = (scannedId) => {
+    setShowScanner(false);
+    setHostId(scannedId);
   };
 
   return (
     <div className="flex flex-col gap-4 pb-8">
       <div className="flex items-center gap-3">
-        <button onClick={() => setView('home')} className="text-[var(--text)] opacity-60 hover:opacity-100 p-2 rounded-full hover:bg-[var(--bg)] transition-all"><ArrowLeft size={24} /></button>
-        <h2 className="text-2xl font-black text-[var(--text)] flex items-center gap-2"><Download size={22} /> {F("通信","つうしん")}でもらう</h2>
+        <button onClick={() => setView('home')} className="text-[var(--text)] opacity-60 hover:opacity-100 p-2 rounded-full hover:bg-[var(--bg)] transition-all min-w-[44px] min-h-[44px] flex items-center justify-center">
+          <ArrowLeft size={24} />
+        </button>
+        <h2 className="text-2xl font-black text-[var(--text)] flex items-center gap-2">
+          <Download size={22} /> {F("通信","つうしん")}でもらう
+        </h2>
       </div>
-      <div className="bg-[var(--panel)] border-[4px] border-[var(--text)] rounded-2xl p-5 shadow-[4px_4px_0_var(--text)] flex flex-col gap-3">
-        <div className="text-sm font-bold text-[var(--text)] opacity-70">{F("先生","せんせい")}から{F("教","おし")}えてもらったIDを{F("入力","にゅうりょく")}してください</div>
-        <input value={hostId} onChange={e => setHostId(e.target.value)} placeholder="ID を入力" className="w-full bg-[var(--bg)] border-[3px] border-[var(--text)] rounded-xl px-4 py-3 font-black text-[var(--text)] placeholder:opacity-30 focus:outline-none focus:border-[var(--primary)] text-xl tracking-widest" />
-        <MotionButton variant="primary" onClick={handleConnect} disabled={!isPeerLoaded || !hostId.trim()} className="w-full py-4 text-lg font-black border-[3px] border-[var(--text)] shadow-[0_4px_0_#9f1239]">
-          <Wifi size={20} /> つなぐ
-        </MotionButton>
-        {!isPeerLoaded && <div className="text-xs text-center text-[var(--text)] opacity-50">PeerJS {F("読","よ")}み{F("込","こ")}み{F("中","ちゅう")}...</div>}
-      </div>
+
+      {!receivedDrill && (
+        <div className="bg-[var(--panel)] border-[4px] border-[var(--text)] rounded-2xl p-5 shadow-[4px_4px_0_var(--text)] flex flex-col gap-4">
+          <div className="text-center font-bold text-[var(--text)]">
+            <span className="text-lg">4けたのすうじ</span>をいれてね
+          </div>
+
+          {/* 数字キーパッド */}
+          <NumericKeypad
+            value={hostId}
+            onChange={setHostId}
+            onSubmit={handleConnect}
+            disabled={!isPeerLoaded}
+          />
+
+          {/* QRコードスキャンボタン */}
+          <div className="flex items-center gap-3">
+            <div className="flex-1 h-[2px] bg-[var(--text)] opacity-10" />
+            <span className="text-xs font-bold text-[var(--text)] opacity-40">または</span>
+            <div className="flex-1 h-[2px] bg-[var(--text)] opacity-10" />
+          </div>
+
+          <MotionButton variant="secondary" onClick={() => setShowScanner(true)}
+            className="w-full py-4 text-lg font-black border-[3px] border-[var(--text)]">
+            <Camera size={22} /> QRコードでよみとる
+          </MotionButton>
+
+          {!isPeerLoaded && (
+            <div className="text-xs text-center text-[var(--text)] opacity-50">
+              じゅんびしています...
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* 接続ステータス */}
       {status !== '' && (
-        <div className={`border-[3px] rounded-xl p-4 font-bold text-center transition-colors ${status.includes('受け取り') ? 'bg-emerald-50 border-emerald-400 text-emerald-700' : status.includes('エラー') || status.includes('失敗') ? 'bg-rose-50 border-rose-400 text-rose-700' : 'bg-[var(--bg)] border-[var(--text)] text-[var(--text)]'}`}>
+        <div className={`border-[3px] rounded-xl p-4 font-bold text-center transition-colors ${
+          status.includes('うけとり') ? 'bg-emerald-50 border-emerald-400 text-emerald-700'
+            : status.includes('エラー') || status.includes('しっぱい') ? 'bg-rose-50 border-rose-400 text-rose-700'
+            : 'bg-[var(--bg)] border-[var(--text)] text-[var(--text)]'
+        }`}>
+          <div className="text-2xl mb-1">
+            {status.includes('うけとり') ? '🎉' : status.includes('エラー') || status.includes('しっぱい') ? '😢' : '⏳'}
+          </div>
           {status}
         </div>
       )}
-      {receivedDrill && (
-        <div className="bg-[var(--panel)] border-[4px] border-emerald-400 rounded-2xl p-5 shadow-[4px_4px_0_#059669] flex flex-col gap-3">
-          <div className="font-black text-[var(--text)] text-lg flex items-center gap-2"><Gift size={20} className="text-emerald-500" /> {receivedDrill.name}</div>
-          <div className="flex flex-wrap gap-1">{(receivedDrill.kanjis || []).map(id => { const k = KANJI_DATA.find(k => k.id === id); return k ? <span key={id} className="text-2xl font-black">{k.char}</span> : null; })}</div>
-          <MotionButton variant="success" onClick={handleSaveDrill} className="w-full py-4 text-lg font-black border-[3px] border-[var(--text)] shadow-[0_4px_0_#065f46]">
-            マイドリルに{F("保存","ほぞん")}する
-          </MotionButton>
-        </div>
-      )}
+
+      {/* 受信したドリル */}
+      <AnimatePresence>
+        {receivedDrill && (
+          <motion.div initial={{ scale: 0.9, opacity: 0 }} animate={{ scale: 1, opacity: 1 }}
+            className="bg-[var(--panel)] border-[4px] border-emerald-400 rounded-2xl p-5 shadow-[4px_4px_0_#059669] flex flex-col gap-3">
+            <div className="font-black text-[var(--text)] text-lg flex items-center gap-2">
+              <Gift size={20} className="text-emerald-500" /> {receivedDrill.name}
+            </div>
+            <div className="flex flex-wrap gap-1">
+              {(receivedDrill.kanjis || []).map(id => {
+                const k = KANJI_DATA.find(k => k.id === id);
+                return k ? <span key={id} className="text-2xl font-black">{k.char}</span> : null;
+              })}
+            </div>
+            <MotionButton variant="success" onClick={handleSaveDrill}
+              className="w-full py-4 text-lg font-black border-[3px] border-[var(--text)] shadow-[0_4px_0_#065f46]">
+              マイドリルに{F("保存","ほぞん")}する
+            </MotionButton>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* QRスキャナーモーダル */}
+      <AnimatePresence>
+        {showScanner && (
+          <QRScanner onScan={handleQRScan} onClose={() => setShowScanner(false)} />
+        )}
+      </AnimatePresence>
     </div>
   );
 };

--- a/src/components/social/TeacherHostView.jsx
+++ b/src/components/social/TeacherHostView.jsx
@@ -1,54 +1,166 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { Wifi, ArrowLeft } from 'lucide-react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { Wifi, ArrowLeft, Copy, Check } from 'lucide-react';
 import { usePeerJS } from '../../hooks/usePeerJS';
+import { useQRCode } from '../../hooks/useQRCode';
 import { F } from '../ui/FormatKun';
 import { KANJI_DATA } from '../../data/kanji-data';
+import { audioCtrl } from '../../systems/audio';
+
+// 4桁のランダムな数字IDを生成
+const generate4DigitId = () => {
+  return String(Math.floor(Math.random() * 10000)).padStart(4, '0');
+};
+
+const PEER_ID_PREFIX = 'kanji-town-';
 
 const TeacherHostView = ({ setView, drill }) => {
   const isPeerLoaded = usePeerJS();
-  const [peerId, setPeerId] = useState('');
+  const isQRLoaded = useQRCode();
+  const [numericId, setNumericId] = useState('');
   const [status, setStatus] = useState('起動中...');
+  const [copied, setCopied] = useState(false);
   const peerRef = useRef(null);
+  const qrCanvasRef = useRef(null);
+  const retryCountRef = useRef(0);
 
-  useEffect(() => {
-    if (!isPeerLoaded || !drill) return;
+  // QRコード描画
+  const renderQR = useCallback((id) => {
+    if (!isQRLoaded || !qrCanvasRef.current || !id) return;
     try {
-      const peer = new window.Peer();
+      window.QRCode.toCanvas(qrCanvasRef.current, id, {
+        width: 200,
+        margin: 2,
+        color: { dark: '#292f36', light: '#ffffff' },
+      });
+    } catch (e) {
+      console.error('QR code rendering failed:', e);
+    }
+  }, [isQRLoaded]);
+
+  // Peer接続を開始（IDが衝突した場合はリトライ）
+  const initPeer = useCallback(() => {
+    if (!isPeerLoaded || !drill) return;
+    const id4 = generate4DigitId();
+    const fullId = PEER_ID_PREFIX + id4;
+    try {
+      if (peerRef.current) peerRef.current.destroy();
+      const peer = new window.Peer(fullId);
       peerRef.current = peer;
-      peer.on('open', id => { setPeerId(id); setStatus('生徒の接続を待っています'); });
+
+      peer.on('open', () => {
+        setNumericId(id4);
+        setStatus('IDができました！');
+        retryCountRef.current = 0;
+        renderQR(fullId);
+      });
+
       peer.on('connection', conn => {
-        setStatus('生徒が接続しました！送信中...');
+        setStatus('せつぞくしました！おくっています...');
         conn.on('open', () => {
           conn.send(JSON.stringify({ type: 'drill', data: drill }));
-          setTimeout(() => setStatus('送信完了！'), 500);
+          setTimeout(() => {
+            setStatus('おくれました！');
+            audioCtrl.playSE('success');
+          }, 500);
         });
       });
-      peer.on('error', () => setStatus('エラーが発生しました'));
-      return () => { peer.destroy(); };
-    } catch (e) { setStatus('PeerJS の初期化に失敗しました'); }
-  }, [isPeerLoaded, drill]);
+
+      peer.on('error', err => {
+        // IDが既に使われている場合はリトライ
+        if (err.type === 'unavailable-id' && retryCountRef.current < 5) {
+          retryCountRef.current++;
+          peer.destroy();
+          initPeer();
+        } else {
+          setStatus('エラーがおきました');
+        }
+      });
+    } catch (e) {
+      setStatus('PeerJS のじゅんびにしっぱいしました');
+    }
+  }, [isPeerLoaded, drill, renderQR]);
+
+  useEffect(() => {
+    initPeer();
+    return () => { if (peerRef.current) peerRef.current.destroy(); };
+  }, [initPeer]);
+
+  // QRコードが後からロードされた場合に再描画
+  useEffect(() => {
+    if (numericId && isQRLoaded) {
+      renderQR(PEER_ID_PREFIX + numericId);
+    }
+  }, [numericId, isQRLoaded, renderQR]);
+
+  const handleCopy = () => {
+    navigator.clipboard?.writeText(numericId).then(() => {
+      setCopied(true);
+      audioCtrl.playSE('click');
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  const statusEmoji = status.includes('おくれました') ? '✅' : status.includes('エラー') || status.includes('しっぱい') ? '❌' : status.includes('おくって') ? '📨' : '📡';
 
   return (
     <div className="flex flex-col gap-4 pb-8">
       <div className="flex items-center gap-3">
-        <button onClick={() => setView('myDrills')} className="text-[var(--text)] opacity-60 hover:opacity-100 p-2 rounded-full hover:bg-[var(--bg)] transition-all"><ArrowLeft size={24} /></button>
-        <h2 className="text-2xl font-black text-[var(--text)] flex items-center gap-2"><Wifi size={22} /> ドリルを{F("送","おく")}る</h2>
+        <button onClick={() => setView('myDrills')} className="text-[var(--text)] opacity-60 hover:opacity-100 p-2 rounded-full hover:bg-[var(--bg)] transition-all min-w-[44px] min-h-[44px] flex items-center justify-center">
+          <ArrowLeft size={24} />
+        </button>
+        <h2 className="text-2xl font-black text-[var(--text)] flex items-center gap-2">
+          <Wifi size={22} /> ドリルを{F("送","おく")}る
+        </h2>
       </div>
+
       <div className="bg-[var(--panel)] border-[4px] border-[var(--text)] rounded-2xl p-6 shadow-[4px_4px_0_var(--text)] flex flex-col items-center gap-4">
-        <div className="text-4xl">{status.includes('完了') ? '✅' : status.includes('エラー') ? '❌' : '📡'}</div>
+        <div className="text-4xl">{statusEmoji}</div>
         <div className="font-bold text-[var(--text)] text-center">{status}</div>
-        {peerId && (
+
+        {numericId && (
           <>
-            <div className="bg-[var(--bg)] border-[3px] border-[var(--text)] rounded-xl px-6 py-3 font-black text-2xl tracking-widest text-[var(--primary)]">{peerId}</div>
-            <p className="text-sm text-[var(--text)] opacity-60 text-center">このIDを{F("生徒","せいと")}に{F("伝","つた")}えてください</p>
+            {/* 4桁の数字ID表示 */}
+            <div className="flex items-center gap-3">
+              <div className="bg-[var(--bg)] border-[4px] border-[var(--text)] rounded-2xl px-8 py-4 font-black text-5xl tracking-[0.3em] text-[var(--primary)] text-center select-all" style={{ fontFamily: "'Zen Maru Gothic', sans-serif", letterSpacing: '0.3em' }}>
+                {numericId}
+              </div>
+              <button onClick={handleCopy} className="p-3 rounded-xl border-[3px] border-[var(--text)] bg-[var(--bg)] hover:bg-[var(--accent)] transition-colors min-w-[48px] min-h-[48px] flex items-center justify-center" aria-label="IDをコピー">
+                {copied ? <Check size={24} className="text-emerald-500" /> : <Copy size={24} className="text-[var(--text)] opacity-60" />}
+              </button>
+            </div>
+
+            <p className="text-sm text-[var(--text)] opacity-60 text-center">
+              この<span className="font-black text-base text-[var(--primary)]">4けたのすうじ</span>を{F("相手","あいて")}に{F("伝","つた")}えてください
+            </p>
+
+            {/* QRコード */}
+            <div className="bg-white rounded-2xl p-4 border-[3px] border-[var(--text)] shadow-inner">
+              <canvas ref={qrCanvasRef} />
+            </div>
+            <p className="text-xs text-[var(--text)] opacity-40 text-center">
+              QRコードをよみとってもつなげます
+            </p>
           </>
         )}
-        {!isPeerLoaded && <div className="text-sm text-[var(--text)] opacity-50">PeerJS を{F("読","よ")}み{F("込","こ")}み{F("中","ちゅう")}...</div>}
+
+        {!isPeerLoaded && (
+          <div className="text-sm text-[var(--text)] opacity-50">
+            じゅんびしています...
+          </div>
+        )}
       </div>
+
       {drill && (
         <div className="bg-[var(--panel)] border-[3px] border-[var(--text)] rounded-xl p-4">
-          <div className="font-black text-[var(--text)] mb-2">{F("送","おく")}るドリル：{drill.name}</div>
-          <div className="flex flex-wrap gap-1">{(drill.kanjis || []).map(id => { const k = KANJI_DATA.find(k => k.id === id); return k ? <span key={id} className="text-xl font-black">{k.char}</span> : null; })}</div>
+          <div className="font-black text-[var(--text)] mb-2">
+            {F("送","おく")}るドリル：{drill.name}
+          </div>
+          <div className="flex flex-wrap gap-1">
+            {(drill.kanjis || []).map(id => {
+              const k = KANJI_DATA.find(k => k.id === id);
+              return k ? <span key={id} className="text-xl font-black">{k.char}</span> : null;
+            })}
+          </div>
         </div>
       )}
     </div>

--- a/src/hooks/useQRCode.js
+++ b/src/hooks/useQRCode.js
@@ -1,0 +1,29 @@
+import { useState, useEffect } from 'react';
+
+// QRコード生成ライブラリをCDNから動的ロード
+export const useQRCode = () => {
+  const [isLoaded, setIsLoaded] = useState(false);
+  useEffect(() => {
+    if (window.QRCode) { setIsLoaded(true); return; }
+    const script = document.createElement('script');
+    script.src = "https://unpkg.com/qrcode@1.5.4/build/qrcode.min.js";
+    script.onload = () => setIsLoaded(true);
+    script.onerror = () => console.error('QRCode library failed to load');
+    document.body.appendChild(script);
+  }, []);
+  return isLoaded;
+};
+
+// QRコードスキャナーライブラリをCDNから動的ロード (jsQR)
+export const useJsQR = () => {
+  const [isLoaded, setIsLoaded] = useState(false);
+  useEffect(() => {
+    if (window.jsQR) { setIsLoaded(true); return; }
+    const script = document.createElement('script');
+    script.src = "https://unpkg.com/jsqr@1.4.0/dist/jsQR.js";
+    script.onload = () => setIsLoaded(true);
+    script.onerror = () => console.error('jsQR library failed to load');
+    document.body.appendChild(script);
+  }, []);
+  return isLoaded;
+};


### PR DESCRIPTION
- 送信側: 4桁の数字IDを生成し大きく表示、QRコードも同時表示
- 受信側: ソフトウェア数字キーボードで簡単入力、QRスキャナー機能付き
- 低学年の児童でも簡単に操作できるUIに改善
- PeerJS IDにプレフィックス(kanji-town-)を付加しID衝突を回避
- QRコード生成(qrcode)・読取(jsQR)ライブラリをCDNから動的ロード

https://claude.ai/code/session_01GKaHqdPE8UzuHgRMQbDBdJ