### PR TITLE
fix: QRコードライブラリのCDN URLを修正、カメラエラー処理を改善

### DIFF
--- a/src/components/social/StudentClientView.jsx
+++ b/src/components/social/StudentClientView.jsx
@@ -133,7 +133,11 @@ const QRScanner = ({ onScan, onClose }) => {
 
   useEffect(() => {
     if (!isJsQRLoaded) return;
-    navigator.mediaDevices?.getUserMedia({ video: { facingMode: 'environment' } })
+    if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+      setError('このブラウザではカメラがつかえません');
+      return;
+    }
+    navigator.mediaDevices.getUserMedia({ video: { facingMode: 'environment' } })
       .then(stream => {
         streamRef.current = stream;
         if (videoRef.current) {

--- a/src/hooks/useQRCode.js
+++ b/src/hooks/useQRCode.js
@@ -1,15 +1,32 @@
 import { useState, useEffect } from 'react';
 
+// CDNロードのヘルパー（フォールバック付き）
+const loadScript = (urls, onLoad, onError) => {
+  let idx = 0;
+  const tryLoad = () => {
+    if (idx >= urls.length) { onError(); return; }
+    const script = document.createElement('script');
+    script.src = urls[idx];
+    script.onload = onLoad;
+    script.onerror = () => { idx++; script.remove(); tryLoad(); };
+    document.body.appendChild(script);
+  };
+  tryLoad();
+};
+
 // QRコード生成ライブラリをCDNから動的ロード
 export const useQRCode = () => {
   const [isLoaded, setIsLoaded] = useState(false);
   useEffect(() => {
     if (window.QRCode) { setIsLoaded(true); return; }
-    const script = document.createElement('script');
-    script.src = "https://unpkg.com/qrcode@1.5.4/build/qrcode.min.js";
-    script.onload = () => setIsLoaded(true);
-    script.onerror = () => console.error('QRCode library failed to load');
-    document.body.appendChild(script);
+    loadScript(
+      [
+        "https://cdn.jsdelivr.net/npm/qrcode@1.5.4/build/qrcode.min.js",
+        "https://unpkg.com/qrcode@1.4.4/build/qrcode.min.js",
+      ],
+      () => setIsLoaded(true),
+      () => console.error('QRCode library failed to load')
+    );
   }, []);
   return isLoaded;
 };
@@ -19,11 +36,14 @@ export const useJsQR = () => {
   const [isLoaded, setIsLoaded] = useState(false);
   useEffect(() => {
     if (window.jsQR) { setIsLoaded(true); return; }
-    const script = document.createElement('script');
-    script.src = "https://unpkg.com/jsqr@1.4.0/dist/jsQR.js";
-    script.onload = () => setIsLoaded(true);
-    script.onerror = () => console.error('jsQR library failed to load');
-    document.body.appendChild(script);
+    loadScript(
+      [
+        "https://cdn.jsdelivr.net/npm/jsqr@1.4.0/dist/jsQR.js",
+        "https://unpkg.com/jsqr@1.4.0/dist/jsQR.js",
+      ],
+      () => setIsLoaded(true),
+      () => console.error('jsQR library failed to load')
+    );
   }, []);
   return isLoaded;
 };


### PR DESCRIPTION
- qrcodeライブラリをjsDelivr優先に変更（unpkgフォールバック付き）
- jsQRライブラリも同様にフォールバック対応
- カメラAPI非対応ブラウザでの適切なエラーメッセージ表示

https://claude.ai/code/session_01GKaHqdPE8UzuHgRMQbDBdJ