### PR TITLE
fix: ストローク判定の閾値不整合を統一し、漢字表示の位置ズレを修正

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -1023,7 +1023,7 @@ const TestMode = ({ kanji, onEvaluate, canvasSize, commonSidebar }) => {
       {showAnswer && (
         <div className="relative border-[4px] border-[var(--primary)] rounded-[20px] bg-[var(--bg)] overflow-hidden flex items-center justify-center transition-all duration-200 shadow-[4px_4px_0_var(--primary)] md:shadow-[8px_8px_0_var(--primary)] animate-in fade-in slide-in-from-left-4 shrink-0" style={{ width: canvasSize, maxWidth: 'calc(50% - 16px)', maxHeight: '100%', aspectRatio: '1/1' }}>
           <div className="absolute top-0 left-1/2 w-0 h-full border-l-4 border-dashed border-[var(--primary)] opacity-20 -translate-x-1/2 pointer-events-none" /><div className="absolute top-1/2 left-0 w-full h-0 border-t-4 border-dashed border-[var(--primary)] opacity-20 -translate-y-1/2 pointer-events-none" />
-          <svg viewBox="0 0 100 100" className="w-full h-full relative z-10 pointer-events-none select-none drop-shadow-sm p-2"><text x="50" y="52" dominantBaseline="middle" textAnchor="middle" fontSize="70" fontWeight="900" fill="var(--primary)" fontFamily="'Klee One', serif">{kanji.char}</text></svg>
+          <svg viewBox="0 0 100 100" className="w-full h-full relative z-10 pointer-events-none select-none drop-shadow-sm p-2"><text x="50" y="55" dominantBaseline="central" textAnchor="middle" fontSize="70" fontWeight="900" fill="var(--primary)" fontFamily="'Klee One', serif">{kanji.char}</text></svg>
           <div className="absolute top-3 right-3 bg-[var(--primary)] text-[var(--panel)] text-[10px] md:text-xs font-black px-3 md:px-4 py-1.5 rounded-full border-[3px] border-[var(--text)] shadow-sm z-20">こたえ</div>
         </div>
       )}

--- a/src/components/session/TestMode.jsx
+++ b/src/components/session/TestMode.jsx
@@ -147,7 +147,7 @@ const TestMode = ({ kanji, strokeData, onEvaluate, canvasSize, commonSidebar }) 
         <div className="relative border-[4px] border-[var(--primary)] rounded-[20px] bg-[var(--bg)] overflow-hidden flex items-center justify-center transition-all duration-200 shadow-[4px_4px_0_var(--primary)] md:shadow-[8px_8px_0_var(--primary)] animate-in fade-in slide-in-from-left-4 shrink-0" style={{ width: canvasSize, maxWidth: 'calc(50% - 16px)', maxHeight: '100%', aspectRatio: '1/1' }}>
           <div className="absolute top-0 left-1/2 w-0 h-full border-l-4 border-dashed border-[var(--primary)] opacity-20 -translate-x-1/2 pointer-events-none" />
           <div className="absolute top-1/2 left-0 w-full h-0 border-t-4 border-dashed border-[var(--primary)] opacity-20 -translate-y-1/2 pointer-events-none" />
-          <svg viewBox="0 0 100 100" className="w-full h-full relative z-10 pointer-events-none select-none drop-shadow-sm p-2"><text x="50" y="52" dominantBaseline="middle" textAnchor="middle" fontSize="70" fontWeight="900" fill="var(--primary)" fontFamily="'Klee One', serif">{kanji.char}</text></svg>
+          <svg viewBox="0 0 100 100" className="w-full h-full relative z-10 pointer-events-none select-none drop-shadow-sm p-2"><text x="50" y="55" dominantBaseline="central" textAnchor="middle" fontSize="70" fontWeight="900" fill="var(--primary)" fontFamily="'Klee One', serif">{kanji.char}</text></svg>
           <div className="absolute top-3 right-3 bg-[var(--primary)] text-[var(--panel)] text-[10px] md:text-xs font-black px-3 md:px-4 py-1.5 rounded-full border-[3px] border-[var(--text)] shadow-sm z-20">こたえ</div>
         </div>
       )}

--- a/src/components/session/WriteMode.jsx
+++ b/src/components/session/WriteMode.jsx
@@ -7,6 +7,7 @@ import Confetti from '../ui/Confetti';
 import { Analyzer } from '../../systems/analyzer';
 import { audioCtrl } from '../../systems/audio';
 import { F } from '../ui/FormatKun';
+import { STROKE_THRESHOLDS } from '../../constants/strokeConfig';
 
 const WriteMode = ({ paths, strokeData, crossMatrix, onNext, canvasSize, commonSidebar, onRecordPerfect }) => {
   const guideRef = useRef(null); const inkRef = useRef(null); const writeRef = useRef(null);
@@ -53,7 +54,7 @@ const WriteMode = ({ paths, strokeData, crossMatrix, onNext, canvasSize, commonS
     // FIX: guard against missing strokeData
     if (!strokeData[currentStrokeRef.current]) return;
     const { x, y } = getCoords(e); const target = strokeData[currentStrokeRef.current].s;
-    if (Math.hypot(x / canvasSize - target.x, y / canvasSize - target.y) > 0.18) { setStatusMsg("かきはじめが ちがうよ💦"); audioCtrl.playSE('stamp_bad'); return; }
+    if (Math.hypot(x / canvasSize - target.x, y / canvasSize - target.y) > STROKE_THRESHOLDS.START_POINT) { setStatusMsg("かきはじめが ちがうよ💦"); audioCtrl.playSE('stamp_bad'); return; }
     setStatusMsg(`${currentStrokeRef.current + 1}かくめ なぞり中...`); setIsDrawing(true); lastPos.current = { x, y }; currentPathRef.current = [{ x, y, time: Date.now() }];
     const ctx = writeRef.current.getContext('2d'); ctx.lineCap = 'round'; ctx.lineJoin = 'round'; ctx.lineWidth = canvasSize * 0.08; ctx.strokeStyle = "var(--secondary)"; ctx.beginPath(); ctx.moveTo(x, y); ctx.lineTo(x, y); ctx.stroke();
   };
@@ -67,7 +68,7 @@ const WriteMode = ({ paths, strokeData, crossMatrix, onNext, canvasSize, commonS
     // FIX: guard against missing strokeData
     if (!strokeData[currentStrokeRef.current]) return;
     const target = strokeData[currentStrokeRef.current].e; const currentDist = Math.hypot(lastPos.current.x / canvasSize - target.x, lastPos.current.y / canvasSize - target.y);
-    if (currentDist < 0.25) {
+    if (currentDist < STROKE_THRESHOLDS.END_POINT) {
       let isError = false; let errMsg = "";
       if (count >= 2) {
         const normalizedPoints = currentPathRef.current.map(p => ({ x: p.x / canvasSize, y: p.y / canvasSize, time: p.time })); const ending = Analyzer.analyzeEnding(normalizedPoints);

--- a/src/constants/strokeConfig.js
+++ b/src/constants/strokeConfig.js
@@ -1,0 +1,7 @@
+// ストローク判定の共有閾値
+// WriteMode（書き中）と strokeGrader（採点時）で同一の定数を使用する
+export const STROKE_THRESHOLDS = {
+  START_POINT: 0.20,   // 始点の許容距離（正規化座標）
+  END_POINT: 0.25,     // 終点の許容距離（正規化座標）
+  CROSS_DISTANCE: 0.3, // 書き順マッチングの許容距離
+};

--- a/src/systems/strokeGrader.js
+++ b/src/systems/strokeGrader.js
@@ -1,5 +1,6 @@
 // ボスバトル用 客観的ストローク採点エンジン
 // 画数・始点・終点・書き順を100点満点で採点
+import { STROKE_THRESHOLDS } from '../constants/strokeConfig';
 
 /**
  * ユーザーのストロークを正解データと比較して採点する
@@ -40,7 +41,7 @@ export function gradeStrokes(userStrokes, strokeData, canvasSize) {
     const targetStart = strokeData[i].s;
     const dist = Math.hypot(userStart.x - targetStart.x, userStart.y - targetStart.y);
     // dist 0 → 1.0, dist 0.2+ → 0
-    const score = Math.max(0, 1 - dist / 0.2);
+    const score = Math.max(0, 1 - dist / STROKE_THRESHOLDS.START_POINT);
     startTotal += score;
   }
   const startScore = Math.round((startTotal / expectedCount) * 30);
@@ -57,7 +58,7 @@ export function gradeStrokes(userStrokes, strokeData, canvasSize) {
     const userEnd = { x: lastPt.x / canvasSize, y: lastPt.y / canvasSize };
     const targetEnd = strokeData[i].e;
     const dist = Math.hypot(userEnd.x - targetEnd.x, userEnd.y - targetEnd.y);
-    const score = Math.max(0, 1 - dist / 0.25);
+    const score = Math.max(0, 1 - dist / STROKE_THRESHOLDS.END_POINT);
     endTotal += score;
   }
   const endScore = Math.round((endTotal / expectedCount) * 30);
@@ -84,7 +85,7 @@ export function gradeStrokes(userStrokes, strokeData, canvasSize) {
       const d = Math.hypot(userStart.x - strokeData[j].s.x, userStart.y - strokeData[j].s.y);
       if (d < bestDist) { bestDist = d; bestIdx = j; }
     }
-    if (bestIdx >= 0 && bestDist < 0.3) {
+    if (bestIdx >= 0 && bestDist < STROKE_THRESHOLDS.CROSS_DISTANCE) {
       usedTargets.add(bestIdx);
       matchMap[i] = bestIdx;
       if (bestIdx === i) orderCorrect++;


### PR DESCRIPTION
WriteMode（書き中: 0.18）とstrokeGrader（採点時: 0.20）で始点閾値が 異なっていたため、「書けたのに低スコア」という矛盾体験が生じていた。
共有定数ファイル(STROKE_THRESHOLDS)を新設し、全モードで同一閾値を参照するよう統一。

また、テストモードの答え表示でy="52" + dominantBaseline="middle"だった SVGテキストをy="55" + dominantBaseline="central"に修正し、CJK文字の 視覚的中央配置を改善。

https://claude.ai/code/session_01VgB3ec7738AYpgDo2MiUYa