### PR TITLE
feat: オフライン完全対応（PWA強化）

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,46 +1,60 @@
 // マイ漢字タウン Service Worker
-const CACHE_NAME = 'kanji-town-v1';
+// 戦略キャッシュでGIGAスクール端末のオフライン環境に完全対応
+const CACHE_VERSION = 2;
+const CACHE_STATIC = `kanji-town-static-v${CACHE_VERSION}`;
+const CACHE_KANJIVG = `kanji-town-kanjivg-v${CACHE_VERSION}`;
+const CACHE_FONTS = `kanji-town-fonts-v${CACHE_VERSION}`;
+const CACHE_RUNTIME = `kanji-town-runtime-v${CACHE_VERSION}`;
+const ALL_CACHES = [CACHE_STATIC, CACHE_KANJIVG, CACHE_FONTS, CACHE_RUNTIME];
 const BASE = '/KANJI_Town/';
 
-// ビルド時に生成されるアセットはランタイムキャッシュで対応
+// プリキャッシュ: アプリシェルの最低限
 const PRECACHE_URLS = [
   BASE,
   BASE + 'offline.html',
 ];
 
-// インストール: 最低限のファイルをプリキャッシュ
+// ── インストール ──
 self.addEventListener('install', (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE_URLS))
+    caches.open(CACHE_STATIC).then((cache) => cache.addAll(PRECACHE_URLS))
   );
   self.skipWaiting();
 });
 
-// アクティベート: 古いキャッシュを削除
+// ── アクティベート: 古いバージョンのキャッシュを削除 ──
 self.addEventListener('activate', (event) => {
   event.waitUntil(
     caches.keys().then((keys) =>
-      Promise.all(keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)))
+      Promise.all(
+        keys
+          .filter((k) => !ALL_CACHES.includes(k))
+          .map((k) => caches.delete(k))
+      )
     )
   );
   self.clients.claim();
 });
 
-// フェッチ: Network-first + キャッシュフォールバック戦略
+// ── フェッチ: リソース種別ごとの戦略キャッシュ ──
 self.addEventListener('fetch', (event) => {
   const { request } = event;
+  const url = request.url;
 
-  // POST, non-HTTP requests はスキップ
-  if (request.method !== 'GET' || !request.url.startsWith('http')) return;
+  // POST, non-HTTP はスキップ
+  if (request.method !== 'GET' || !url.startsWith('http')) return;
 
-  // Google Fonts: Cache-first (変更されないため)
-  if (request.url.includes('fonts.googleapis.com') || request.url.includes('fonts.gstatic.com')) {
+  // ── KanjiVG CDN: Cache-first → Network ──
+  // 一度取得したSVGは変更されないためキャッシュ優先
+  if (url.includes('cdn.jsdelivr.net') && url.includes('kanjivg')) {
     event.respondWith(
       caches.match(request).then((cached) => {
         if (cached) return cached;
         return fetch(request).then((response) => {
-          const clone = response.clone();
-          caches.open(CACHE_NAME).then((cache) => cache.put(request, clone));
+          if (response.ok) {
+            const clone = response.clone();
+            caches.open(CACHE_KANJIVG).then((cache) => cache.put(request, clone));
+          }
           return response;
         });
       })
@@ -48,30 +62,77 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
-  // ナビゲーション: Network-first → オフラインページ
+  // ── Google Fonts: Cache-first ──
+  if (url.includes('fonts.googleapis.com') || url.includes('fonts.gstatic.com')) {
+    event.respondWith(
+      caches.match(request).then((cached) => {
+        if (cached) return cached;
+        return fetch(request).then((response) => {
+          if (response.ok) {
+            const clone = response.clone();
+            caches.open(CACHE_FONTS).then((cache) => cache.put(request, clone));
+          }
+          return response;
+        });
+      })
+    );
+    return;
+  }
+
+  // ── ナビゲーション: Network-first → キャッシュ → オフラインページ ──
   if (request.mode === 'navigate') {
     event.respondWith(
       fetch(request)
         .then((response) => {
           const clone = response.clone();
-          caches.open(CACHE_NAME).then((cache) => cache.put(request, clone));
+          caches.open(CACHE_STATIC).then((cache) => cache.put(request, clone));
           return response;
         })
-        .catch(() => caches.match(BASE + 'offline.html'))
+        .catch(() =>
+          caches.match(request).then((cached) =>
+            cached || caches.match(BASE + 'offline.html')
+          )
+        )
     );
     return;
   }
 
-  // JS/CSS/画像アセット: Network-first + キャッシュ
+  // ── JS/CSS/画像 (ビルドアセット): Stale-While-Revalidate ──
+  // ハッシュ付きアセットは変わらないのでキャッシュ優先、なければネットワーク
+  if (url.includes('/assets/') || url.endsWith('.js') || url.endsWith('.css') || url.endsWith('.png') || url.endsWith('.svg') || url.endsWith('.ico')) {
+    event.respondWith(
+      caches.match(request).then((cached) => {
+        const networkFetch = fetch(request).then((response) => {
+          if (response.ok) {
+            const clone = response.clone();
+            caches.open(CACHE_RUNTIME).then((cache) => cache.put(request, clone));
+          }
+          return response;
+        }).catch(() => cached);
+
+        return cached || networkFetch;
+      })
+    );
+    return;
+  }
+
+  // ── その他: Network-first → キャッシュ ──
   event.respondWith(
     fetch(request)
       .then((response) => {
         if (response.ok) {
           const clone = response.clone();
-          caches.open(CACHE_NAME).then((cache) => cache.put(request, clone));
+          caches.open(CACHE_RUNTIME).then((cache) => cache.put(request, clone));
         }
         return response;
       })
       .catch(() => caches.match(request))
   );
+});
+
+// ── SW更新通知 ──
+self.addEventListener('message', (event) => {
+  if (event.data === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
 });

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect, useCallback, useMemo, lazy, Suspense } from 'react';
 import { AnimatePresence } from 'framer-motion';
 import { PenTool, Volume2, VolumeX, Settings, Users } from 'lucide-react';
+import { useOnlineStatus } from './hooks/useOnlineStatus';
+import OfflineBanner from './components/ui/OfflineBanner';
 
 import { StorageAPI, getLevelInfo } from './systems/storage';
 import { calculateNextReview, migrateCard } from './systems/srs';
@@ -84,6 +86,7 @@ export default function App() {
   const [dailyMissions, setDailyMissions] = useState([]);
   // Phase 5: ヒント
   const [seenHints, setSeenHints] = useState(stats.seenHints || []);
+  const isOnline = useOnlineStatus();
 
   const levelInfo = useMemo(() => getLevelInfo(stats.totalExp, stats.townMap), [stats.totalExp, stats.townMap]);
 
@@ -465,6 +468,9 @@ export default function App() {
   return (
     <div className="flex flex-col h-[100dvh] w-full bg-[var(--bg)] relative overflow-hidden transition-colors duration-500">
       <GlobalStyle />
+
+      {/* オフラインバナー */}
+      {!isOnline && <OfflineBanner />}
 
       {/* Phase 5: チュートリアルオーバーレイ */}
       <AnimatePresence>

--- a/src/components/ui/OfflineBanner.jsx
+++ b/src/components/ui/OfflineBanner.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { WifiOff } from 'lucide-react';
+
+/**
+ * オフライン状態を画面上部に固定表示するバナー
+ * GIGAスクール端末でネットワーク断が発生した際に子供に分かりやすく通知
+ */
+export default function OfflineBanner() {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="fixed top-0 left-0 right-0 z-[9999] flex items-center justify-center gap-2 py-2 px-4 text-sm font-bold"
+      style={{
+        background: '#fbbf24',
+        color: '#292f36',
+        borderBottom: '3px solid #292f36',
+      }}
+    >
+      <WifiOff size={16} strokeWidth={3} />
+      <span>オフラインモード — ネットなしでもべんきょうできるよ！</span>
+    </div>
+  );
+}

--- a/src/components/ui/index.js
+++ b/src/components/ui/index.js
@@ -6,3 +6,4 @@ export { default as AnimatedCounter } from './AnimatedCounter';
 export { default as StampEffect } from './StampEffect';
 export { default as Footer } from './Footer';
 export { R, FormatKun } from './FormatKun';
+export { default as OfflineBanner } from './OfflineBanner';

--- a/src/hooks/useOnlineStatus.js
+++ b/src/hooks/useOnlineStatus.js
@@ -1,0 +1,25 @@
+import { useState, useEffect, useCallback } from 'react';
+
+/**
+ * オンライン/オフライン状態を監視するフック
+ * navigator.onLine + online/offline イベントで即座に検知
+ */
+export function useOnlineStatus() {
+  const [isOnline, setIsOnline] = useState(
+    typeof navigator !== 'undefined' ? navigator.onLine : true
+  );
+
+  const goOnline = useCallback(() => setIsOnline(true), []);
+  const goOffline = useCallback(() => setIsOnline(false), []);
+
+  useEffect(() => {
+    window.addEventListener('online', goOnline);
+    window.addEventListener('offline', goOffline);
+    return () => {
+      window.removeEventListener('online', goOnline);
+      window.removeEventListener('offline', goOffline);
+    };
+  }, [goOnline, goOffline]);
+
+  return isOnline;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -9,9 +9,24 @@ ReactDOM.createRoot(document.getElementById('root')).render(
   </React.StrictMode>
 );
 
-// Service Worker登録（PWA対応）
+// Service Worker登録（PWA対応 + 自動更新）
 if ('serviceWorker' in navigator) {
-  window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/KANJI_Town/sw.js').catch(() => {});
+  window.addEventListener('load', async () => {
+    try {
+      const reg = await navigator.serviceWorker.register('/KANJI_Town/sw.js');
+      // 新バージョン検出時に自動更新
+      reg.addEventListener('updatefound', () => {
+        const newSW = reg.installing;
+        if (!newSW) return;
+        newSW.addEventListener('statechange', () => {
+          if (newSW.state === 'activated' && navigator.serviceWorker.controller) {
+            // 新SWが有効化されたらリロードして最新版を反映
+            window.location.reload();
+          }
+        });
+      });
+    } catch {
+      // SW登録失敗は無視
+    }
   });
 }

--- a/src/systems/idb-cache.js
+++ b/src/systems/idb-cache.js
@@ -1,0 +1,77 @@
+// IndexedDB キャッシュ（KanjiVG SVGパスデータ用）
+// localStorage の 200漢字制限を撤廃し、GIGAスクール端末でも十分な容量を確保
+
+const DB_NAME = 'kanji-town-cache';
+const DB_VERSION = 1;
+const STORE_NAME = 'kanji-vg';
+
+let dbPromise = null;
+
+function openDB() {
+  if (dbPromise) return dbPromise;
+  dbPromise = new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME);
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+  return dbPromise;
+}
+
+export async function idbGet(key) {
+  try {
+    const db = await openDB();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readonly');
+      const req = tx.objectStore(STORE_NAME).get(key);
+      req.onsuccess = () => resolve(req.result ?? null);
+      req.onerror = () => reject(req.error);
+    });
+  } catch {
+    return null;
+  }
+}
+
+export async function idbSet(key, value) {
+  try {
+    const db = await openDB();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readwrite');
+      tx.objectStore(STORE_NAME).put(value, key);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  } catch {
+    // IndexedDB書き込み失敗は無視（容量制限時など）
+  }
+}
+
+// localStorage から IndexedDB への一括移行
+export async function migrateFromLocalStorage(storageKey) {
+  try {
+    const raw = localStorage.getItem(storageKey);
+    if (!raw) return;
+    const cache = JSON.parse(raw);
+    const entries = Object.entries(cache);
+    if (entries.length === 0) return;
+
+    const db = await openDB();
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    const store = tx.objectStore(STORE_NAME);
+    for (const [key, value] of entries) {
+      store.put(value, key);
+    }
+    await new Promise((resolve, reject) => {
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+    localStorage.removeItem(storageKey);
+  } catch {
+    // 移行失敗は無視（次回ネットワーク取得時にIndexedDBに保存される）
+  }
+}

--- a/src/systems/kanjiVg.js
+++ b/src/systems/kanjiVg.js
@@ -1,38 +1,22 @@
 // KanjiVG SVG データの取得・パース・キャッシュ
 // - タイムアウト (5秒)
 // - リトライ (3回、指数バックオフ)
-// - メモリキャッシュ + localStorage キャッシュ
+// - メモリキャッシュ + IndexedDB キャッシュ（容量制限なし）
+
+import { idbGet, idbSet, migrateFromLocalStorage } from './idb-cache';
 
 const CDN_URL = 'https://cdn.jsdelivr.net/gh/KanjiVG/kanjivg@master/kanji';
 const FETCH_TIMEOUT = 5000;
 const MAX_RETRIES = 3;
-const STORAGE_KEY = 'kanji_vg_cache';
+const LEGACY_STORAGE_KEY = 'kanji_vg_cache';
 const VIEWBOX_SIZE = 109;
 const SAMPLE_INTERVAL = 2;
 
 // メモリキャッシュ（セッション中は即返却）
 const memoryCache = new Map();
 
-// localStorage キャッシュの読み書き
-function readDiskCache() {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    return raw ? JSON.parse(raw) : {};
-  } catch { return {}; }
-}
-
-function writeDiskCache(key, pathStrings) {
-  try {
-    const cache = readDiskCache();
-    cache[key] = pathStrings;
-    // 最大200漢字分を保持（古いものから削除）
-    const keys = Object.keys(cache);
-    if (keys.length > 200) {
-      keys.slice(0, keys.length - 200).forEach(k => delete cache[k]);
-    }
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(cache));
-  } catch { /* localStorage容量超過時は無視 */ }
-}
+// 起動時に localStorage → IndexedDB へ移行（非同期・失敗無視）
+migrateFromLocalStorage(LEGACY_STORAGE_KEY);
 
 // タイムアウト付きfetch
 function fetchWithTimeout(url, timeout) {
@@ -108,11 +92,11 @@ export async function fetchKanjiVg(char) {
     return { paths: cached, strokeData: buildStrokeData(cached) };
   }
 
-  // 2. localStorage キャッシュ
-  const disk = readDiskCache();
-  if (disk[hex]) {
-    memoryCache.set(hex, disk[hex]);
-    return { paths: disk[hex], strokeData: buildStrokeData(disk[hex]) };
+  // 2. IndexedDB キャッシュ
+  const idbCached = await idbGet(hex);
+  if (idbCached) {
+    memoryCache.set(hex, idbCached);
+    return { paths: idbCached, strokeData: buildStrokeData(idbCached) };
   }
 
   // 3. ネットワーク取得（リトライ付き）
@@ -122,7 +106,7 @@ export async function fetchKanjiVg(char) {
 
   // キャッシュ保存
   memoryCache.set(hex, pathStrings);
-  writeDiskCache(hex, pathStrings);
+  idbSet(hex, pathStrings); // 非同期・await不要
 
   return { paths: pathStrings, strokeData: buildStrokeData(pathStrings) };
 }


### PR DESCRIPTION
- IndexedDBキャッシュ導入: KanjiVG SVGデータをIndexedDBに保存（localStorage 200漢字制限を撤廃）
- Service Worker戦略キャッシュ: KanjiVG CDN(Cache-first)、ビルドアセット(Stale-While-Revalidate)、フォント(Cache-first)、ナビゲーション(Network-first→キャッシュ→offline.html)
- オフラインUI: useOnlineStatusフック + OfflineBannerコンポーネントで接続断を即座に視覚的通知
- SW自動更新: 新バージョン検出時にactivated後自動リロード
- localStorage→IndexedDB移行: 既存キャッシュの自動マイグレーション

GIGAスクール端末のオフライン環境に対応

https://claude.ai/code/session_0172UeqCdV78A2izqh6yZ9Sv