### PR TITLE
fix: 住人がオブジェクトの奥にいるとき正しく隠れるよう深度ソートを修正

### DIFF
--- a/src/components/town/DraggableTownMap.jsx
+++ b/src/components/town/DraggableTownMap.jsx
@@ -572,6 +572,10 @@ const DraggableTownMap = ({ mapData, isDanger, isEditing, onCellTap, reviewCount
         transformOrigin: '0 0',
       }}>
         {cells}
+        {/* 住民（セルと同じコンテナ内でz-indexによる前後関係を正しく処理） */}
+        {visibleVillagers.map(v => (
+          <VillagerDot key={v.id} villager={v} mapData={safeMapData} tileW={TILE_W} tileH={TILE_H} />
+        ))}
         {/* ホバーハイライト */}
         {hoveredCell && (
           <div style={{
@@ -589,10 +593,6 @@ const DraggableTownMap = ({ mapData, isDanger, isEditing, onCellTap, reviewCount
           </div>
         )}
       </div>
-      {/* 住民オーバーレイ */}
-      {visibleVillagers.map(v => (
-        <VillagerDot key={v.id} villager={v} mapData={safeMapData} tileW={TILE_W} tileH={TILE_H} offset={offset} zoom={zoom} containerWidth={containerSize.w} />
-      ))}
     </div>
   );
 };

--- a/src/components/town/VillagerDot.jsx
+++ b/src/components/town/VillagerDot.jsx
@@ -30,7 +30,7 @@ const CULTIVATABLE_TERRAIN = new Set([
 // 距離計算ヘルパー
 const distance = (x1, y1, x2, y2) => Math.sqrt((x1 - x2) ** 2 + (y1 - y2) ** 2);
 
-const VillagerDot = React.memo(({ villager, mapData = {}, tileW, tileH, offset, zoom = 1, containerWidth }) => {
+const VillagerDot = React.memo(({ villager, mapData = {}, tileW, tileH }) => {
   // === ステートマシンの状態 ===
   // 座標は初期値として村民のデータ上の座標を利用
   const [gridPos, setGridPos] = useState({ x: villager.x, y: villager.y });
@@ -188,8 +188,8 @@ const VillagerDot = React.memo(({ villager, mapData = {}, tileW, tileH, offset, 
   // インタラクト中のジャンプ
   const jumping = (aiState === 'INTERACTING' && emotion === 'heart') ? Math.abs(Math.sin(Date.now() / 200)) * -6 : 0;
 
-  const screenX = baseIsoX * zoom + offset.x + visualOffset.x * zoom + (containerWidth ? containerWidth / 2 : (typeof window !== 'undefined' ? window.innerWidth / 2 : 400));
-  const screenY = (baseIsoY + bobbing + jumping) * zoom + offset.y + visualOffset.y * zoom;
+  const screenX = baseIsoX + visualOffset.x;
+  const screenY = baseIsoY + bobbing + jumping + visualOffset.y;
 
   // 現在地のタイルIDを取得し、未開拓（草木）か判定する
   const currentTileId = mapData[`${Math.round(gridPos.x)},${Math.round(gridPos.y)}`];


### PR DESCRIPTION
VillagerDotをマップのtransformコンテナ外から内側に移動し、
セルと同じスタッキングコンテキストでz-indexが正しく機能するようにした。
これにより住人がオブジェクトの手前にいるときは前面に、奥にいるときは
オブジェクトの背後に隠れて表示される。

https://claude.ai/code/session_01BLPgBUmJ88EqmjjC9ukcvA