### PR TITLE
fix: VillagerDotからtransformを除去し、position:absoluteをインラインスタイルで明示

### DIFF
--- a/src/components/town/DraggableTownMap.jsx
+++ b/src/components/town/DraggableTownMap.jsx
@@ -570,6 +570,7 @@ const DraggableTownMap = ({ mapData, isDanger, isEditing, onCellTap, reviewCount
         position: 'absolute', top: 0, left: '50%',
         transform: `translate(${offset.x}px, ${offset.y}px) scale(${zoom})`,
         transformOrigin: '0 0',
+        isolation: 'isolate',
       }}>
         {cells}
         {/* 住民（セルと同じコンテナ内でz-indexによる前後関係を正しく処理） */}

--- a/src/components/town/VillagerDot.jsx
+++ b/src/components/town/VillagerDot.jsx
@@ -188,8 +188,11 @@ const VillagerDot = React.memo(({ villager, mapData = {}, tileW, tileH }) => {
   // インタラクト中のジャンプ
   const jumping = (aiState === 'INTERACTING' && emotion === 'heart') ? Math.abs(Math.sin(Date.now() / 200)) * -6 : 0;
 
-  const screenX = baseIsoX + visualOffset.x;
-  const screenY = baseIsoY + bobbing + jumping + visualOffset.y;
+  // VillagerDotの幅・高さ（transform:translate(-50%,-100%)の代わりに手動オフセット）
+  const vW = 40;
+  const vH = 48;
+  const screenX = baseIsoX + visualOffset.x - vW / 2;
+  const screenY = baseIsoY + bobbing + jumping + visualOffset.y - vH;
 
   // 現在地のタイルIDを取得し、未開拓（草木）か判定する
   const currentTileId = mapData[`${Math.round(gridPos.x)},${Math.round(gridPos.y)}`];
@@ -199,8 +202,8 @@ const VillagerDot = React.memo(({ villager, mapData = {}, tileW, tileH }) => {
   const zIndex = Math.round(gridPos.x + gridPos.y);
 
   return (
-    <div className={`absolute pointer-events-none flex flex-col items-center justify-end transition-opacity duration-500 ${isHidden ? 'opacity-0' : 'opacity-100'}`}
-      style={{ left: screenX, top: screenY, transform: 'translate(-50%,-100%)', width: 40, height: 48, zIndex }}>
+    <div className={`pointer-events-none flex flex-col items-center justify-end transition-opacity duration-500 ${isHidden ? 'opacity-0' : 'opacity-100'}`}
+      style={{ position: 'absolute', left: screenX, top: screenY, width: vW, height: vH, zIndex }}>
       
       {/* 感情ふきだし (AIステート起因) */}
       <AnimatePresence>


### PR DESCRIPTION
前回の修正でVillagerDotをtransformコンテナ内に移動したが、
VillagerDot自体のCSS transformがGPUコンポジティングレイヤーを
生成し、z-index競合を妨げていた可能性がある。

- VillagerDotのtransform: translate(-50%,-100%)を除去し、 手動でleft/topオフセットを計算
- position: absoluteをTailwindクラスからインラインスタイルに変更
- transformコンテナにisolation: isolateを追加し、 明示的なスタッキングコンテキストを生成

https://claude.ai/code/session_01BLPgBUmJ88EqmjjC9ukcvA