### PR TITLE
fix: 全要素からz-indexを除去し純粋なDOM描画順で深度制御

### DIFF
--- a/src/components/town/DraggableTownMap.jsx
+++ b/src/components/town/DraggableTownMap.jsx
@@ -367,7 +367,6 @@ const DraggableTownMap = ({ mapData, isDanger, isEditing, onCellTap, reviewCount
         left: isoX - TILE_W / 2,
         top: isoY - isoHeight,
         width: TILE_W,
-        zIndex: depth,
       };
 
       // フォグ（未探索）
@@ -406,7 +405,6 @@ const DraggableTownMap = ({ mapData, isDanger, isEditing, onCellTap, reviewCount
           top: megaCenterY - megaH,
           width: TILE_W * mw,
           height: TILE_H * mh + megaH,
-          zIndex: depth + mw + mh,
         };
         result.push({ depth: depth + mw + mh, element:
           <div key={key} style={megaStyle}
@@ -610,7 +608,7 @@ const DraggableTownMap = ({ mapData, isDanger, isEditing, onCellTap, reviewCount
             width: TILE_W,
             height: TILE_H,
             pointerEvents: 'none',
-            zIndex: hoveredCell.x + hoveredCell.y + 1,
+            zIndex: 9999,
           }}>
             <svg viewBox="0 0 64 32" width={TILE_W} height={TILE_H}>
               <polygon points="32,0 64,16 32,32 0,16" fill="rgba(255, 255, 255, 0.2)" stroke="rgba(255, 255, 255, 0.8)" strokeWidth="2" />

--- a/src/components/town/VillagerDot.jsx
+++ b/src/components/town/VillagerDot.jsx
@@ -208,12 +208,9 @@ const VillagerDot = React.memo(({ villager, mapData = {}, tileW, tileH, onDepthC
   const currentTileId = mapData[`${Math.round(gridPos.x)},${Math.round(gridPos.y)}`];
   const isHidden = CULTIVATABLE_TERRAIN.has(currentTileId);
 
-  // Z-Indexはアイソメトリックの深さに依存させる (x + y)
-  const zIndex = Math.round(gridPos.x + gridPos.y);
-
   return (
     <div className={`pointer-events-none flex flex-col items-center justify-end transition-opacity duration-500 ${isHidden ? 'opacity-0' : 'opacity-100'}`}
-      style={{ position: 'absolute', left: screenX, top: screenY, width: vW, height: vH, zIndex }}>
+      style={{ position: 'absolute', left: screenX, top: screenY, width: vW, height: vH }}>
       
       {/* 感情ふきだし (AIステート起因) */}
       <AnimatePresence>


### PR DESCRIPTION
z-indexがDOM順序を上書きして正しい前後関係を妨げていた可能性があるため、
セル・住人・メガ建築からz-indexを完全に除去。
position:absoluteでz-index:autoの要素はDOM順序で描画されるため、
sortedElementsによる深度ソート済みDOM順序のみで前後関係を制御する。

https://claude.ai/code/session_01BLPgBUmJ88EqmjjC9ukcvA