### PR TITLE
fix: VillagerDotにisolation:isolateを追加し子要素のz-indexをスコープ内に封じ込め

### DIFF
--- a/src/components/town/VillagerDot.jsx
+++ b/src/components/town/VillagerDot.jsx
@@ -210,7 +210,7 @@ const VillagerDot = React.memo(({ villager, mapData = {}, tileW, tileH, onDepthC
 
   return (
     <div className={`pointer-events-none flex flex-col items-center justify-end transition-opacity duration-500 ${isHidden ? 'opacity-0' : 'opacity-100'}`}
-      style={{ position: 'absolute', left: screenX, top: screenY, width: vW, height: vH }}>
+      style={{ position: 'absolute', left: screenX, top: screenY, width: vW, height: vH, isolation: 'isolate' }}>
       
       {/* 感情ふきだし (AIステート起因) */}
       <AnimatePresence>


### PR DESCRIPTION
根本原因: VillagerDotの外側divがスタッキングコンテキストを作成していなかった。
そのため内部の感情バブル(z-20)と漢字テキスト(z-10)が親コンテナの
スタッキングコンテキストに直接参加し、z-index:autoの全セルより
常に上に描画されていた。

isolation:isolateで新しいスタッキングコンテキストを作成することで、
子要素のz-indexがVillagerDot内に封じ込められ、
VillagerDot自体はDOM順序（sortedElementsの深度ソート）に従って
正しく前後関係が決まるようになる。

https://claude.ai/code/session_01BLPgBUmJ88EqmjjC9ukcvA