### PR TITLE
fix: マルチタイルオブジェクトのSVG位置をタイルグリッドに正確に整合

### DIFF
--- a/src/data/iso-svg.jsx
+++ b/src/data/iso-svg.jsx
@@ -946,7 +946,7 @@ export const SvgSchool = () => {
       {/* 既存の環境への互換性のため残しています */}
       {typeof SharedDefs !== 'undefined' && <SharedDefs />}
       
-      <g transform="translate(50, 100) scale(3.2)">
+      <g transform="translate(50, 41) scale(3.55)">
 
         {/* === 地面（ベース） === */}
         <polygon 
@@ -1302,7 +1302,7 @@ export const SvgGrandWarehouse = () => {
   return (
     <svg viewBox="0 -100 100 200" className="w-full h-full" style={{ overflow: "visible" }}>
       {typeof SharedDefs !== 'undefined' && <SharedDefs />}
-      <g transform="translate(50, 90) scale(2.0)">
+      <g transform="translate(82, 74) scale(2.9)">
 
         {/* === 1. ベース（1x2マスの敷地） === */}
         {/* 幅(X)を狭く、奥行き(Y)を長くすることで「左手前」に伸びる1x2マスを表現 */}
@@ -1553,9 +1553,7 @@ export const SvgPort = () => {
   return (
     <svg viewBox="0 -100 100 200" className="w-full h-full" style={{ overflow: "visible" }}>
       {typeof SharedDefs !== 'undefined' && <SharedDefs />}
-      <g transform="translate(50, 100) scale(2.5)">
-
-        {/* 背景の土台（海と陸） */}
+      <g transform="translate(50, 67) scale(3.03)">
         <polygon points={`${iso(50,0,seaZ)} ${iso(100,0,seaZ)} ${iso(100,100,seaZ)} ${iso(50,100,seaZ)}`} fill="#0891b2" />
         <polygon points={`${iso(0,0,0)} ${iso(50,0,0)} ${iso(50,100,0)} ${iso(0,100,0)}`} fill="#94a3b8" />
         <polygon points={`${iso(50,0,seaZ)} ${iso(50,100,seaZ)} ${iso(50,100,0)} ${iso(50,0,0)}`} fill="#64748b" stroke="#334155" strokeWidth="0.5" />


### PR DESCRIPTION
viewBox "0 -100 100 200" (1:2 縦長) とコンテナ (横長) のアスペクト比 不一致により、preserveAspectRatio=meet の高さ制約で描画位置がズレていた。

各オブジェクトのコンテナサイズから逆算してtranslate/scaleを再計算:
- 港(2×2): translate(50,67) scale(3.03) — コンテナ128×96, vbScale=0.48
- 学校(4×4): translate(50,41) scale(3.55) — コンテナ256×164, vbScale=0.82
- 大倉庫(1×2): translate(82,74) scale(2.9) — コンテナ64×94, vbScale=0.47

ダイヤモンドの前面・背面・左右がタイルグリッドと一致するよう調整。

https://claude.ai/code/session_01TN6PcfcHniRtqcJP8cqns9