### PR TITLE
Fix watermill 2×1 base diamond to fit within allocated tiles

### DIFF
--- a/src/data/iso-svg.jsx
+++ b/src/data/iso-svg.jsx
@@ -1652,8 +1652,8 @@ export const SvgFactory = () => (
 
 export const SvgWatermill = () => {
   const iso = (x, y, z = 0) => {
-    const ptX = (x - y) * 0.44;
-    const ptY = -44 + (x + y) * 0.22 - z;
+    const ptX = (x * 2 - y) * 0.44;
+    const ptY = -66 + (x * 2 + y) * 0.22 - z;
     return `${ptX.toFixed(2)},${ptY.toFixed(2)}`;
   };
   const colors = {
@@ -1708,7 +1708,7 @@ export const SvgWatermill = () => {
   return (
     <svg viewBox="0 -100 100 200" className="w-full h-full" style={{ overflow: "visible" }}>
       {typeof SharedDefs !== 'undefined' && <SharedDefs />}
-      <g transform="translate(50, 126) scale(3.52)">
+      <g transform="translate(-2, 126) scale(2.35)">
         {/* 地面と水路 */}
         <polygon points={`${iso(0,0,0)} ${iso(65,0,0)} ${iso(65,100,0)} ${iso(0,100,0)}`} fill={colors.base} />
         <polygon points={`${iso(65,0,0)} ${iso(65,100,0)} ${iso(65,100,-5)} ${iso(65,0,-5)}`} fill={colors.stoneSide} />


### PR DESCRIPTION
Modified iso() function to produce a non-square rhombus matching the 2×1 tile area: ptX = (x*2-y)*0.44, ptY = -66+(x*2+y)*0.22-z. Updated transform from translate(50,126) scale(3.52) to translate(-2,126) scale(2.35).

https://claude.ai/code/session_01TN6PcfcHniRtqcJP8cqns9