### PR TITLE
アプリ起動時に実績の進捗を一括更新するよう修正

### DIFF
--- a/src/systems/storage.js
+++ b/src/systems/storage.js
@@ -360,6 +360,10 @@ const StorageAPI = {
     // ── サボり検出：街が廃れる仕組み ──
     StorageAPI._applyNeglectPenalties(stats);
 
+    // ── 実績の進捗を起動時に一括更新（新規追加分も反映） ──
+    if (!stats.achievements) stats.achievements = {};
+    StorageAPI._updateAchievements(stats);
+
     return stats;
   },
 


### PR DESCRIPTION
_updateAchievements() がセッション完了時 (updateDaily) にしか
呼ばれていなかったため、新規追加した実績が既存の進捗を反映
しない問題を修正。getStats() の最後で _updateAchievements() を
呼び出し、起動時に全実績の current 値を最新の統計から算出する。

https://claude.ai/code/session_01HzqhJZwCSUBHQybJBQ3mqX