### PR TITLE
Add drill test mode with stroke grading and review system

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,7 +8,7 @@ import { StorageAPI, getLevelInfo } from './systems/storage';
 import { calculateNextReview, migrateCard } from './systems/srs';
 import { audioCtrl } from './systems/audio';
 import { checkLevelUp } from './utils/level-system';
-import { SESSION, EXP, RARE_DROP, ECONOMY, DEBOUNCE } from './constants/gameConfig';
+import { SESSION, EXP, RARE_DROP, ECONOMY, DEBOUNCE, TEST } from './constants/gameConfig';
 
 // Data
 import { KANJI_DATA, KANJI_UNLOCK_EXTRA } from './data/kanji-data';
@@ -47,6 +47,7 @@ const SessionView = lazy(() => import('./components/session/SessionView'));
 const FlashcardView = lazy(() => import('./components/training/FlashcardView'));
 const SurvivalView = lazy(() => import('./components/training/SurvivalView'));
 const BossBattleView = lazy(() => import('./components/training/BossBattleView'));
+const DrillTestView = lazy(() => import('./components/training/DrillTestView'));
 
 // Social
 const TeacherHostView = lazy(() => import('./components/social/TeacherHostView'));
@@ -82,6 +83,7 @@ function createInitialSessionData(overrides = {}) {
     unlockedItems: [],
     rareDrop: null,
     isDrill: false,
+    isTest: false,
     newVillager: null,
     ...overrides,
   };
@@ -186,7 +188,7 @@ export default function App() {
 
   useEffect(() => {
     if (isMuted) { audioCtrl.stopBGM(); return; }
-    const gameViews = new Set(['session', 'survival', 'flashcard', 'boss']);
+    const gameViews = new Set(['session', 'survival', 'flashcard', 'boss', 'drillTest']);
     if (gameViews.has(view)) {
       audioCtrl.playBGM(view === 'boss' ? 'boss' : 'game');
     } else if (view === 'result') {
@@ -273,6 +275,28 @@ export default function App() {
     if (queue.length > 0) {
       setSessionData(createInitialSessionData({ queue, oldExp: stats.totalExp, expMultiplier, isDrill: true }));
       setView('session');
+    }
+  };
+
+  const startDrillTest = (drill, questionCount) => {
+    audioCtrl.init();
+    let candidates = KANJI_DATA.filter(k => drill.kanjis?.includes(k.id));
+    if (questionCount < candidates.length) {
+      candidates.sort((a, b) => {
+        const aMistakes = stats.kanjiStats?.[a.id]?.mistakes || 0;
+        const bMistakes = stats.kanjiStats?.[b.id]?.mistakes || 0;
+        if (bMistakes !== aMistakes) return bMistakes - aMistakes;
+        const aReview = stats.kanjiStats?.[a.id]?.nextReview || 0;
+        const bReview = stats.kanjiStats?.[b.id]?.nextReview || 0;
+        return aReview - bReview;
+      });
+      candidates = candidates.slice(0, questionCount);
+    }
+    candidates.sort(() => Math.random() - 0.5);
+    const expMultiplier = getSatisfactionMultiplier(calculateSatisfaction(stats));
+    if (candidates.length > 0) {
+      setSessionData(createInitialSessionData({ queue: candidates, oldExp: stats.totalExp, expMultiplier, isDrill: true, isTest: true }));
+      setView('drillTest');
     }
   };
 
@@ -556,7 +580,7 @@ export default function App() {
         )}
       </AnimatePresence>
 
-      {view !== 'session' && view !== 'townEditor' && view !== 'flashcard' && view !== 'survival' && view !== 'boss' && (
+      {view !== 'session' && view !== 'townEditor' && view !== 'flashcard' && view !== 'survival' && view !== 'boss' && view !== 'drillTest' && (
         <header className="flex-shrink-0 bg-[var(--panel)]/90 backdrop-blur border-b-[4px] border-[var(--text)] py-3 px-5 flex justify-between items-center z-50 sticky top-0 shadow-[0_4px_0_var(--text)] transition-colors duration-500" role="banner">
           <button className="flex items-center cursor-pointer gap-2 bg-transparent border-none p-0 focus:outline-none focus:ring-2 focus:ring-[var(--primary)] rounded-lg" onClick={() => { audioCtrl.playSE('click'); setView('home'); }} aria-label="ホームに戻る">
             <div className="bg-[var(--primary)] p-1.5 rounded-lg text-[var(--panel)] shadow-sm border-2 border-[var(--text)]" aria-hidden="true"><PenTool size={22} strokeWidth={3} /></div>
@@ -602,7 +626,7 @@ export default function App() {
           {view === 'achievements' && <PageWrapper key="achievements"><ErrorBoundary onReset={() => setView('home')}><FeatureHint featureKey="achievements" seenHints={seenHints} onDismiss={handleDismissHint} /><AchievementView setView={setView} stats={stats} setStats={setStats} /></ErrorBoundary></PageWrapper>}
           {view === 'stats' && <PageWrapper key="stats"><ErrorBoundary onReset={() => setView('home')}><FeatureHint featureKey="stats" seenHints={seenHints} onDismiss={handleDismissHint} /><StatsView setView={setView} stats={stats} /></ErrorBoundary></PageWrapper>}
           {view === 'settings' && <PageWrapper key="settings"><ErrorBoundary onReset={() => setView('home')}><SettingsView setView={setView} stats={stats} setStats={setStats} isMuted={isMuted} setIsMuted={setIsMuted} levelInfo={levelInfo} /></ErrorBoundary></PageWrapper>}
-          {view === 'myDrills' && <PageWrapper key="myDrills"><ErrorBoundary onReset={() => setView('home')}><MyDrillsView setView={setView} stats={stats} setStats={setStats} startDrillSession={startDrillSession} setHostDrill={setHostDrill} /></ErrorBoundary></PageWrapper>}
+          {view === 'myDrills' && <PageWrapper key="myDrills"><ErrorBoundary onReset={() => setView('home')}><MyDrillsView setView={setView} stats={stats} setStats={setStats} startDrillSession={startDrillSession} startDrillTest={startDrillTest} setHostDrill={setHostDrill} /></ErrorBoundary></PageWrapper>}
           {view === 'drillEditor' && <PageWrapper key="drillEditor"><ErrorBoundary onReset={() => setView('home')}><DrillEditorView setView={setView} stats={stats} setStats={setStats} /></ErrorBoundary></PageWrapper>}
           {view === 'peerHost' && <PageWrapper key="peerHost"><ErrorBoundary onReset={() => setView('home')}><TeacherHostView setView={setView} drill={hostDrill} /></ErrorBoundary></PageWrapper>}
           {view === 'peerClient' && <PageWrapper key="peerClient"><ErrorBoundary onReset={() => setView('home')}><StudentClientView setView={setView} stats={stats} setStats={setStats} /></ErrorBoundary></PageWrapper>}
@@ -611,6 +635,7 @@ export default function App() {
           {view === 'flashcard' && <FullScreenWrapper key="flashcard"><ErrorBoundary onReset={() => setView('home')}><FlashcardView queue={sessionData.queue} stats={stats} setStats={setStats} onFinish={handleFinishSession} /></ErrorBoundary></FullScreenWrapper>}
           {view === 'survival' && <FullScreenWrapper key="survival"><ErrorBoundary onReset={() => setView('home')}><SurvivalView queue={sessionData.queue} onUpdateStat={handleUpdateStat} onFinish={handleFinishSession} /></ErrorBoundary></FullScreenWrapper>}
           {view === 'boss' && <FullScreenWrapper key="boss"><ErrorBoundary onReset={() => setView('home')}><BossBattleView queue={sessionData.queue} onUpdateStat={handleUpdateStat} onFinish={handleFinishSession} onBossDefeat={handleBossDefeat} /></ErrorBoundary></FullScreenWrapper>}
+          {view === 'drillTest' && <FullScreenWrapper key="drillTest"><ErrorBoundary onReset={() => setView('home')}><DrillTestView queue={sessionData.queue} stats={stats} onUpdateStat={handleUpdateStat} onFinish={handleFinishSession} startDrillSession={startDrillSession} setView={setView} setSessionData={setSessionData} createInitialSessionData={createInitialSessionData} /></ErrorBoundary></FullScreenWrapper>}
           {view === 'result' && <PageWrapper key="result"><ErrorBoundary onReset={() => setView('home')}><ResultView sessionMetrics={sessionData} oldExp={sessionData.oldExp} setView={setView} stats={stats} setStats={setStats} /></ErrorBoundary></PageWrapper>}
         </AnimatePresence>
         </Suspense>

--- a/src/components/pages/MyDrillsView.jsx
+++ b/src/components/pages/MyDrillsView.jsx
@@ -1,20 +1,28 @@
 import React, { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { FileText, Plus, PenTool, Share2, Trash2, ArrowLeft } from 'lucide-react';
+import { FileText, Plus, PenTool, Share2, Trash2, ArrowLeft, ClipboardCheck } from 'lucide-react';
 import MotionButton from '../ui/MotionButton';
 import { KANJI_DATA } from '../../data/kanji-data';
 import { StorageAPI } from '../../systems/storage';
 import { audioCtrl } from '../../systems/audio';
 import { F } from '../ui/FormatKun';
+import { TEST } from '../../constants/gameConfig';
 
-const MyDrillsView = ({ setView, stats, setStats, startDrillSession, setHostDrill }) => {
+const MyDrillsView = ({ setView, stats, setStats, startDrillSession, startDrillTest, setHostDrill }) => {
   const drills = stats.myDrills || [];
   const [confirmDelete, setConfirmDelete] = useState(null);
+  const [testDrill, setTestDrill] = useState(null);
 
   const handleDelete = (idx) => {
     const newDrills = drills.filter((_, i) => i !== idx);
     const newStats = { ...stats, myDrills: newDrills };
     setStats(newStats); StorageAPI.saveStats(newStats); audioCtrl.playSE('click'); setConfirmDelete(null);
+  };
+
+  const handleSelectTestCount = (count) => {
+    audioCtrl.playSE('click');
+    startDrillTest(testDrill, count);
+    setTestDrill(null);
   };
 
   return (
@@ -43,6 +51,7 @@ const MyDrillsView = ({ setView, stats, setStats, startDrillSession, setHostDril
               </div>
               <div className="flex flex-col gap-2 shrink-0">
                 <MotionButton variant="primary" onClick={() => startDrillSession(drill)} className="px-3 py-2 text-xs border-[2px] border-[var(--text)] shadow-[0_2px_0_#9f1239] min-h-[36px]"><PenTool size={14} /> {F("練習","れんしゅう")}</MotionButton>
+                <MotionButton variant="secondary" onClick={() => { audioCtrl.playSE('click'); setTestDrill(drill); }} className="px-3 py-2 text-xs border-[2px] border-[var(--text)] shadow-[0_2px_0_var(--text)] min-h-[36px]"><ClipboardCheck size={14} /> テスト</MotionButton>
                 <MotionButton variant="accent" onClick={() => { setHostDrill(drill); setView('peerHost'); }} className="px-3 py-2 text-xs border-[2px] border-[var(--text)] shadow-[0_2px_0_#b45309] min-h-[36px]"><Share2 size={14} /> {F("送","おく")}る</MotionButton>
                 <button onClick={() => setConfirmDelete(i)} aria-label="ドリルを削除" className="px-3 py-2 text-xs border-[2px] border-rose-300 text-rose-500 rounded-[16px] font-bold hover:bg-rose-50 transition-colors min-h-[36px] flex items-center gap-1"><Trash2 size={14} /> {F("削除","さくじょ")}</button>
               </div>
@@ -63,6 +72,30 @@ const MyDrillsView = ({ setView, stats, setStats, startDrillSession, setHostDril
                 <MotionButton variant="secondary" onClick={() => setConfirmDelete(null)} className="flex-1 py-3 border-[3px] border-[var(--text)] shadow-[0_3px_0_var(--text)]">キャンセル</MotionButton>
                 <MotionButton variant="primary" onClick={() => handleDelete(confirmDelete)} className="flex-1 py-3 border-[3px] border-[var(--text)] shadow-[0_3px_0_#9f1239]">{F("削除","さくじょ")}する</MotionButton>
               </div>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* テスト問題数選択モーダル */}
+      <AnimatePresence>
+        {testDrill !== null && (
+          <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/40 backdrop-blur-sm">
+            <motion.div initial={{ scale: 0.9, y: 20 }} animate={{ scale: 1, y: 0 }} exit={{ scale: 0.9, y: 20 }} className="bg-[var(--panel)] border-[4px] border-[var(--text)] rounded-2xl p-6 shadow-[8px_8px_0_var(--text)] max-w-sm w-full">
+              <div className="text-3xl text-center mb-3">📝</div>
+              <p className="font-black text-[var(--text)] text-center text-lg mb-1">「{testDrill.name}」</p>
+              <p className="text-sm text-[var(--text)] opacity-60 text-center mb-4">テスト{F("問題数","もんだいすう")}をえらぼう</p>
+              <div className="flex flex-col gap-2 mb-4">
+                {TEST.QUESTION_OPTIONS.filter(n => (testDrill.kanjis?.length || 0) >= n).map(n => (
+                  <MotionButton key={n} variant="secondary" onClick={() => handleSelectTestCount(n)} className="w-full py-3 border-[3px] border-[var(--text)] shadow-[0_3px_0_var(--text)] text-sm font-black">
+                    {n}{F("問","もん")}
+                  </MotionButton>
+                ))}
+                <MotionButton variant="primary" onClick={() => handleSelectTestCount(testDrill.kanjis?.length || 0)} className="w-full py-3 border-[3px] border-[var(--text)] shadow-[0_3px_0_#9f1239] text-sm font-black">
+                  ぜんぶ（{testDrill.kanjis?.length || 0}{F("問","もん")}）
+                </MotionButton>
+              </div>
+              <MotionButton variant="secondary" onClick={() => setTestDrill(null)} className="w-full py-3 border-[3px] border-[var(--text)] shadow-[0_3px_0_var(--text)]">キャンセル</MotionButton>
             </motion.div>
           </motion.div>
         )}

--- a/src/components/training/DrillTestView.jsx
+++ b/src/components/training/DrillTestView.jsx
@@ -1,0 +1,472 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { ChevronRight, RefreshCw, CheckCircle, XCircle, RotateCcw, LogOut } from 'lucide-react';
+import MotionButton from '../ui/MotionButton';
+import { audioCtrl } from '../../systems/audio';
+import { F, SurvivalRubyText, FormatKun } from '../ui/FormatKun';
+import { gradeStrokes } from '../../systems/strokeGrader';
+import { fetchKanjiVg } from '../../systems/kanjiVg';
+import { TEST } from '../../constants/gameConfig';
+import { getSatisfactionMultiplier, calculateSatisfaction } from '../../systems/residents';
+
+// --- テスト専用キャンバス ---
+const TestCanvas = ({ strokeData, canvasSize, onSubmit, disabled }) => {
+  const inkRef = useRef(null);
+  const writeRef = useRef(null);
+  const [userStrokes, setUserStrokes] = useState([]);
+  const [isDrawing, setIsDrawing] = useState(false);
+  const lastPos = useRef({ x: 0, y: 0 });
+  const currentPathRef = useRef([]);
+
+  useEffect(() => {
+    [inkRef, writeRef].forEach(ref => {
+      const c = ref.current;
+      if (c) {
+        c.width = canvasSize * 2;
+        c.height = canvasSize * 2;
+        c.style.width = '100%';
+        c.style.height = '100%';
+        const ctx = c.getContext('2d');
+        ctx.setTransform(1, 0, 0, 1, 0, 0);
+        ctx.scale(2, 2);
+        ctx.clearRect(0, 0, canvasSize, canvasSize);
+      }
+    });
+    setUserStrokes([]);
+  }, [strokeData, canvasSize]);
+
+  const redrawInk = useCallback((strokes) => {
+    const ctx = inkRef.current?.getContext('2d');
+    if (!ctx) return;
+    ctx.clearRect(0, 0, canvasSize, canvasSize);
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+    ctx.strokeStyle = 'var(--text, #292f36)';
+    ctx.lineWidth = canvasSize * 0.07;
+    strokes.forEach(stroke => {
+      if (stroke.length === 0) return;
+      ctx.beginPath();
+      ctx.moveTo(stroke[0].x, stroke[0].y);
+      stroke.forEach(pt => ctx.lineTo(pt.x, pt.y));
+      ctx.stroke();
+    });
+  }, [canvasSize]);
+
+  const handleStartRef = useRef(null);
+  const handleMoveRef = useRef(null);
+  const handleEndRef = useRef(null);
+
+  const getCoords = (e) => {
+    const rect = writeRef.current.getBoundingClientRect();
+    const scaleX = canvasSize / rect.width;
+    const scaleY = canvasSize / rect.height;
+    const clientX = e.touches ? e.touches[0].clientX : e.clientX;
+    const clientY = e.touches ? e.touches[0].clientY : e.clientY;
+    return { x: (clientX - rect.left) * scaleX, y: (clientY - rect.top) * scaleY };
+  };
+
+  const handleStart = (e) => {
+    e.preventDefault();
+    if (disabled) return;
+    audioCtrl.init();
+    const { x, y } = getCoords(e);
+    setIsDrawing(true);
+    lastPos.current = { x, y };
+    currentPathRef.current = [{ x, y, time: Date.now() }];
+    const ctx = writeRef.current.getContext('2d');
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+    ctx.lineWidth = canvasSize * 0.07;
+    ctx.strokeStyle = 'var(--text, #292f36)';
+    ctx.beginPath();
+    ctx.moveTo(x, y);
+    ctx.lineTo(x, y);
+    ctx.stroke();
+  };
+
+  const handleMove = (e) => {
+    e.preventDefault();
+    if (!isDrawing || disabled) return;
+    const { x, y } = getCoords(e);
+    currentPathRef.current.push({ x, y, time: Date.now() });
+    const ctx = writeRef.current.getContext('2d');
+    ctx.beginPath();
+    ctx.moveTo(lastPos.current.x, lastPos.current.y);
+    ctx.lineTo(x, y);
+    ctx.stroke();
+    lastPos.current = { x, y };
+  };
+
+  const handleEnd = (e) => {
+    if (e && e.type !== 'mouseleave') e.preventDefault();
+    if (!isDrawing || disabled) return;
+    setIsDrawing(false);
+    const newStrokes = [...userStrokes, [...currentPathRef.current]];
+    setUserStrokes(newStrokes);
+    redrawInk(newStrokes);
+    const ctx = writeRef.current?.getContext('2d');
+    if (ctx) ctx.clearRect(0, 0, canvasSize, canvasSize);
+  };
+
+  handleStartRef.current = handleStart;
+  handleMoveRef.current = handleMove;
+  handleEndRef.current = handleEnd;
+
+  useEffect(() => {
+    const canvas = writeRef.current;
+    if (!canvas) return;
+    const onStart = (e) => handleStartRef.current(e);
+    const onMove = (e) => handleMoveRef.current(e);
+    const onEnd = (e) => handleEndRef.current(e);
+    canvas.addEventListener('touchstart', onStart, { passive: false });
+    canvas.addEventListener('touchmove', onMove, { passive: false });
+    canvas.addEventListener('touchend', onEnd, { passive: false });
+    return () => { canvas.removeEventListener('touchstart', onStart); canvas.removeEventListener('touchmove', onMove); canvas.removeEventListener('touchend', onEnd); };
+  }, []);
+
+  const handleClear = () => {
+    setUserStrokes([]);
+    [inkRef, writeRef].forEach(ref => {
+      const ctx = ref.current?.getContext('2d');
+      if (ctx) ctx.clearRect(0, 0, canvasSize, canvasSize);
+    });
+  };
+
+  const handleSubmit = () => {
+    if (userStrokes.length === 0) return;
+    onSubmit(userStrokes);
+  };
+
+  const expectedCount = strokeData.length;
+
+  return (
+    <div className="flex flex-col items-center gap-2 w-full">
+      <div className="flex items-center gap-2 w-full" style={{ maxWidth: canvasSize }}>
+        <div className={`text-xs font-black px-3 py-1 rounded-full border-2 ${userStrokes.length === expectedCount ? 'bg-emerald-100 dark:bg-emerald-900/30 border-emerald-400 text-emerald-600' : userStrokes.length > expectedCount ? 'bg-rose-100 dark:bg-rose-900/30 border-rose-400 text-rose-600' : 'bg-[var(--panel)] border-[var(--text)] text-[var(--text)] opacity-60'}`}>
+          {userStrokes.length} / {expectedCount} {F("画","かく")}
+        </div>
+        <div className="flex gap-0.5 flex-1">
+          {[...Array(expectedCount)].map((_, i) => (
+            <div key={i} className={`h-1.5 flex-1 rounded-full transition-all duration-200 ${i < userStrokes.length ? (userStrokes.length <= expectedCount ? 'bg-emerald-400' : 'bg-rose-400') : 'bg-[var(--text)] opacity-10'}`} />
+          ))}
+        </div>
+      </div>
+
+      <div className="relative border-[4px] border-amber-500 rounded-[20px] bg-[var(--panel)] overflow-hidden touch-none shrink-0 shadow-[4px_4px_0_var(--text)]" style={{ width: canvasSize, maxWidth: '100%', aspectRatio: '1/1' }}>
+        <div className="absolute top-0 left-1/2 w-0 h-full border-l-2 border-dashed border-[var(--text)] opacity-10 -translate-x-1/2 pointer-events-none" />
+        <div className="absolute top-1/2 left-0 w-full h-0 border-t-2 border-dashed border-[var(--text)] opacity-10 -translate-y-1/2 pointer-events-none" />
+        <canvas ref={inkRef} className="absolute inset-0 z-10 pointer-events-none w-full h-full" />
+        <canvas ref={writeRef} onMouseDown={handleStart} onMouseMove={handleMove} onMouseUp={handleEnd} onMouseLeave={handleEnd} className="absolute inset-0 z-20 cursor-crosshair w-full h-full" />
+        {disabled && <div className="absolute inset-0 z-30 bg-black/30 flex items-center justify-center" />}
+      </div>
+
+      <div className="flex gap-2 w-full" style={{ maxWidth: canvasSize }}>
+        <MotionButton variant="secondary" onClick={handleClear} disabled={disabled || userStrokes.length === 0} className="flex-1 py-3 text-sm font-bold border-[3px] border-[var(--text)]">
+          <RefreshCw size={16} /> {F("消","け")}す
+        </MotionButton>
+        <MotionButton variant="primary" onClick={handleSubmit} disabled={disabled || userStrokes.length === 0} className="flex-2 py-3 text-lg font-black border-[3px] border-[var(--text)] shadow-[0_4px_0_#9f1239] flex-grow-[2]">
+          <ChevronRight size={18} /> {F("答","こた")}える
+        </MotionButton>
+      </div>
+    </div>
+  );
+};
+
+// --- ストローク再描画コンポーネント ---
+const StrokeReplay = ({ userStrokes, canvasSize, displaySize = 80 }) => {
+  const canvasRef = useRef(null);
+
+  useEffect(() => {
+    const c = canvasRef.current;
+    if (!c || !userStrokes) return;
+    c.width = displaySize * 2;
+    c.height = displaySize * 2;
+    const ctx = c.getContext('2d');
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.scale(2, 2);
+    ctx.clearRect(0, 0, displaySize, displaySize);
+    const scale = displaySize / canvasSize;
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+    ctx.lineWidth = displaySize * 0.07;
+    ctx.strokeStyle = '#292f36';
+    userStrokes.forEach(stroke => {
+      if (!stroke || stroke.length === 0) return;
+      ctx.beginPath();
+      ctx.moveTo(stroke[0].x * scale, stroke[0].y * scale);
+      stroke.forEach(pt => ctx.lineTo(pt.x * scale, pt.y * scale));
+      ctx.stroke();
+    });
+  }, [userStrokes, canvasSize, displaySize]);
+
+  return <canvas ref={canvasRef} style={{ width: displaySize, height: displaySize }} className="rounded-lg" />;
+};
+
+// --- メインのテストビュー ---
+const DrillTestView = ({ queue, stats, onUpdateStat, onFinish, startDrillSession, setView, setSessionData, createInitialSessionData }) => {
+  const [phase, setPhase] = useState('testing'); // 'testing' | 'results'
+  const [currentIdx, setCurrentIdx] = useState(0);
+  const [answers, setAnswers] = useState([]);
+  const [canvasSize] = useState(window.innerWidth < 768 ? 260 : 360);
+
+  // KanjiVGデータ
+  const [strokeData, setStrokeData] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const total = queue.length;
+  const kanji = queue[currentIdx];
+
+  // KanjiVGデータ取得
+  useEffect(() => {
+    if (!kanji || phase !== 'testing') return;
+    let cancelled = false;
+    const load = async () => {
+      setIsLoading(true);
+      try {
+        const { strokeData: data } = await fetchKanjiVg(kanji.char);
+        if (cancelled) return;
+        setStrokeData(data);
+      } catch {
+        if (cancelled) return;
+        setStrokeData([]);
+      }
+      setIsLoading(false);
+    };
+    load();
+    return () => { cancelled = true; };
+  }, [kanji, phase]);
+
+  // 次の問題をプリフェッチ
+  useEffect(() => {
+    if (phase !== 'testing' || currentIdx + 1 >= total) return;
+    const nextKanji = queue[currentIdx + 1];
+    if (nextKanji) fetchKanjiVg(nextKanji.char).catch(() => {});
+  }, [currentIdx, phase, queue, total]);
+
+  // ストローク提出
+  const handleSubmitStrokes = (userStrokes) => {
+    if (phase !== 'testing') return;
+    const result = gradeStrokes(userStrokes, strokeData, canvasSize);
+    const passed = result.total >= TEST.PASS_THRESHOLD && result.strokeCountMatch;
+
+    // EXP累積のためonUpdateStatを呼ぶ
+    onUpdateStat(kanji, passed ? 'good' : 'again');
+
+    const answer = {
+      kanji,
+      userStrokes,
+      canvasSize,
+      gradeResult: result,
+      passed,
+    };
+
+    const newAnswers = [...answers, answer];
+    setAnswers(newAnswers);
+
+    if (currentIdx + 1 < total) {
+      setCurrentIdx(currentIdx + 1);
+    } else {
+      // 全問終了
+      audioCtrl.playSE('success');
+      setPhase('results');
+    }
+  };
+
+  // 結果: 終了
+  const handleFinish = () => {
+    onFinish();
+  };
+
+  // 結果: 復習
+  const handleReview = () => {
+    // テストのEXPを確定
+    onFinish();
+    // 不正解の漢字で新しいドリルセッションを開始
+    const failedKanjis = answers.filter(a => !a.passed).map(a => a.kanji);
+    if (failedKanjis.length > 0) {
+      const expMultiplier = getSatisfactionMultiplier(calculateSatisfaction(stats));
+      setSessionData(createInitialSessionData({
+        queue: failedKanjis,
+        oldExp: stats.totalExp,
+        expMultiplier,
+        isDrill: true,
+      }));
+      // 少し遅延してからセッションビューに切り替え（onFinishの処理完了を待つ）
+      setTimeout(() => setView('session'), 50);
+    }
+  };
+
+  const ex = kanji?.examples?.[Math.floor(Math.random() * (kanji?.examples?.length || 1))];
+  // exをrefで固定して再レンダー時に変わらないようにする
+  const exRef = useRef(null);
+  const exKanjiIdRef = useRef(null);
+  if (kanji && exKanjiIdRef.current !== kanji.id) {
+    exKanjiIdRef.current = kanji.id;
+    exRef.current = kanji.examples?.[Math.floor(Math.random() * (kanji.examples?.length || 1))] || null;
+  }
+  const currentEx = exRef.current;
+
+  if (phase === 'testing') {
+    const correctCount = answers.filter(a => a.passed).length;
+
+    return (
+      <div className="flex flex-col h-full w-full bg-[var(--bg)] relative overflow-hidden">
+        {/* ヘッダー */}
+        <div className="flex-shrink-0 px-3 py-2 md:px-4 md:py-3 z-10 bg-[var(--panel)] border-b-[3px] border-[var(--text)]">
+          <div className="flex items-center gap-2 mb-1.5">
+            <div className="flex items-center gap-1 bg-blue-100 dark:bg-blue-900/30 border-2 border-blue-400 rounded-full px-2.5 py-0.5 shrink-0">
+              <span className="text-xs font-black text-blue-600">テスト</span>
+            </div>
+            <div className="flex-1" />
+            <div className="text-sm font-black text-[var(--text)] opacity-60">
+              {currentIdx + 1} / {total} {F("問目","もんめ")}
+            </div>
+          </div>
+          <div className="flex gap-0.5">
+            {[...Array(total)].map((_, i) => (
+              <div key={i} className={`h-1.5 flex-1 rounded-full transition-all duration-300 ${i < currentIdx ? (answers[i]?.passed ? 'bg-emerald-400' : 'bg-rose-400') : i === currentIdx ? 'bg-blue-400/60' : 'bg-[var(--text)] opacity-10'}`} />
+            ))}
+          </div>
+        </div>
+
+        {/* メインエリア */}
+        <div className="flex-1 flex items-center justify-center px-2 md:px-4 py-2 min-h-0 overflow-hidden">
+          {isLoading ? (
+            <div className="text-center">
+              <div className="w-10 h-10 border-4 border-[var(--primary)] border-t-transparent rounded-full animate-spin mx-auto mb-3" />
+              <div className="text-sm font-bold text-[var(--text)] opacity-50">よみこみ中...</div>
+            </div>
+          ) : (
+            <div className="w-full max-w-4xl flex flex-col lg:flex-row items-center lg:items-start justify-center gap-3 lg:gap-6">
+              {/* 左: お題パネル */}
+              <div className="w-full lg:flex-1 flex flex-col gap-3 order-first">
+                {/* 例文 */}
+                <div className="bg-[var(--panel)] border-[3px] border-[var(--text)] rounded-2xl p-4 md:p-5 shadow-[3px_3px_0_var(--text)]">
+                  <div className="flex items-center gap-2 mb-3">
+                    <span className="text-xs font-black text-[var(--text)] opacity-50">
+                      この「◯」は{F("何","なん")}の{F("漢字","かんじ")}？
+                    </span>
+                  </div>
+                  {currentEx ? (
+                    <p className="text-2xl md:text-3xl lg:text-4xl font-bold text-[var(--text)] text-center ruby-text leading-relaxed">
+                      <SurvivalRubyText text={currentEx} targetChar={kanji.char} />
+                    </p>
+                  ) : (
+                    <div className="text-center">
+                      <div className="text-lg md:text-xl lg:text-2xl font-black text-[var(--text)] leading-relaxed">
+                        {kanji.on.length > 0 ? kanji.on.join(' / ') : ''}
+                        {kanji.on.length > 0 && kanji.kun.length > 0 ? ' / ' : ''}
+                        {kanji.kun.length > 0 ? kanji.kun.map((k, i) => (
+                          <React.Fragment key={i}><FormatKun text={k} />{i < kanji.kun.length - 1 ? ' / ' : ''}</React.Fragment>
+                        )) : ''}
+                      </div>
+                    </div>
+                  )}
+                </div>
+
+                {/* 読みヒント */}
+                <div className="bg-[var(--panel)] border-[3px] border-[var(--text)] rounded-2xl px-4 py-2 shadow-[3px_3px_0_var(--text)]">
+                  <div className="text-[10px] font-bold text-[var(--text)] opacity-40 mb-1">よみかた</div>
+                  <div className="text-base font-black text-[var(--text)] text-center">
+                    {kanji.on.length > 0 ? kanji.on.join(' / ') : ''}
+                    {kanji.on.length > 0 && kanji.kun.length > 0 ? ' / ' : ''}
+                    {kanji.kun.length > 0 ? kanji.kun.map((k, i) => (
+                      <React.Fragment key={i}><FormatKun text={k} />{i < kanji.kun.length - 1 ? ' / ' : ''}</React.Fragment>
+                    )) : ''}
+                  </div>
+                </div>
+              </div>
+
+              {/* 右: キャンバス */}
+              <div className="w-full lg:w-auto flex flex-col items-center">
+                <TestCanvas
+                  strokeData={strokeData}
+                  canvasSize={canvasSize}
+                  onSubmit={handleSubmitStrokes}
+                  disabled={false}
+                />
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // Phase: results
+  const correctCount = answers.filter(a => a.passed).length;
+  const incorrectCount = total - correctCount;
+  const percentage = Math.round((correctCount / total) * 100);
+  const allCorrect = incorrectCount === 0;
+
+  return (
+    <div className="flex flex-col h-full w-full bg-[var(--bg)] relative overflow-hidden">
+      {/* ヘッダー */}
+      <div className="flex-shrink-0 px-4 py-3 z-10 bg-[var(--panel)] border-b-[3px] border-[var(--text)]">
+        <div className="text-center">
+          <div className="text-2xl font-black text-[var(--text)]">
+            {allCorrect ? '🎉' : percentage >= 80 ? '😊' : percentage >= 60 ? '🙂' : '😢'} テスト{F("結果","けっか")}
+          </div>
+        </div>
+      </div>
+
+      {/* スコアサマリー */}
+      <div className="flex-shrink-0 px-4 py-3">
+        <div className="bg-[var(--panel)] border-[4px] border-[var(--text)] rounded-2xl p-4 shadow-[4px_4px_0_var(--text)]">
+          <div className="text-center">
+            <div className="text-4xl font-black text-[var(--text)] mb-1">{percentage}%</div>
+            <div className="text-sm font-bold text-[var(--text)] opacity-60">
+              {total}{F("問中","もんちゅう")}{correctCount}{F("問正解","もんせいかい")}
+            </div>
+          </div>
+          <div className="flex gap-3 mt-3">
+            <div className="flex-1 bg-emerald-50 dark:bg-emerald-900/20 rounded-xl p-2 text-center border-2 border-emerald-300">
+              <div className="text-[10px] font-bold text-emerald-600 opacity-70">{F("正解","せいかい")}</div>
+              <div className="text-xl font-black text-emerald-600">{correctCount}</div>
+            </div>
+            <div className="flex-1 bg-rose-50 dark:bg-rose-900/20 rounded-xl p-2 text-center border-2 border-rose-300">
+              <div className="text-[10px] font-bold text-rose-600 opacity-70">{F("不正解","ふせいかい")}</div>
+              <div className="text-xl font-black text-rose-600">{incorrectCount}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* 回答一覧 */}
+      <div className="flex-1 overflow-auto px-4 pb-4 min-h-0">
+        <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-2">
+          {answers.map((answer, i) => (
+            <div key={i} className={`bg-[var(--panel)] border-[3px] rounded-xl p-2 flex flex-col items-center gap-1 ${answer.passed ? 'border-emerald-400' : 'border-rose-400'}`}>
+              <div className="relative">
+                <StrokeReplay userStrokes={answer.userStrokes} canvasSize={answer.canvasSize} displaySize={60} />
+                <div className={`absolute -top-1 -right-1 ${answer.passed ? 'text-emerald-500' : 'text-rose-500'}`}>
+                  {answer.passed ? <CheckCircle size={16} /> : <XCircle size={16} />}
+                </div>
+              </div>
+              <div className="text-2xl font-black text-[var(--text)]">{answer.kanji.char}</div>
+              <div className={`text-[10px] font-black ${answer.passed ? 'text-emerald-600' : 'text-rose-600'}`}>
+                {answer.gradeResult.total}{F("点","てん")}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* ボタン */}
+      <div className="flex-shrink-0 px-4 py-3 bg-[var(--panel)] border-t-[3px] border-[var(--text)]">
+        <div className="flex gap-3">
+          {!allCorrect && (
+            <MotionButton variant="primary" onClick={handleReview} className="flex-1 py-3 text-sm font-black border-[3px] border-[var(--text)] shadow-[0_3px_0_#9f1239]">
+              <RotateCcw size={16} /> {F("復習","ふくしゅう")}する
+            </MotionButton>
+          )}
+          <MotionButton variant={allCorrect ? 'primary' : 'secondary'} onClick={handleFinish} className={`flex-1 py-3 text-sm font-black border-[3px] border-[var(--text)] ${allCorrect ? 'shadow-[0_3px_0_#9f1239]' : 'shadow-[0_3px_0_var(--text)]'}`}>
+            <LogOut size={16} /> おわる
+          </MotionButton>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DrillTestView;

--- a/src/constants/gameConfig.js
+++ b/src/constants/gameConfig.js
@@ -182,6 +182,12 @@ export const WEATHER = {
   SAKURA_CHANCE: 20,
 };
 
+/** テストモード設定 */
+export const TEST = {
+  PASS_THRESHOLD: 60,
+  QUESTION_OPTIONS: [10, 20, 50, 100],
+};
+
 /** PWA / Service Worker */
 export const PWA = {
   SW_PATH: '/KANJI_Town/sw.js',


### PR DESCRIPTION
## Summary
Introduces a new test mode for drill sessions that allows users to practice writing kanji characters with automatic stroke grading and the ability to review failed characters in a new drill session.

## Key Changes

- **New DrillTestView component** (`src/components/training/DrillTestView.jsx`):
  - Implements a two-phase test interface: testing phase and results phase
  - `TestCanvas` sub-component handles real-time stroke drawing with touch and mouse support
  - Displays stroke count validation and visual feedback during writing
  - `StrokeReplay` sub-component renders user strokes at smaller scale for review
  - Results screen shows percentage score, correct/incorrect counts, and individual answer review
  - Integrates with stroke grading system to evaluate user submissions
  - Supports review workflow: failed questions can be immediately drilled in a new session

- **Updated MyDrillsView** (`src/components/pages/MyDrillsView.jsx`):
  - Added "テスト" (Test) button to each drill for launching test mode
  - Added modal for selecting test question count (10, 20, 50, or 100 questions)
  - Integrated `startDrillTest` callback

- **Updated App.jsx**:
  - Added `startDrillTest` function that:
    - Filters kanji from selected drill
    - Prioritizes questions by mistake count and review date when limiting question count
    - Randomizes question order
    - Creates session data with `isTest: true` flag
  - Added `DrillTestView` to lazy-loaded components
  - Updated BGM logic to include 'drillTest' view
  - Added `isTest` field to initial session data

- **Updated gameConfig.js**:
  - Added `TEST` configuration object with:
    - `PASS_THRESHOLD`: 60 points minimum to pass a question
    - `QUESTION_OPTIONS`: [10, 20, 50, 100] available test lengths

## Implementation Details

- Test mode integrates with existing stroke grading system (`gradeStrokes`) to evaluate accuracy
- Questions are intelligently selected based on user performance (mistakes and review timing)
- Results display includes visual stroke replay for each answer with pass/fail indicators
- Failed questions can trigger an immediate review drill session with satisfaction multiplier applied
- Canvas drawing supports both touch and mouse input with proper coordinate scaling
- Stroke count validation provides real-time feedback during writing

https://claude.ai/code/session_016frUaZWaVamT9rfzXHaauZ