### PR TITLE
fix: テストモードの合格閾値を60→70に引き上げ

### DIFF
--- a/src/constants/gameConfig.js
+++ b/src/constants/gameConfig.js
@@ -184,7 +184,7 @@ export const WEATHER = {
 
 /** テストモード設定 */
 export const TEST = {
-  PASS_THRESHOLD: 60,
+  PASS_THRESHOLD: 70,
   QUESTION_OPTIONS: [10, 20, 50, 100],
 };
 


### PR DESCRIPTION
鏡文字の「七」が64点で合格になってしまうバグを修正。
GRADING.LABELSの「よくできました」(70点以上)と基準を統一。

https://claude.ai/code/session_016frUaZWaVamT9rfzXHaauZ