### PR TITLE
Add URL-based peer connection with QR code support

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -90,7 +90,19 @@ function createInitialSessionData(overrides = {}) {
 }
 
 export default function App() {
-  const [view, setView] = useState('home');
+  // URLパラメータ ?connect=XXXX でQRコードからの接続をハンドル
+  const connectParam = useMemo(() => {
+    const params = new URLSearchParams(window.location.search);
+    const id = params.get('connect');
+    if (id && /^\d{4}$/.test(id)) {
+      // パラメータを消してURLをクリーンにする
+      window.history.replaceState({}, '', window.location.pathname);
+      return id;
+    }
+    return null;
+  }, []);
+
+  const [view, setView] = useState(connectParam ? 'peerClient' : 'home');
   const [isMuted, setIsMuted] = useState(audioCtrl.muted);
   const [stats, setStats] = useState(StorageAPI.getStats());
   const [sessionData, setSessionData] = useState(createInitialSessionData);
@@ -629,7 +641,7 @@ export default function App() {
           {view === 'myDrills' && <PageWrapper key="myDrills"><ErrorBoundary onReset={() => setView('home')}><MyDrillsView setView={setView} stats={stats} setStats={setStats} startDrillSession={startDrillSession} startDrillTest={startDrillTest} setHostDrill={setHostDrill} /></ErrorBoundary></PageWrapper>}
           {view === 'drillEditor' && <PageWrapper key="drillEditor"><ErrorBoundary onReset={() => setView('home')}><DrillEditorView setView={setView} stats={stats} setStats={setStats} /></ErrorBoundary></PageWrapper>}
           {view === 'peerHost' && <PageWrapper key="peerHost"><ErrorBoundary onReset={() => setView('home')}><TeacherHostView setView={setView} drill={hostDrill} /></ErrorBoundary></PageWrapper>}
-          {view === 'peerClient' && <PageWrapper key="peerClient"><ErrorBoundary onReset={() => setView('home')}><StudentClientView setView={setView} stats={stats} setStats={setStats} /></ErrorBoundary></PageWrapper>}
+          {view === 'peerClient' && <PageWrapper key="peerClient"><ErrorBoundary onReset={() => setView('home')}><StudentClientView setView={setView} stats={stats} setStats={setStats} initialConnectId={connectParam} /></ErrorBoundary></PageWrapper>}
           {view === 'gacha' && <PageWrapper key="gacha"><ErrorBoundary onReset={() => setView('home')}><GachaView stats={stats} setStats={setStats} onBack={() => setView('home')} /></ErrorBoundary></PageWrapper>}
           {view === 'session' && <FullScreenWrapper key="session"><ErrorBoundary onReset={() => setView('home')}><SessionView queue={sessionData.queue} stats={stats.kanjiStats || {}} onUpdateStat={handleUpdateStat} onFinish={handleFinishSession} onRecordPerfect={handleRecordPerfect} onRecordEasy={handleRecordEasy} /></ErrorBoundary></FullScreenWrapper>}
           {view === 'flashcard' && <FullScreenWrapper key="flashcard"><ErrorBoundary onReset={() => setView('home')}><FlashcardView queue={sessionData.queue} stats={stats} setStats={setStats} onFinish={handleFinishSession} /></ErrorBoundary></FullScreenWrapper>}

--- a/src/components/social/StudentClientView.jsx
+++ b/src/components/social/StudentClientView.jsx
@@ -116,10 +116,17 @@ const QRScanner = ({ onScan, onClose }) => {
     const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
     const code = window.jsQR(imageData.data, canvas.width, canvas.height);
     if (code && code.data) {
-      // kanji-town- プレフィックスを含むID、または4桁の数字を検出
+      // URL形式（?connect=XXXX）、kanji-town-プレフィックス、または4桁の数字を検出
       let peerId = code.data;
-      if (peerId.startsWith(PEER_ID_PREFIX)) {
-        peerId = peerId.replace(PEER_ID_PREFIX, '');
+      try {
+        const url = new URL(peerId);
+        const connectParam = url.searchParams.get('connect');
+        if (connectParam) peerId = connectParam;
+      } catch {
+        // URL形式でない場合はそのまま処理
+        if (peerId.startsWith(PEER_ID_PREFIX)) {
+          peerId = peerId.replace(PEER_ID_PREFIX, '');
+        }
       }
       if (/^\d{4}$/.test(peerId)) {
         audioCtrl.playSE('success');
@@ -187,9 +194,9 @@ const QRScanner = ({ onScan, onClose }) => {
   );
 };
 
-const StudentClientView = ({ setView, stats, setStats }) => {
+const StudentClientView = ({ setView, stats, setStats, initialConnectId }) => {
   const isPeerLoaded = usePeerJS();
-  const [hostId, setHostId] = useState('');
+  const [hostId, setHostId] = useState(initialConnectId || '');
   const [status, setStatus] = useState('');
   const [receivedDrill, setReceivedDrill] = useState(null);
   const [showScanner, setShowScanner] = useState(false);

--- a/src/components/social/TeacherHostView.jsx
+++ b/src/components/social/TeacherHostView.jsx
@@ -23,11 +23,12 @@ const TeacherHostView = ({ setView, drill }) => {
   const qrCanvasRef = useRef(null);
   const retryCountRef = useRef(0);
 
-  // QRコード描画
-  const renderQR = useCallback((id) => {
-    if (!isQRLoaded || !qrCanvasRef.current || !id) return;
+  // QRコード描画（接続用URLをエンコード）
+  const renderQR = useCallback((numId) => {
+    if (!isQRLoaded || !qrCanvasRef.current || !numId) return;
     try {
-      window.QRCode.toCanvas(qrCanvasRef.current, id, {
+      const url = `${window.location.origin}${window.location.pathname}?connect=${numId}`;
+      window.QRCode.toCanvas(qrCanvasRef.current, url, {
         width: 200,
         margin: 2,
         color: { dark: '#292f36', light: '#ffffff' },
@@ -51,7 +52,7 @@ const TeacherHostView = ({ setView, drill }) => {
         setNumericId(id4);
         setStatus('IDができました！');
         retryCountRef.current = 0;
-        renderQR(fullId);
+        renderQR(id4);
       });
 
       peer.on('connection', conn => {
@@ -88,7 +89,7 @@ const TeacherHostView = ({ setView, drill }) => {
   // QRコードが後からロードされた場合に再描画
   useEffect(() => {
     if (numericId && isQRLoaded) {
-      renderQR(PEER_ID_PREFIX + numericId);
+      renderQR(numericId);
     }
   }, [numericId, isQRLoaded, renderQR]);
 


### PR DESCRIPTION
## Summary
Enhanced the peer connection flow to support URL-based connection parameters, allowing students to join peer sessions directly via QR codes that encode connection URLs instead of just peer IDs.

## Key Changes

- **QR Code Generation**: Modified `TeacherHostView` to generate QR codes containing full URLs with `?connect=XXXX` parameter instead of just peer IDs
  - QR codes now encode: `{origin}{pathname}?connect={numericId}`
  - Simplified QR rendering to use only the 4-digit numeric ID

- **QR Code Scanning**: Enhanced `StudentClientView` QR scanner to parse multiple connection formats:
  - URL format with `?connect=` parameter (primary)
  - Legacy `kanji-town-` prefixed IDs (fallback)
  - Direct 4-digit numeric IDs (fallback)
  - Gracefully handles invalid URLs and falls back to prefix/numeric parsing

- **URL Parameter Handling**: Added URL parameter parsing in `App.jsx`:
  - Extracts `?connect=XXXX` from URL on app load
  - Validates that the parameter is a 4-digit number
  - Automatically navigates to peer client view when valid parameter is present
  - Cleans up URL using `replaceState` to remove the parameter from browser history

- **Initial Connection**: Updated `StudentClientView` to accept `initialConnectId` prop:
  - Pre-populates the host ID field when joining via URL parameter
  - Enables seamless one-click connection flow from QR code

## Implementation Details
- URL parsing uses try-catch to safely handle non-URL QR code data
- Maintains backward compatibility with existing peer ID formats
- Uses `useMemo` to ensure URL parameter is only parsed once on mount
- Validates numeric IDs with regex `/^\d{4}$/` before processing

https://claude.ai/code/session_01MRZbXB7ZUDjdohLdMJ2k9L