### PR TITLE
feat: スマートフォン専用レスポンシブレイアウトを追加

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,9 @@ import React, { useState, useEffect, useCallback, useMemo, lazy, Suspense } from
 import { AnimatePresence } from 'framer-motion';
 import { PenTool, Volume2, VolumeX, Settings, Users } from 'lucide-react';
 import { useOnlineStatus } from './hooks/useOnlineStatus';
+import { useIsMobile } from './hooks/useIsMobile';
 import OfflineBanner from './components/ui/OfflineBanner';
+import MobileBottomNav from './components/ui/MobileBottomNav';
 
 import { StorageAPI, getLevelInfo } from './systems/storage';
 import { calculateNextReview, migrateCard } from './systems/srs';
@@ -121,6 +123,7 @@ export default function App() {
   // Phase 5: ヒント
   const [seenHints, setSeenHints] = useState(stats.seenHints || []);
   const isOnline = useOnlineStatus();
+  const isMobile = useIsMobile();
 
   const levelInfo = useMemo(() => getLevelInfo(stats.totalExp, stats.townMap), [stats.totalExp, stats.townMap]);
 
@@ -593,26 +596,26 @@ export default function App() {
       </AnimatePresence>
 
       {view !== 'session' && view !== 'townEditor' && view !== 'flashcard' && view !== 'survival' && view !== 'boss' && view !== 'drillTest' && (
-        <header className="flex-shrink-0 bg-[var(--panel)]/90 backdrop-blur border-b-[4px] border-[var(--text)] py-3 px-5 flex justify-between items-center z-50 sticky top-0 shadow-[0_4px_0_var(--text)] transition-colors duration-500" role="banner">
-          <button className="flex items-center cursor-pointer gap-2 bg-transparent border-none p-0 focus:outline-none focus:ring-2 focus:ring-[var(--primary)] rounded-lg" onClick={() => { audioCtrl.playSE('click'); setView('home'); }} aria-label="ホームに戻る">
-            <div className="bg-[var(--primary)] p-1.5 rounded-lg text-[var(--panel)] shadow-sm border-2 border-[var(--text)]" aria-hidden="true"><PenTool size={22} strokeWidth={3} /></div>
-            <h1 className="text-xl font-black text-[var(--text)] tracking-wide">マイ{F("漢字","かんじ")}タウン</h1>
+        <header className="flex-shrink-0 bg-[var(--panel)]/90 backdrop-blur border-b-[3px] md:border-b-[4px] border-[var(--text)] py-2 md:py-3 px-3 md:px-5 flex justify-between items-center z-50 sticky top-0 shadow-[0_4px_0_var(--text)] transition-colors duration-500" role="banner">
+          <button className="flex items-center cursor-pointer gap-1.5 md:gap-2 bg-transparent border-none p-0 focus:outline-none focus:ring-2 focus:ring-[var(--primary)] rounded-lg" onClick={() => { audioCtrl.playSE('click'); setView('home'); }} aria-label="ホームに戻る">
+            <div className="bg-[var(--primary)] p-1 md:p-1.5 rounded-lg text-[var(--panel)] shadow-sm border-2 border-[var(--text)]" aria-hidden="true"><PenTool size={isMobile ? 18 : 22} strokeWidth={3} /></div>
+            <h1 className="text-base md:text-xl font-black text-[var(--text)] tracking-wide">マイ{F("漢字","かんじ")}タウン</h1>
           </button>
-          <nav className="flex items-center gap-1" aria-label="メイン操作">
-            <button onClick={() => setIsMuted(audioCtrl.toggle())} aria-label={isMuted ? "音をオンにする" : "音をオフにする"} aria-pressed={!isMuted} className="text-[var(--text)] opacity-50 hover:opacity-100 p-2 rounded-full transition-all focus:outline-none focus:ring-2 focus:ring-[var(--primary)] border-2 border-transparent hover:border-[var(--text)] hover:bg-[var(--bg)] min-w-[44px] min-h-[44px] flex items-center justify-center">
-              {isMuted ? <VolumeX size={24} aria-hidden="true" /> : <Volume2 size={24} className="text-[var(--secondary)]" aria-hidden="true" />}
+          <nav className="flex items-center gap-0.5 md:gap-1" aria-label="メイン操作">
+            <button onClick={() => setIsMuted(audioCtrl.toggle())} aria-label={isMuted ? "音をオンにする" : "音をオフにする"} aria-pressed={!isMuted} className="text-[var(--text)] opacity-50 hover:opacity-100 p-1.5 md:p-2 rounded-full transition-all focus:outline-none focus:ring-2 focus:ring-[var(--primary)] border-2 border-transparent hover:border-[var(--text)] hover:bg-[var(--bg)] min-w-[40px] min-h-[40px] md:min-w-[44px] md:min-h-[44px] flex items-center justify-center">
+              {isMuted ? <VolumeX size={isMobile ? 20 : 24} aria-hidden="true" /> : <Volume2 size={isMobile ? 20 : 24} className="text-[var(--secondary)]" aria-hidden="true" />}
             </button>
-            <button onClick={() => { audioCtrl.playSE('click'); setView('settings'); }} aria-label="設定を開く" className="text-[var(--text)] opacity-50 hover:opacity-100 p-2 rounded-full transition-all focus:outline-none focus:ring-2 focus:ring-[var(--primary)] border-2 border-transparent hover:border-[var(--text)] hover:bg-[var(--bg)] min-w-[44px] min-h-[44px] flex items-center justify-center">
-              <Settings size={24} aria-hidden="true" />
+            <button onClick={() => { audioCtrl.playSE('click'); setView('settings'); }} aria-label="設定を開く" className="text-[var(--text)] opacity-50 hover:opacity-100 p-1.5 md:p-2 rounded-full transition-all focus:outline-none focus:ring-2 focus:ring-[var(--primary)] border-2 border-transparent hover:border-[var(--text)] hover:bg-[var(--bg)] min-w-[40px] min-h-[40px] md:min-w-[44px] md:min-h-[44px] flex items-center justify-center">
+              <Settings size={isMobile ? 20 : 24} aria-hidden="true" />
             </button>
           </nav>
         </header>
       )}
 
-      <main className="flex-grow relative overflow-hidden p-0 md:p-4">
+      <main className="flex-grow relative overflow-hidden p-0 md:p-4 min-h-0">
         <Suspense fallback={<LazyFallback />}>
         <AnimatePresence mode="wait">
-          {view === 'home' && <PageWrapper key="home" wide><ErrorBoundary onReset={() => setView('home')}><HomeView setView={setView} stats={stats} setStats={setStats} startSession={startSession} startFlashcard={startFlashcard} startSurvival={startSurvival} startBossBattle={startBossBattle} levelInfo={levelInfo} dailyMissions={dailyMissions} onClaimMission={handleClaimMission} /></ErrorBoundary></PageWrapper>}
+          {view === 'home' && <PageWrapper key="home" wide><ErrorBoundary onReset={() => setView('home')}><HomeView setView={setView} stats={stats} setStats={setStats} startSession={startSession} startFlashcard={startFlashcard} startSurvival={startSurvival} startBossBattle={startBossBattle} levelInfo={levelInfo} dailyMissions={dailyMissions} onClaimMission={handleClaimMission} isMobile={isMobile} /></ErrorBoundary></PageWrapper>}
           {view === 'dictionary' && <PageWrapper key="dict" wide><ErrorBoundary onReset={() => setView('home')}><FeatureHint featureKey="dictionary" seenHints={seenHints} onDismiss={handleDismissHint} /><DictionaryView kanjiStats={stats.kanjiStats} onBack={() => setView('home')} onSelectKanji={startSingleSession} /></ErrorBoundary></PageWrapper>}
           {view === 'townEditor' && <FullScreenWrapper key="townEditor"><ErrorBoundary onReset={() => setView('home')}><TownEditorView setView={setView} stats={stats} setStats={setStats} onCraft={() => {
                 setDailyMissions(prev => {
@@ -652,6 +655,15 @@ export default function App() {
         </AnimatePresence>
         </Suspense>
       </main>
+      {/* モバイルボトムナビ（ホーム画面のみ表示） */}
+      {isMobile && view === 'home' && (
+        <MobileBottomNav
+          setView={setView}
+          currentView={view}
+          isCraftUnlocked={levelInfo.level >= 3}
+          isTownEditorUnlocked={levelInfo.level >= 1}
+        />
+      )}
       <Footer />
     </div>
   );

--- a/src/components/pages/HomeView.jsx
+++ b/src/components/pages/HomeView.jsx
@@ -12,7 +12,7 @@ import { audioCtrl } from '../../systems/audio';
 import { F } from '../ui/FormatKun';
 import { calculateSatisfaction, getSatisfactionLabel } from '../../systems/residents';
 
-const HomeView = ({ setView, stats, setStats, startSession, startFlashcard, startSurvival, startBossBattle, levelInfo, dailyMissions, onClaimMission }) => {
+const HomeView = ({ setView, stats, setStats, startSession, startFlashcard, startSurvival, startBossBattle, levelInfo, dailyMissions, onClaimMission, isMobile }) => {
   const currentLevelInfo = levelInfo || getLevelInfo(stats.totalExp, stats.townMap);
   const { level, title, badge, progress, remainingExp, targetReward, isMaxLevel } = currentLevelInfo;
   const now = Date.now();
@@ -32,69 +32,176 @@ const HomeView = ({ setView, stats, setStats, startSession, startFlashcard, star
   const isTownEditorUnlocked = level >= 1;
   const isResidentsUnlocked = (stats.population || 0) >= 1;
 
+  // ── 共通パーツ ──
 
+  /** ステータスバー（レベル・コイン・繁栄度） */
+  const StatusBar = () => (
+    <div className="flex items-center justify-between shrink-0 px-1">
+      <div className="flex items-center gap-1.5 md:gap-2 min-w-0">
+        <span className="text-xs md:text-sm font-bold text-[var(--text)] opacity-60 truncate">{badge} {title}</span>
+        <span className="text-base md:text-lg font-black text-[var(--text)]">Lv.{level}</span>
+        <span className="hidden sm:inline text-xs font-bold text-[var(--text)] opacity-50">{stage.emoji} {stage.title}</span>
+      </div>
+      <div className="flex items-center gap-1.5 md:gap-2 shrink-0">
+        <span className="text-[10px] md:text-xs font-bold text-[var(--text)] opacity-60 flex items-center gap-0.5"><Users size={12} />{stats.population || 0}{F("人","にん")}</span>
+        <span className="text-[10px] md:text-xs font-bold flex items-center gap-0.5" style={{ color: satLabel.color }}>{satLabel.emoji}{satLabel.text}</span>
+        <span className="flex items-center gap-1 bg-[var(--accent)] px-2 md:px-2.5 py-0.5 md:py-1 rounded-full text-[var(--text)] border-[2px] border-[var(--text)] font-black text-xs md:text-sm shadow-sm"><Coins size={14} />{stats.coins}</span>
+        <span className="hidden sm:flex text-xs font-bold text-[var(--primary)] items-center gap-1"><TrendingUp size={12} />{prosperity}</span>
+      </div>
+    </div>
+  );
+
+  /** EXPバー */
+  const ExpBar = () => (
+    <div className="flex flex-col gap-0.5 md:gap-1 shrink-0">
+      <div className="w-full h-2.5 md:h-3 bg-gray-200 rounded-full overflow-hidden border-2 border-[var(--text)]">
+        <motion.div initial={{ width: 0 }} animate={{ width: `${progress}%` }} className="h-full bg-[var(--secondary)]" />
+      </div>
+      {isMaxLevel ? (
+        <div className="text-[10px] font-black text-right text-[var(--accent)] tracking-widest px-1">✨ MAX LEVEL!</div>
+      ) : (
+        <div className="flex justify-between items-center px-1">
+          <span className="text-[10px] font-bold text-[var(--text)] opacity-60">
+            あと <strong className="text-[var(--text)] text-xs">{remainingExp || 0}</strong> EXP で Lv.{(level || 1) + 1}
+          </span>
+          {targetReward && (
+            <span className="text-[10px] font-bold text-[var(--primary)] bg-[var(--primary)]/10 px-2 py-0.5 rounded-full border border-[var(--primary)]/30 flex items-center gap-1 shadow-sm">
+              🎁 {targetReward.text || 'ごほうび'}
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+
+  /** タウンマップ */
+  const TownMap = ({ className = '' }) => (
+    <div
+      className={`relative rounded-2xl overflow-hidden border-[4px] ${isTownEditorUnlocked ? 'border-[var(--text)] cursor-pointer hover:border-[var(--secondary)] transition-colors' : 'border-[var(--text)]'} ${className}`}
+      onClick={() => { if (isTownEditorUnlocked) { audioCtrl.playSE('click'); setView('townEditor'); } }}
+      role={isTownEditorUnlocked ? "button" : undefined}
+      aria-label={isTownEditorUnlocked ? "まちづくりモードへ" : undefined}
+    >
+      <DraggableTownMap mapData={stats.townMap} isDanger={isReviewNeeded} isEditing={false} reviewCount={reviewTargetsCount} villagers={stats.villagers || []} exploredRadius={stats.exploredRadius || 3} />
+      {isTownEditorUnlocked && (
+        <div className="absolute bottom-2 right-2 bg-[var(--panel)]/90 backdrop-blur-sm border-[2px] border-[var(--text)] rounded-xl px-2.5 md:px-3 py-1 md:py-1.5 flex items-center gap-1.5 z-10 pointer-events-none shadow-sm">
+          <Map size={14} className="text-[var(--accent)]" />
+          <span className="text-[10px] md:text-xs font-black text-[var(--text)]">タップでまちづくり</span>
+        </div>
+      )}
+      {!isTownEditorUnlocked && (
+        <div className="absolute inset-0 flex items-center justify-center bg-black/10 z-10">
+          <span className="bg-[var(--panel)] border-[2px] border-[var(--text)] rounded-full px-3 py-1.5 text-xs font-bold flex items-center gap-1"><Lock size={12} /> {F("漢字","かんじ")}を{F("覚","おぼ")}えると{F("開放","かいほう")}</span>
+        </div>
+      )}
+    </div>
+  );
+
+  /** 学年選択 + メインアクション */
+  const GradeAndAction = () => (
+    <div className="bg-[var(--panel)] border-[3px] border-[var(--text)] rounded-2xl p-2.5 md:p-3 flex flex-col gap-2 shadow-[2px_2px_0_var(--text)] shrink-0">
+      <div className="flex gap-1">
+        {[1, 2, 3, 4, 5, 6].map(g => (
+          <button key={g} onClick={() => { audioCtrl.playSE('click'); handleGradeChange(g); }} className={`flex-1 py-1.5 md:py-2 font-black text-sm md:text-base rounded-xl border-[2px] transition-all ${selectedGrade === g ? 'bg-[var(--text)] text-[var(--panel)] border-[var(--text)]' : 'bg-[var(--bg)] text-[var(--text)] border-transparent opacity-60 hover:opacity-100'}`}>{g}年</button>
+        ))}
+      </div>
+      <MotionButton variant={isReviewNeeded ? "danger" : "primary"} className="w-full py-3 md:py-4 text-base md:text-lg font-black border-[3px] border-[var(--text)] shadow-[0_3px_0_rgba(0,0,0,0.3)]" onClick={() => startSession(selectedGrade)}>
+        {isReviewNeeded ? <><ShieldAlert size={20} /> おばけを たいじする！</> : <><PenTool size={20} /> {selectedGrade}{F("年生","ねんせい")}の{F("漢字","かんじ")}を{F("覚","おぼ")}える！</>}
+      </MotionButton>
+    </div>
+  );
+
+  /** ドリルボタン */
+  const DrillButtons = () => (
+    <div className="grid grid-cols-2 gap-2 shrink-0">
+      <MotionButton variant="success" className="py-2.5 md:py-3 flex-col gap-1 text-sm border-[3px] border-[var(--text)] shadow-[0_3px_0_#065f46]" onClick={() => setView('myDrills')}><FileText size={20} /> マイドリル</MotionButton>
+      <MotionButton variant="accent" className="py-2.5 md:py-3 flex-col gap-1 text-sm border-[3px] border-[var(--text)] shadow-[0_3px_0_#b45309]" onClick={() => setView('peerClient')}><Download size={20} /> {F("通信","つうしん")}でもらう</MotionButton>
+    </div>
+  );
+
+  /** 特別トレーニング */
+  const SpecialTraining = () => (
+    <div className="bg-[var(--panel)] border-[3px] border-[var(--text)] rounded-2xl p-2 md:p-2.5 relative overflow-hidden shrink-0">
+      {!isSpecialTrainingUnlocked && (
+        <div className="absolute inset-0 z-10 bg-[var(--panel)]/80 backdrop-blur-[2px] flex items-center justify-center">
+          <span className="text-xs font-bold text-[var(--text)] bg-[var(--bg)] px-3 py-1.5 rounded-full border-2 border-[var(--text)] flex items-center gap-1 shadow-sm"><AlertCircle size={14} className="text-amber-500" /> まずは{F("漢字","かんじ")}を{F("覚","おぼ")}えよう！</span>
+        </div>
+      )}
+      <div className="grid grid-cols-3 gap-2">
+        <MotionButton variant="secondary" onClick={startFlashcard} disabled={!isSpecialTrainingUnlocked} className="flex-col py-2.5 md:py-3 border-[2px] border-[var(--text)] shadow-[0_2px_0_var(--text)] text-xs gap-1"><Zap size={18} className="text-amber-500" /> フラッシュ</MotionButton>
+        <MotionButton variant="secondary" onClick={startSurvival} disabled={!isSpecialTrainingUnlocked} className="flex-col py-2.5 md:py-3 border-[2px] border-[var(--text)] shadow-[0_2px_0_var(--text)] text-xs gap-1"><Flame size={18} className="text-rose-500" /> サバイバル</MotionButton>
+        <MotionButton variant="secondary" onClick={startBossBattle} disabled={!isSpecialTrainingUnlocked} className="flex-col py-2.5 md:py-3 border-[2px] border-[var(--text)] shadow-[0_2px_0_var(--text)] text-xs gap-1"><Ghost size={18} className="text-purple-500" /> ボスバトル</MotionButton>
+      </div>
+    </div>
+  );
+
+  /** ナビゲーションボタン（PC/タブレット用サイドバー向け） */
+  const NavButtons = () => (
+    <>
+      <div className="grid grid-cols-2 gap-2 shrink-0">
+        <MotionButton variant="secondary" className="py-3 text-sm border-[2px] border-[var(--text)] shadow-sm gap-2" onClick={() => setView('dictionary')}><Library size={20} className="text-[var(--secondary)]" /> {F("図鑑","ずかん")}</MotionButton>
+        <MotionButton variant="secondary" className="py-3 text-sm border-[2px] border-[var(--text)] border-amber-200 bg-amber-50 shadow-sm gap-2" onClick={() => setView('gacha')}><Sparkles size={20} className="text-amber-500" /> ガチャ</MotionButton>
+      </div>
+      <div className="grid grid-cols-2 gap-2 shrink-0">
+        <MotionButton variant="secondary" className="py-3 text-sm border-[2px] border-[var(--text)] shadow-sm gap-2" onClick={() => setView('achievements')}><Medal size={20} className="text-amber-500" /> {F("実績","じっせき")}</MotionButton>
+        <MotionButton variant="secondary" className="py-3 text-sm border-[2px] border-[var(--text)] shadow-sm gap-2" onClick={() => setView('stats')}><BarChart3 size={20} className="text-[var(--secondary)]" /> {F("記録","きろく")}</MotionButton>
+      </div>
+    </>
+  );
+
+  /** アンロックヒント */
+  const UnlockHints = () => (
+    <>
+      {!isTownEditorUnlocked && (
+        <div className="text-xs text-center text-[var(--text)] opacity-40 bg-[var(--bg)] rounded-lg px-2 py-1 shrink-0">
+          {F("漢字","かんじ")}を1つ{F("覚","おぼ")}えると「まちづくり」が{F("使","つか")}えるよ
+        </div>
+      )}
+      {isTownEditorUnlocked && !isCraftUnlocked && (
+        <div className="text-xs text-center text-[var(--text)] opacity-40 bg-[var(--bg)] rounded-lg px-2 py-1 shrink-0">
+          {F("漢字","かんじ")}を3つ{F("覚","おぼ")}えると「クラフト」が{F("使","つか")}えるよ
+        </div>
+      )}
+    </>
+  );
+
+  // ━━━━━━━━━━ モバイルレイアウト（< md） ━━━━━━━━━━
+  if (isMobile) {
+    return (
+      <div className="flex flex-col h-full gap-2 overflow-hidden">
+        {/* ステータスバー */}
+        <StatusBar />
+        <ExpBar />
+
+        {/* タウンマップ（コンパクト） */}
+        <TownMap className="h-[35vh] min-h-[180px] shrink-0" />
+
+        {/* コントロール（スクロール可能） */}
+        <div className="flex-1 flex flex-col gap-2 overflow-y-auto no-scrollbar pb-2">
+          {/* デイリーミッション */}
+          {dailyMissions && dailyMissions.length > 0 && (
+            <div className="shrink-0">
+              <DailyMissionsPanel missions={dailyMissions} onClaim={onClaimMission} />
+            </div>
+          )}
+
+          <GradeAndAction />
+          <DrillButtons />
+          <SpecialTraining />
+          <UnlockHints />
+        </div>
+      </div>
+    );
+  }
+
+  // ━━━━━━━━━━ タブレット/PCレイアウト（>= md）━━━━━━━━━━
   return (
     <div className="flex h-full gap-3 overflow-hidden">
       {/* === LEFT: Town Map === */}
       <div className="flex-1 flex flex-col gap-2 min-w-0 h-full">
-        {/* Town header bar */}
-        <div className="flex items-center justify-between shrink-0 px-1">
-          <div className="flex items-center gap-2 min-w-0">
-            <span className="text-sm font-bold text-[var(--text)] opacity-60">{badge} {title}</span>
-            <span className="text-lg font-black text-[var(--text)]">Lv.{level}</span>
-            <span className="text-xs font-bold text-[var(--text)] opacity-50">{stage.emoji} {stage.title}</span>
-          </div>
-          <div className="flex items-center gap-2 shrink-0">
-            <span className="text-xs font-bold text-[var(--text)] opacity-60 flex items-center gap-0.5"><Users size={12} />{stats.population || 0}{F("人","にん")}</span>
-            <span className="text-xs font-bold flex items-center gap-0.5" style={{ color: satLabel.color }}>{satLabel.emoji}{satLabel.text}</span>
-            <span className="flex items-center gap-1 bg-[var(--accent)] px-2.5 py-1 rounded-full text-[var(--text)] border-[2px] border-[var(--text)] font-black text-sm shadow-sm"><Coins size={14} />{stats.coins}</span>
-            <span className="text-xs font-bold text-[var(--primary)] flex items-center gap-1"><TrendingUp size={12} />{prosperity}</span>
-          </div>
-        </div>
-
-        {/* EXP bar & Next Reward Motivation */}
-        <div className="flex flex-col gap-1 shrink-0">
-          <div className="w-full h-3 bg-gray-200 rounded-full overflow-hidden border-2 border-[var(--text)]">
-            <motion.div initial={{ width: 0 }} animate={{ width: `${progress}%` }} className="h-full bg-[var(--secondary)]" />
-          </div>
-          {isMaxLevel ? (
-            <div className="text-[10px] font-black text-right text-[var(--accent)] tracking-widest px-1">✨ MAX LEVEL!</div>
-          ) : (
-            <div className="flex justify-between items-center px-1">
-              <span className="text-[10px] font-bold text-[var(--text)] opacity-60">
-                あと <strong className="text-[var(--text)] text-xs">{remainingExp || 0}</strong> EXP で Lv.{(level || 1) + 1}
-              </span>
-              {targetReward && (
-                <span className="text-[10px] font-bold text-[var(--primary)] bg-[var(--primary)]/10 px-2 py-0.5 rounded-full border border-[var(--primary)]/30 flex items-center gap-1 shadow-sm">
-                  🎁 {targetReward.text || 'ごほうび'}
-                </span>
-              )}
-            </div>
-          )}
-        </div>
-
-        {/* Town map - clickable to enter town editor */}
-        <div
-          className={`flex-1 min-h-0 relative rounded-2xl overflow-hidden border-[4px] ${isTownEditorUnlocked ? 'border-[var(--text)] cursor-pointer hover:border-[var(--secondary)] transition-colors' : 'border-[var(--text)]'}`}
-          onClick={() => { if (isTownEditorUnlocked) { audioCtrl.playSE('click'); setView('townEditor'); } }}
-          role={isTownEditorUnlocked ? "button" : undefined}
-          aria-label={isTownEditorUnlocked ? "まちづくりモードへ" : undefined}
-        >
-          <DraggableTownMap mapData={stats.townMap} isDanger={isReviewNeeded} isEditing={false} reviewCount={reviewTargetsCount} villagers={stats.villagers || []} exploredRadius={stats.exploredRadius || 3} />
-          {/* Overlay label */}
-          {isTownEditorUnlocked && (
-            <div className="absolute bottom-2 right-2 bg-[var(--panel)]/90 backdrop-blur-sm border-[2px] border-[var(--text)] rounded-xl px-3 py-1.5 flex items-center gap-1.5 z-10 pointer-events-none shadow-sm">
-              <Map size={14} className="text-[var(--accent)]" />
-              <span className="text-xs font-black text-[var(--text)]">タップでまちづくり</span>
-            </div>
-          )}
-          {!isTownEditorUnlocked && (
-            <div className="absolute inset-0 flex items-center justify-center bg-black/10 z-10">
-              <span className="bg-[var(--panel)] border-[2px] border-[var(--text)] rounded-full px-3 py-1.5 text-xs font-bold flex items-center gap-1"><Lock size={12} /> {F("漢字","かんじ")}を{F("覚","おぼ")}えると{F("開放","かいほう")}</span>
-            </div>
-          )}
-        </div>
-
+        <StatusBar />
+        <ExpBar />
+        <TownMap className="flex-1 min-h-0" />
       </div>
 
       {/* === RIGHT: Controls === */}
@@ -106,59 +213,11 @@ const HomeView = ({ setView, stats, setStats, startSession, startFlashcard, star
           </div>
         )}
 
-        {/* Grade selector + Main action */}
-        <div className="bg-[var(--panel)] border-[3px] border-[var(--text)] rounded-2xl p-3 flex flex-col gap-2 shadow-[2px_2px_0_var(--text)] shrink-0">
-          <div className="flex gap-1">
-            {[1, 2, 3, 4, 5, 6].map(g => (
-              <button key={g} onClick={() => { audioCtrl.playSE('click'); handleGradeChange(g); }} className={`flex-1 py-2 font-black text-base rounded-xl border-[2px] transition-all ${selectedGrade === g ? 'bg-[var(--text)] text-[var(--panel)] border-[var(--text)]' : 'bg-[var(--bg)] text-[var(--text)] border-transparent opacity-60 hover:opacity-100'}`}>{g}年</button>
-            ))}
-          </div>
-          <MotionButton variant={isReviewNeeded ? "danger" : "primary"} className="w-full py-4 text-lg font-black border-[3px] border-[var(--text)] shadow-[0_3px_0_rgba(0,0,0,0.3)]" onClick={() => startSession(selectedGrade)}>
-            {isReviewNeeded ? <><ShieldAlert size={22} /> おばけを たいじする！</> : <><PenTool size={22} /> {selectedGrade}{F("年生","ねんせい")}の{F("漢字","かんじ")}を{F("覚","おぼ")}える！</>}
-          </MotionButton>
-        </div>
-
-        {/* Drill buttons */}
-        <div className="grid grid-cols-2 gap-2 shrink-0">
-          <MotionButton variant="success" className="py-3 flex-col gap-1 text-sm border-[3px] border-[var(--text)] shadow-[0_3px_0_#065f46]" onClick={() => setView('myDrills')}><FileText size={20} /> マイドリル</MotionButton>
-          <MotionButton variant="accent" className="py-3 flex-col gap-1 text-sm border-[3px] border-[var(--text)] shadow-[0_3px_0_#b45309]" onClick={() => setView('peerClient')}><Download size={20} /> {F("通信","つうしん")}でもらう</MotionButton>
-        </div>
-
-        {/* Special training */}
-        <div className="bg-[var(--panel)] border-[3px] border-[var(--text)] rounded-2xl p-2.5 relative overflow-hidden shrink-0">
-          {!isSpecialTrainingUnlocked && (
-            <div className="absolute inset-0 z-10 bg-[var(--panel)]/80 backdrop-blur-[2px] flex items-center justify-center">
-              <span className="text-xs font-bold text-[var(--text)] bg-[var(--bg)] px-3 py-1.5 rounded-full border-2 border-[var(--text)] flex items-center gap-1 shadow-sm"><AlertCircle size={14} className="text-amber-500" /> まずは{F("漢字","かんじ")}を{F("覚","おぼ")}えよう！</span>
-            </div>
-          )}
-          <div className="grid grid-cols-3 gap-2">
-            <MotionButton variant="secondary" onClick={startFlashcard} disabled={!isSpecialTrainingUnlocked} className="flex-col py-3 border-[2px] border-[var(--text)] shadow-[0_2px_0_var(--text)] text-xs gap-1"><Zap size={18} className="text-amber-500" /> フラッシュ</MotionButton>
-            <MotionButton variant="secondary" onClick={startSurvival} disabled={!isSpecialTrainingUnlocked} className="flex-col py-3 border-[2px] border-[var(--text)] shadow-[0_2px_0_var(--text)] text-xs gap-1"><Flame size={18} className="text-rose-500" /> サバイバル</MotionButton>
-            <MotionButton variant="secondary" onClick={startBossBattle} disabled={!isSpecialTrainingUnlocked} className="flex-col py-3 border-[2px] border-[var(--text)] shadow-[0_2px_0_var(--text)] text-xs gap-1"><Ghost size={18} className="text-purple-500" /> ボスバトル</MotionButton>
-          </div>
-        </div>
-
-        {/* Navigation buttons */}
-        <div className="grid grid-cols-2 gap-2 shrink-0">
-          <MotionButton variant="secondary" className="py-3 text-sm border-[2px] border-[var(--text)] shadow-sm gap-2" onClick={() => setView('dictionary')}><Library size={20} className="text-[var(--secondary)]" /> {F("図鑑","ずかん")}</MotionButton>
-          <MotionButton variant="secondary" className="py-3 text-sm border-[2px] border-[var(--text)] border-amber-200 bg-amber-50 shadow-sm gap-2" onClick={() => setView('gacha')}><Sparkles size={20} className="text-amber-500" /> ガチャ</MotionButton>
-        </div>
-        <div className="grid grid-cols-2 gap-2 shrink-0">
-          <MotionButton variant="secondary" className="py-3 text-sm border-[2px] border-[var(--text)] shadow-sm gap-2" onClick={() => setView('achievements')}><Medal size={20} className="text-amber-500" /> {F("実績","じっせき")}</MotionButton>
-          <MotionButton variant="secondary" className="py-3 text-sm border-[2px] border-[var(--text)] shadow-sm gap-2" onClick={() => setView('stats')}><BarChart3 size={20} className="text-[var(--secondary)]" /> {F("記録","きろく")}</MotionButton>
-        </div>
-
-        {/* Unlock hints */}
-        {!isTownEditorUnlocked && (
-          <div className="text-xs text-center text-[var(--text)] opacity-40 bg-[var(--bg)] rounded-lg px-2 py-1 shrink-0">
-            {F("漢字","かんじ")}を1つ{F("覚","おぼ")}えると「まちづくり」が{F("使","つか")}えるよ
-          </div>
-        )}
-        {isTownEditorUnlocked && !isCraftUnlocked && (
-          <div className="text-xs text-center text-[var(--text)] opacity-40 bg-[var(--bg)] rounded-lg px-2 py-1 shrink-0">
-            {F("漢字","かんじ")}を3つ{F("覚","おぼ")}えると「クラフト」が{F("使","つか")}えるよ
-          </div>
-        )}
+        <GradeAndAction />
+        <DrillButtons />
+        <SpecialTraining />
+        <NavButtons />
+        <UnlockHints />
       </div>
     </div>
   );

--- a/src/components/ui/MobileBottomNav.jsx
+++ b/src/components/ui/MobileBottomNav.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { Library, Medal, BarChart3, Sparkles, Hammer, Map } from 'lucide-react';
+import { audioCtrl } from '../../systems/audio';
+import { F } from './FormatKun';
+
+/**
+ * モバイル専用ボトムナビゲーション
+ * スマートフォンで主要画面へのアクセスを提供する
+ */
+const MobileBottomNav = ({ setView, currentView, isCraftUnlocked, isTownEditorUnlocked }) => {
+  const navItems = [
+    { key: 'townEditor', icon: Map, label: 'まち', color: 'text-[var(--accent)]', locked: !isTownEditorUnlocked },
+    { key: 'dictionary', icon: Library, label: F("図鑑", "ずかん"), color: 'text-[var(--secondary)]' },
+    { key: 'gacha', icon: Sparkles, label: 'ガチャ', color: 'text-amber-500' },
+    { key: 'achievements', icon: Medal, label: F("実績", "じっせき"), color: 'text-amber-500' },
+    { key: 'stats', icon: BarChart3, label: F("記録", "きろく"), color: 'text-[var(--secondary)]' },
+  ];
+
+  return (
+    <nav
+      className="md:hidden flex-shrink-0 bg-[var(--panel)]/95 backdrop-blur-sm border-t-[3px] border-[var(--text)] z-50 safe-area-bottom"
+      aria-label="メインナビゲーション"
+    >
+      <div className="flex justify-around items-center h-14 px-1">
+        {navItems.map(({ key, icon: Icon, label, color, locked }) => {
+          const isActive = currentView === key;
+          return (
+            <motion.button
+              key={key}
+              whileTap={!locked ? { scale: 0.9 } : {}}
+              onClick={() => {
+                if (locked) return;
+                audioCtrl.playSE('click');
+                setView(key);
+              }}
+              disabled={locked}
+              className={`flex flex-col items-center justify-center gap-0.5 px-2 py-1 rounded-xl transition-all min-w-[56px] touch-manipulation
+                ${locked ? 'opacity-30' : ''}
+                ${isActive ? 'bg-[var(--bg)] scale-105' : 'opacity-70 hover:opacity-100'}
+              `}
+              aria-label={typeof label === 'string' ? label : key}
+              aria-current={isActive ? 'page' : undefined}
+            >
+              <Icon size={20} className={isActive ? color : 'text-[var(--text)]'} />
+              <span className={`text-[10px] font-bold leading-none ${isActive ? 'text-[var(--text)]' : 'text-[var(--text)] opacity-60'}`}>
+                {label}
+              </span>
+            </motion.button>
+          );
+        })}
+      </div>
+    </nav>
+  );
+};
+
+export default MobileBottomNav;

--- a/src/components/ui/PageWrapper.jsx
+++ b/src/components/ui/PageWrapper.jsx
@@ -1,6 +1,6 @@
 import { motion } from 'framer-motion';
 
-const PageWrapper = ({ children, keyName, wide }) => (<motion.div key={keyName} initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: -20 }} transition={{ duration: 0.25 }} className={`absolute inset-0 flex flex-col overflow-y-auto overflow-x-hidden p-4 no-scrollbar ${wide ? '' : ''}`}><div className={`m-auto w-full h-full ${wide ? 'max-w-7xl' : 'max-w-lg'}`}>{children}</div></motion.div>);
+const PageWrapper = ({ children, keyName, wide }) => (<motion.div key={keyName} initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: -20 }} transition={{ duration: 0.25 }} className={`absolute inset-0 flex flex-col overflow-y-auto overflow-x-hidden p-2 md:p-4 no-scrollbar ${wide ? '' : ''}`}><div className={`m-auto w-full h-full ${wide ? 'max-w-7xl' : 'max-w-lg'}`}>{children}</div></motion.div>);
 const FullScreenWrapper = ({ children, keyName }) => (<motion.div key={keyName} initial={{ opacity: 0, scale: 0.98 }} animate={{ opacity: 1, scale: 1 }} exit={{ opacity: 0, scale: 0.98 }} transition={{ duration: 0.25 }} className="absolute inset-0 flex flex-col p-0 md:p-6 overflow-hidden"><div className="w-full h-full max-w-7xl mx-auto flex flex-col">{children}</div></motion.div>);
 
 export { PageWrapper, FullScreenWrapper };

--- a/src/components/ui/index.js
+++ b/src/components/ui/index.js
@@ -7,3 +7,4 @@ export { default as StampEffect } from './StampEffect';
 export { default as Footer } from './Footer';
 export { R, FormatKun } from './FormatKun';
 export { default as OfflineBanner } from './OfflineBanner';
+export { default as MobileBottomNav } from './MobileBottomNav';

--- a/src/hooks/useIsMobile.js
+++ b/src/hooks/useIsMobile.js
@@ -1,0 +1,22 @@
+import { useState, useEffect } from 'react';
+
+const MOBILE_BREAKPOINT = 768;
+
+/**
+ * スマートフォン判定フック
+ * 画面幅768px未満でモバイルとみなす（Tailwindのmdブレークポイントに合わせる）
+ */
+export function useIsMobile() {
+  const [isMobile, setIsMobile] = useState(
+    typeof window !== 'undefined' ? window.innerWidth < MOBILE_BREAKPOINT : false
+  );
+
+  useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    const handler = (e) => setIsMobile(e.matches);
+    mql.addEventListener('change', handler);
+    return () => mql.removeEventListener('change', handler);
+  }, []);
+
+  return isMobile;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -60,3 +60,15 @@ ruby.survival-blank rt {
   color: var(--primary);
   font-weight: 700;
 }
+
+/* モバイルセーフエリア対応（ノッチ・ホームバー） */
+.safe-area-bottom {
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+
+/* モバイルでフッターを非表示（ボトムナビ表示時にスペースを節約） */
+@media (max-width: 767px) {
+  footer {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary\n\n- **モバイル専用レイアウト追加**: タブレット/PCの既存2カラムレイアウトを維持しつつ、スマートフォン(768px未満)では縦積みレイアウトに自動切替\n- **MobileBottomNav**: モバイル時にボトムナビゲーションを表示し、図鑑・ガチャ・実績・記録・まちづくりへワンタップでアクセス\n- **ヘッダー/UI全体のモバイル最適化**: フォントサイズ・パディング・アイコンサイズをモバイル向けにコンパクト化、safe-area-inset対応\n\n## 変更内容\n\n| ファイル | 内容 |\n|---|---|\n| `src/hooks/useIsMobile.js` | matchMediaベースのモバイル判定フック(768pxブレークポイント) |\n| `src/components/ui/MobileBottomNav.jsx` | モバイル専用ボトムナビゲーション |\n| `src/components/pages/HomeView.jsx` | モバイル/PC分岐レイアウト(共通パーツを抽出して構造化) |\n| `src/App.jsx` | useIsMobile統合、ヘッダーレスポンシブ化、MobileBottomNav配置 |\n| `src/components/ui/PageWrapper.jsx` | モバイルでパディング縮小(p-2 → md:p-4) |\n| `src/index.css` | safe-area-bottom対応、モバイルフッター非表示 |\n\n## レイアウト設計\n\n**モバイル (< 768px)**:\n- タウンマップ(35vh) → コントロール(スクロール可能) の縦積み\n- ボトムナビで主要画面へ即アクセス\n- フッター非表示でスペース確保\n\n**タブレット/PC (>= 768px)**:\n- 従来通り: タウンマップ(左) + サイドバー340px(右) の2カラム\n- ナビゲーションボタンはサイドバー内に配置\n\n## Test plan\n\n- [ ] モバイル端末(iPhone/Android)でホーム画面の縦積みレイアウトが正しく表示される\n- [ ] ボトムナビの各ボタンが正しい画面に遷移する\n- [ ] タブレット/PCで従来の2カラムレイアウトが維持されている\n- [ ] 画面回転時にレイアウトが正しく切り替わる\n- [ ] セーフエリア(ノッチ・ホームバー)が正しく考慮されている\n- [ ] セッション/タウンエディタ等のフルスクリーンビューでボトムナビが非表示になる\n\nhttps://claude.ai/code/session_01MFRPh7X9fw5656WhzT59hK