### PR TITLE
fix: モバイルで学習画面がスクロールできない問題を修正

### DIFF
--- a/src/components/session/SessionView.jsx
+++ b/src/components/session/SessionView.jsx
@@ -66,7 +66,7 @@ const SessionView = ({ queue: initialQueue, stats, onUpdateStat, onFinish, onRec
   );
 
   return (
-    <div className="flex-1 bg-[var(--panel)] rounded-[24px] shadow-[6px_6px_0_var(--text)] border-[4px] border-[var(--text)] p-3 md:p-5 flex flex-col h-full overflow-hidden relative">
+    <div className="flex-1 bg-[var(--panel)] rounded-none md:rounded-[24px] shadow-none md:shadow-[6px_6px_0_var(--text)] border-0 md:border-[4px] border-[var(--text)] p-2 md:p-5 flex flex-col h-full overflow-hidden relative">
       <StampEffect stamp={activeStamp} />
       <div className="flex justify-between items-center mb-3 shrink-0">
         <div className="text-[var(--text)] font-bold text-sm bg-[var(--bg)] px-4 py-2 rounded-full border-[3px] border-[var(--text)] shadow-sm flex items-center gap-2">のこり <span className="text-lg font-black">{queue.length}</span> {F("文字","もじ")}</div>

--- a/src/components/ui/ModeLayout.jsx
+++ b/src/components/ui/ModeLayout.jsx
@@ -1,7 +1,7 @@
 const ModeLayout = ({ mainContent, sidebarContent }) => (
-  <div className="flex flex-col md:flex-row flex-1 min-h-0 gap-4 md:gap-6 w-full h-full">
-    <div className="flex-1 bg-[var(--bg)] rounded-[20px] border-[4px] border-[var(--text)] flex items-center justify-center overflow-auto p-2 md:p-6 shadow-inner relative min-h-[40vh] md:min-h-0">{mainContent}</div>
-    <div className="w-full md:w-[360px] flex flex-col shrink-0 h-auto md:h-full overflow-y-auto no-scrollbar pb-6 md:pb-0">{sidebarContent}</div>
+  <div className="flex flex-col md:flex-row flex-1 min-h-0 gap-4 md:gap-6 w-full h-full overflow-y-auto md:overflow-hidden no-scrollbar">
+    <div className="bg-[var(--bg)] rounded-[20px] border-[4px] border-[var(--text)] flex items-center justify-center overflow-auto p-2 md:p-6 shadow-inner relative shrink-0 h-[40vh] min-h-[200px] md:h-auto md:flex-1 md:min-h-0">{mainContent}</div>
+    <div className="w-full md:w-[360px] flex flex-col shrink-0 md:h-full md:overflow-y-auto no-scrollbar pb-6 md:pb-0">{sidebarContent}</div>
   </div>
 );
 


### PR DESCRIPTION
ModeLayoutのモバイル縦積みレイアウトで、メインコンテンツが
flex-1+min-h-[40vh]を占有しサイドバー（次へ進むボタン含む）が
overflow-hiddenで切り取られていた問題を修正。

- ModeLayout: モバイルでメインコンテンツをh-[40vh]固定にし、 コンテナ全体をoverflow-y-autoでスクロール可能に変更
- SessionView: モバイルでボーダー/シャドウ/パディングを縮小し コンテンツ領域を最大化

https://claude.ai/code/session_01MFRPh7X9fw5656WhzT59hK