### PR TITLE
fix: モバイル学習画面のレイアウトを3ゾーン構造に再設計

### DIFF
--- a/src/components/session/ReadMode.jsx
+++ b/src/components/session/ReadMode.jsx
@@ -10,10 +10,10 @@ const ReadMode = ({ kanji, onNext, commonSidebar }) => {
   const [exampleIdx, setExampleIdx] = useState(Math.floor(Math.random() * kanji.examples.length));
   const main = (<div className="text-[12rem] md:text-[18rem] lg:text-[22rem] leading-none font-black text-[var(--text)] drop-shadow-md select-none" style={{ fontFamily: "'Klee One', serif" }}>{kanji.char}</div>);
   const handleNextExample = () => { setExampleIdx((prev) => (prev + 1) % kanji.examples.length); audioCtrl.playSE('click'); };
-  const sidebar = (
+
+  const info = (
     <>
-      {commonSidebar}
-      <div className="flex flex-col gap-4 bg-[var(--panel)] p-4 rounded-2xl border-[4px] border-[var(--text)] shadow-[4px_4px_0_var(--text)] mt-4">
+      <div className="flex flex-col gap-4 bg-[var(--panel)] p-4 rounded-2xl border-[4px] border-[var(--text)] shadow-[4px_4px_0_var(--text)]">
         <div className="bg-[var(--accent)] text-[var(--text)] px-4 py-1.5 rounded-full text-sm font-black border-[3px] border-[var(--text)] text-center shadow-sm -mt-8 mx-auto w-max">{F("声","こえ")}にだそう！</div>
         <div className="relative min-h-[80px] flex items-center justify-center">
           <AnimatePresence mode="wait"><motion.p key={exampleIdx} initial={{ opacity: 0, x: 10 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: -10 }} className="ruby-text text-xl md:text-2xl font-bold text-[var(--text)] text-center py-2"><RubyText text={kanji.examples[exampleIdx]} /></motion.p></AnimatePresence>
@@ -21,7 +21,7 @@ const ReadMode = ({ kanji, onNext, commonSidebar }) => {
         </div>
         {kanji.examples.length > 1 && (<div className="flex justify-center gap-1.5">{kanji.examples.map((_, i) => (<div key={i} className={`w-2 h-2 rounded-full border border-[var(--text)] ${i === exampleIdx ? 'bg-[var(--text)]' : 'bg-transparent'}`} />))}</div>)}
       </div>
-      <div className="flex flex-col gap-3 mt-4">
+      <div className="flex flex-col gap-3">
         <div className="bg-[var(--panel)] rounded-xl px-4 py-3 border-[3px] border-[var(--text)] shadow-sm flex items-start justify-between gap-4">
           <span className="text-sm font-bold text-[var(--primary)] bg-[var(--bg)] px-3 py-1 rounded-lg border-2 border-[var(--primary)] shrink-0">{F("音","おん")}</span>
           <div className="flex flex-wrap gap-1.5 justify-end">{kanji.on.length > 0 ? kanji.on.map((o, i) => (<span key={i} className="font-black text-xl text-[var(--text)] bg-gray-100 px-2 py-0.5 rounded-md border border-gray-300">{o}</span>)) : <span className="font-black text-xl text-gray-400">-</span>}</div>
@@ -31,10 +31,14 @@ const ReadMode = ({ kanji, onNext, commonSidebar }) => {
           <div className="flex flex-wrap gap-1.5 justify-end">{kanji.kun.length > 0 ? kanji.kun.map((k, i) => (<span key={i} className="font-black text-xl text-[var(--text)] bg-gray-100 px-2 py-0.5 rounded-md border border-gray-300"><FormatKun text={k} /></span>)) : <span className="font-black text-xl text-gray-400">-</span>}</div>
         </div>
       </div>
-      <div className="mt-auto pt-4 pb-2"><MotionButton variant="primary" onClick={onNext} className="w-full py-6 text-2xl font-black border-[4px] border-[var(--text)] shadow-[0_6px_0_#9f1239]">{F("書","か")}き{F("順","じゅん")}をみる <ChevronRight size={28} /></MotionButton></div>
     </>
   );
-  return <ModeLayout mainContent={main} sidebarContent={sidebar} />;
+
+  const action = (
+    <MotionButton variant="primary" onClick={onNext} className="w-full py-4 md:py-6 text-xl md:text-2xl font-black border-[4px] border-[var(--text)] shadow-[0_6px_0_#9f1239]">{F("書","か")}き{F("順","じゅん")}をみる <ChevronRight size={28} /></MotionButton>
+  );
+
+  return <ModeLayout mainContent={main} tabsContent={commonSidebar} infoContent={info} actionContent={action} />;
 };
 
 export default ReadMode;

--- a/src/components/session/SessionView.jsx
+++ b/src/components/session/SessionView.jsx
@@ -55,8 +55,8 @@ const SessionView = ({ queue: initialQueue, stats, onUpdateStat, onFinish, onRec
   if (!currentKanji) return null;
 
   const commonSidebarTop = (
-    <div className="flex flex-col gap-3 shrink-0 mb-4">
-      <div className="grid grid-cols-4 lg:grid-cols-2 gap-2">
+    <div className="flex flex-col gap-2 md:gap-3 shrink-0 mb-1 md:mb-4">
+      <div className="grid grid-cols-4 lg:grid-cols-2 gap-1.5 md:gap-2">
         {[{ id: 'read', icon: <Volume2 size={18} />, label: <>{F("音","おん")}{F("読","どく")}</> }, { id: 'watch', icon: <PlayCircle size={18} />, label: <>{F("書","か")}き{F("順","じゅん")}</> }, { id: 'write', icon: <Pencil size={18} />, label: "なぞる" }, { id: 'test', icon: <CheckCircle2 size={18} />, label: "テスト" }].map((t, idx) => {
           const isDisabled = isNew && idx > reachedStep;
           return (<button key={t.id} onClick={() => { if (isDisabled) { audioCtrl.playSE('stamp_bad'); return; } audioCtrl.playSE('click'); setMode(t.id); }} className={`flex flex-col items-center justify-center py-2.5 rounded-xl font-bold text-[10px] sm:text-xs border-[3px] transition-all ${mode === t.id ? "bg-[var(--text)] text-[var(--panel)] border-[var(--text)] shadow-[2px_2px_0_var(--primary)] scale-105" : isDisabled ? "bg-gray-100 text-gray-400 border-gray-300 opacity-50 cursor-not-allowed" : "bg-[var(--panel)] text-[var(--text)] border-[var(--text)] hover:bg-[var(--bg)]"}`}>{t.icon} <span className="mt-1">{t.label}</span></button>);

--- a/src/components/session/TestMode.jsx
+++ b/src/components/session/TestMode.jsx
@@ -169,80 +169,81 @@ const TestMode = ({ kanji, strokeData, onEvaluate, canvasSize, commonSidebar }) 
     </div>
   );
 
-  const sidebar = (
-    <>
-      {commonSidebar}
-      <div className="bg-[var(--panel)] rounded-2xl p-4 text-center border-[4px] border-[var(--text)] shadow-[4px_4px_0_var(--text)] flex flex-col gap-2 mt-4">
-        <div className="text-xs font-bold text-[var(--panel)] bg-[var(--text)] py-1.5 px-4 rounded-full mx-auto w-max mb-1">この{F("漢字","かんじ")}、{F("書","か")}ける？</div>
-        <div className="text-2xl md:text-3xl font-black text-[var(--text)] tracking-wider">
-          {kanji.on.length > 0 ? kanji.on.join(' / ') : ''}
-          {kanji.on.length > 0 && kanji.kun.length > 0 ? ' / ' : ''}
-          {kanji.kun.length > 0 ? kanji.kun.map((k, i) => (<React.Fragment key={i}><FormatKun text={k} />{i < kanji.kun.length - 1 ? ' / ' : ''}</React.Fragment>)) : ''}
-        </div>
+  const info = (
+    <div className="bg-[var(--panel)] rounded-2xl p-3 md:p-4 text-center border-[4px] border-[var(--text)] shadow-[4px_4px_0_var(--text)] flex flex-col gap-2">
+      <div className="text-xs font-bold text-[var(--panel)] bg-[var(--text)] py-1.5 px-4 rounded-full mx-auto w-max mb-1">この{F("漢字","かんじ")}、{F("書","か")}ける？</div>
+      <div className="text-xl md:text-3xl font-black text-[var(--text)] tracking-wider">
+        {kanji.on.length > 0 ? kanji.on.join(' / ') : ''}
+        {kanji.on.length > 0 && kanji.kun.length > 0 ? ' / ' : ''}
+        {kanji.kun.length > 0 ? kanji.kun.map((k, i) => (<React.Fragment key={i}><FormatKun text={k} />{i < kanji.kun.length - 1 ? ' / ' : ''}</React.Fragment>)) : ''}
       </div>
-      <div className="mt-auto pt-4 flex flex-col gap-3 pb-2">
-        {!showAnswer ? (
-          <MotionButton variant="primary" onClick={handleReveal} className="w-full py-8 text-2xl md:text-3xl font-black border-[4px] border-[var(--text)] shadow-[0_6px_0_#9f1239] animate-pulse"><Eye size={32} /> こたえあわせ</MotionButton>
-        ) : (
-          <div className="flex flex-col gap-3 animate-in slide-in-from-bottom-2">
-            {banner ? (
-              <div className="text-center text-sm font-bold py-2 px-3 rounded-xl border-[3px] border-[var(--text)] shadow-sm mb-1" style={{ backgroundColor: banner.color, color: banner.textColor }}>
-                {banner.text}
-              </div>
-            ) : (
-              <div className="text-center text-sm font-bold text-[var(--text)] bg-[var(--accent)] py-2 rounded-xl border-[3px] border-[var(--text)] shadow-sm mb-1">
-                {F("自分","じぶん")}に{F("正直","しょうじき")}に{F("評価","ひょうか")}しよう！
-              </div>
-            )}
-            {recommendedEval && (
-              <div className="text-center text-xs font-bold text-[var(--text)] opacity-70 -mt-1 mb-1">
-                コンピューターの おすすめだよ！ちがうと おもったら ほかのボタンでも OK👌
-              </div>
-            )}
-            <div className="grid grid-cols-1 gap-2">
-              {EVAL_BUTTONS.map(btn => {
-                const isRecommended = recommendedEval === btn.key;
-                const hasRecommendation = recommendedEval !== null;
-                return (
-                  <div key={btn.key} className="relative">
-                    {isRecommended && (
-                      <motion.div
-                        initial={{ scale: 0, opacity: 0 }}
-                        animate={{ scale: 1, opacity: 1 }}
-                        className="absolute -top-2 -right-2 z-10 bg-[var(--accent)] text-[var(--text)] text-[10px] font-black px-2 py-0.5 rounded-full border-2 border-[var(--text)] animate-bounce"
-                      >
-                        👈 おすすめ！
-                      </motion.div>
-                    )}
-                    <MotionButton
-                      variant={btn.variant}
-                      onClick={() => onEvaluate(btn.key)}
-                      className={`w-full font-black border-[var(--text)] ${
-                        isRecommended
-                          ? `py-5 text-2xl border-[4px] ${btn.shadow} ring-4 ring-[var(--accent)] ring-offset-1`
-                          : hasRecommendation
-                            ? `py-3 text-base border-[3px] opacity-60`
-                            : `py-5 text-2xl border-[4px] ${btn.shadow}`
-                      }`}
-                    >
-                      {btn.key === 'good' ? <>{F("書","か")}けた👍</> : btn.key === 'again' ? <>{F("忘","わす")}れた💦</> : btn.label}
-                      <span className="text-sm font-bold opacity-70 ml-1">
-                        （{btn.key === 'easy' ? <>{F("次回","じかい")}：4{F("日後","にちご")}〜</> :
-                          btn.key === 'good' ? <>{F("次回","じかい")}：{F("翌日","よくじつ")}〜</> :
-                          btn.key === 'hard' ? <>{F("次回","じかい")}：まもなく</> :
-                          <>もう{F("一度","いちど")}</>}）
-                      </span>
-                    </MotionButton>
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-        )}
-      </div>
-    </>
+    </div>
   );
-  return <ModeLayout mainContent={main} sidebarContent={sidebar} />;
+
+  const action = (
+    <div className="flex flex-col gap-2 md:gap-3">
+      {!showAnswer ? (
+        <MotionButton variant="primary" onClick={handleReveal} className="w-full py-5 md:py-8 text-xl md:text-3xl font-black border-[4px] border-[var(--text)] shadow-[0_6px_0_#9f1239] animate-pulse"><Eye size={28} /> こたえあわせ</MotionButton>
+      ) : (
+        <div className="flex flex-col gap-2 md:gap-3 animate-in slide-in-from-bottom-2">
+          {banner ? (
+            <div className="text-center text-sm font-bold py-2 px-3 rounded-xl border-[3px] border-[var(--text)] shadow-sm" style={{ backgroundColor: banner.color, color: banner.textColor }}>
+              {banner.text}
+            </div>
+          ) : (
+            <div className="text-center text-sm font-bold text-[var(--text)] bg-[var(--accent)] py-2 rounded-xl border-[3px] border-[var(--text)] shadow-sm">
+              {F("自分","じぶん")}に{F("正直","しょうじき")}に{F("評価","ひょうか")}しよう！
+            </div>
+          )}
+          {recommendedEval && (
+            <div className="text-center text-[10px] md:text-xs font-bold text-[var(--text)] opacity-70">
+              コンピューターの おすすめだよ！ちがうと おもったら ほかのボタンでも OK👌
+            </div>
+          )}
+          <div className="grid grid-cols-2 md:grid-cols-1 gap-2">
+            {EVAL_BUTTONS.map(btn => {
+              const isRecommended = recommendedEval === btn.key;
+              const hasRecommendation = recommendedEval !== null;
+              return (
+                <div key={btn.key} className="relative">
+                  {isRecommended && (
+                    <motion.div
+                      initial={{ scale: 0, opacity: 0 }}
+                      animate={{ scale: 1, opacity: 1 }}
+                      className="absolute -top-2 -right-2 z-10 bg-[var(--accent)] text-[var(--text)] text-[10px] font-black px-2 py-0.5 rounded-full border-2 border-[var(--text)] animate-bounce"
+                    >
+                      おすすめ！
+                    </motion.div>
+                  )}
+                  <MotionButton
+                    variant={btn.variant}
+                    onClick={() => onEvaluate(btn.key)}
+                    className={`w-full font-black border-[var(--text)] ${
+                      isRecommended
+                        ? `py-3 md:py-5 text-base md:text-2xl border-[4px] ${btn.shadow} ring-4 ring-[var(--accent)] ring-offset-1`
+                        : hasRecommendation
+                          ? `py-2 md:py-3 text-sm md:text-base border-[3px] opacity-60`
+                          : `py-3 md:py-5 text-base md:text-2xl border-[4px] ${btn.shadow}`
+                    }`}
+                  >
+                    {btn.key === 'good' ? <>{F("書","か")}けた👍</> : btn.key === 'again' ? <>{F("忘","わす")}れた💦</> : btn.label}
+                    <span className="text-[10px] md:text-sm font-bold opacity-70 ml-1">
+                      （{btn.key === 'easy' ? <>{F("次回","じかい")}：4{F("日後","にちご")}〜</> :
+                        btn.key === 'good' ? <>{F("次回","じかい")}：{F("翌日","よくじつ")}〜</> :
+                        btn.key === 'hard' ? <>{F("次回","じかい")}：まもなく</> :
+                        <>もう{F("一度","いちど")}</>}）
+                    </span>
+                  </MotionButton>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+
+  return <ModeLayout mainContent={main} tabsContent={commonSidebar} infoContent={info} actionContent={action} />;
 };
 
 export default TestMode;

--- a/src/components/session/WatchMode.jsx
+++ b/src/components/session/WatchMode.jsx
@@ -21,20 +21,22 @@ const WatchMode = ({ paths, strokeData, isLoading, onNext, canvasSize, commonSid
       <style>{`@keyframes drawStroke { to { stroke-dashoffset: 0; } } @keyframes fadeIn { to { opacity: 1; } }`}</style>
     </div>
   );
-  const sidebar = (
-    <>
-      {commonSidebar}
-      <div className="bg-[var(--panel)] p-4 rounded-2xl border-[4px] border-[var(--text)] shadow-[4px_4px_0_var(--text)] text-center flex flex-col gap-2 mt-4">
-        <div className="text-base font-black text-[var(--panel)] bg-[var(--secondary)] py-2 rounded-xl border-[3px] border-[var(--text)] shadow-sm mx-2">1{F("画","かく")}ずつ よく{F("見","み")}よう！</div>
-        <p className="text-xs md:text-sm text-[var(--text)] font-bold opacity-70 px-2 mt-2 leading-relaxed">{F("正","ただ")}しい{F("書","か")}き{F("順","じゅん")}で{F("書","か")}くと、<br />{F("漢字","かんじ")}がきれいに{F("書","か")}けるようになるよ。</p>
-      </div>
-      <div className="mt-auto pt-4 flex flex-col gap-3 pb-2">
-        <MotionButton variant="secondary" onClick={() => setKey(k => k + 1)} className="py-4 text-lg border-[3px] border-[var(--text)] shadow-[0_4px_0_var(--text)]"><RefreshCw size={20} /> もう{F("一度","いちど")}みる</MotionButton>
-        <MotionButton variant="primary" onClick={onNext} className="w-full py-6 text-2xl font-black border-[4px] border-[var(--text)] shadow-[0_6px_0_#9f1239]">なぞり{F("書","が")}きへ <ChevronRight size={28} /></MotionButton>
-      </div>
-    </>
+
+  const info = (
+    <div className="bg-[var(--panel)] p-3 md:p-4 rounded-2xl border-[4px] border-[var(--text)] shadow-[4px_4px_0_var(--text)] text-center flex flex-col gap-2">
+      <div className="text-base font-black text-[var(--panel)] bg-[var(--secondary)] py-2 rounded-xl border-[3px] border-[var(--text)] shadow-sm mx-2">1{F("画","かく")}ずつ よく{F("見","み")}よう！</div>
+      <p className="text-xs md:text-sm text-[var(--text)] font-bold opacity-70 px-2 mt-1 md:mt-2 leading-relaxed">{F("正","ただ")}しい{F("書","か")}き{F("順","じゅん")}で{F("書","か")}くと、<br />{F("漢字","かんじ")}がきれいに{F("書","か")}けるようになるよ。</p>
+    </div>
   );
-  return <ModeLayout mainContent={main} sidebarContent={sidebar} />;
+
+  const action = (
+    <div className="flex flex-col gap-2 md:gap-3">
+      <MotionButton variant="secondary" onClick={() => setKey(k => k + 1)} className="py-3 md:py-4 text-base md:text-lg border-[3px] border-[var(--text)] shadow-[0_4px_0_var(--text)]"><RefreshCw size={20} /> もう{F("一度","いちど")}みる</MotionButton>
+      <MotionButton variant="primary" onClick={onNext} className="w-full py-4 md:py-6 text-xl md:text-2xl font-black border-[4px] border-[var(--text)] shadow-[0_6px_0_#9f1239]">なぞり{F("書","が")}きへ <ChevronRight size={28} /></MotionButton>
+    </div>
+  );
+
+  return <ModeLayout mainContent={main} tabsContent={commonSidebar} infoContent={info} actionContent={action} />;
 };
 
 export default WatchMode;

--- a/src/components/session/WriteMode.jsx
+++ b/src/components/session/WriteMode.jsx
@@ -52,7 +52,6 @@ const WriteMode = ({ paths, strokeData, crossMatrix, onNext, canvasSize, commonS
 
   const handleStart = (e) => {
     e.preventDefault(); audioCtrl.init(); if (currentStrokeRef.current >= paths.length) return;
-    // FIX: guard against missing strokeData
     if (!strokeData[currentStrokeRef.current]) return;
     const { x, y } = getCoords(e); const target = strokeData[currentStrokeRef.current].s;
     if (Math.hypot(x / canvasSize - target.x, y / canvasSize - target.y) > STROKE_THRESHOLDS.START_POINT) { setStatusMsg("かきはじめが ちがうよ💦"); audioCtrl.playSE('stamp_bad'); return; }
@@ -66,7 +65,6 @@ const WriteMode = ({ paths, strokeData, crossMatrix, onNext, canvasSize, commonS
   };
   const handleEnd = (e) => {
     if (e && e.type !== 'mouseleave') e.preventDefault(); if (!isDrawingRef.current) return; setIsDrawing(false);
-    // FIX: guard against missing strokeData
     if (!strokeData[currentStrokeRef.current]) return;
     const target = strokeData[currentStrokeRef.current].e; const currentDist = Math.hypot(lastPos.current.x / canvasSize - target.x, lastPos.current.y / canvasSize - target.y);
     if (currentDist < STROKE_THRESHOLDS.END_POINT) {
@@ -78,7 +76,6 @@ const WriteMode = ({ paths, strokeData, crossMatrix, onNext, canvasSize, commonS
           if (!pastPoints) continue;
           const pastNormalized = pastPoints.map(p => ({ x: p.x / canvasSize, y: p.y / canvasSize }));
           const isUserCrossed = Analyzer.checkCross(pastNormalized, normalizedPoints);
-          // FIX: safe crossMatrix access
           const isExpectedCrossed = crossMatrix[currentStrokeRef.current]?.[pastIdx] ?? false;
           if (isUserCrossed !== isExpectedCrossed) { isError = true; errMsg = isUserCrossed ? "ちがう画を つきぬけているよ💦" : "ほかの画と まじわっていないよ💦"; break; }
         }
@@ -115,36 +112,37 @@ const WriteMode = ({ paths, strokeData, crossMatrix, onNext, canvasSize, commonS
     </div>
   );
 
-  const sidebar = (
+  const info = (
     <>
-      {commonSidebar}
-      <div className="bg-[var(--panel)] p-3 rounded-2xl border-[4px] border-[var(--text)] shadow-[4px_4px_0_var(--text)] flex flex-col gap-2 shrink-0">
+      <div className="bg-[var(--panel)] p-2 md:p-3 rounded-2xl border-[4px] border-[var(--text)] shadow-[4px_4px_0_var(--text)] flex flex-col gap-2 shrink-0">
         <div className="flex justify-between items-center bg-[var(--bg)] p-2 rounded-xl border-[2px] border-[var(--text)]">
           <span className="text-sm font-bold text-[var(--text)] pl-2">{count < 2 ? <>なぞり{F("書","が")}き</> : count < 5 ? <>{F("手","て")}{F("書","が")}き ({F("手本","てほん")}あり)</> : <>{F("空書","からが")}き ({F("手本","てほん")}なし)</>}</span><div className="text-sm font-black bg-[var(--text)] text-[var(--panel)] px-3 py-1 rounded-lg shadow-sm">{count + 1} {F("回目","かいめ")}</div>
         </div>
         <div className={`text-sm font-black px-3 py-2 rounded-xl border-[2px] border-[var(--text)] text-center shadow-sm transition-colors ${statusMsg.includes('💦') ? 'bg-[var(--primary)] text-[var(--panel)]' : statusMsg.includes('💮') ? 'bg-[var(--secondary)] text-[var(--panel)]' : 'bg-white text-[var(--text)]'}`}>{statusMsg}</div>
       </div>
       {history.length > 0 && (
-        <div className="bg-[var(--panel)] p-2 rounded-2xl border-[4px] border-[var(--text)] shadow-[4px_4px_0_var(--text)] flex flex-col gap-1 shrink-0 mt-2">
+        <div className="bg-[var(--panel)] p-2 rounded-2xl border-[4px] border-[var(--text)] shadow-[4px_4px_0_var(--text)] flex flex-col gap-1 shrink-0">
           <span className="text-[10px] font-bold text-[var(--text)] px-1">これまでに{F("書","か")}いた{F("字","じ")}</span>
           <div className="flex gap-2 overflow-x-auto pb-1 no-scrollbar">
             {history.map((img, idx) => (<div key={idx} className="w-14 h-14 shrink-0 bg-[var(--bg)] border-2 border-[var(--text)] rounded-lg overflow-hidden relative flex items-center justify-center"><span className="absolute top-0.5 left-1 text-[8px] font-black text-[var(--text)] opacity-40">{idx + 1}</span><img src={img} className="w-full h-full object-contain p-1" alt={`try ${idx + 1}`} /></div>))}
           </div>
         </div>
       )}
-      <div className="mt-auto pt-2 flex flex-col gap-2 pb-2 shrink-0">
-        <div className="flex gap-2">
-          <MotionButton variant="secondary" onClick={undoLastStroke} disabled={currentStroke <= 0 || isDrawing} className={`py-2 text-sm border-[2px] border-[var(--text)] flex-1 shadow-[0_2px_0_var(--text)] ${currentStroke <= 0 ? 'opacity-40' : ''}`}><Undo2 size={16} /> 1{F("画","かく")}もどす</MotionButton>
-          <MotionButton variant="secondary" onClick={resetPractice} disabled={currentStroke <= 0 || isDrawing} className={`py-2 text-sm border-[2px] border-[var(--text)] flex-1 shadow-[0_2px_0_var(--text)] ${currentStroke <= 0 ? 'opacity-40' : ''}`}><Trash2 size={16} /> ぜんぶけす</MotionButton>
-        </div>
-        <div className="flex flex-col gap-2 w-full mt-1">
-          <MotionButton variant={currentStroke >= paths.length ? "primary" : "secondary"} disabled={currentStroke < paths.length} onClick={handleNextTry} className={`w-full py-6 text-2xl font-black border-[4px] border-[var(--text)] ${currentStroke >= paths.length ? 'shadow-[0_6px_0_#9f1239] animate-pulse' : 'opacity-50'}`}><Pencil size={24} /> もう1{F("回","かい")}{F("書","か")}く！</MotionButton>
-          <AnimatePresence>{history.length >= 2 && (<motion.div initial={{ opacity: 0, height: 0 }} animate={{ opacity: 1, height: 'auto' }} exit={{ opacity: 0, height: 0 }}><MotionButton variant="success" onClick={onNext} className={`w-full py-4 text-xl font-black border-[4px] border-[var(--text)] shadow-[0_4px_0_#065f46]`}>テストへ{F("進","すす")}む！ <ChevronRight size={24} /></MotionButton></motion.div>)}</AnimatePresence>
-        </div>
-      </div>
     </>
   );
-  return <ModeLayout mainContent={main} sidebarContent={sidebar} />;
+
+  const action = (
+    <div className="flex flex-col gap-2 shrink-0">
+      <div className="flex gap-2">
+        <MotionButton variant="secondary" onClick={undoLastStroke} disabled={currentStroke <= 0 || isDrawing} className={`py-2 text-sm border-[2px] border-[var(--text)] flex-1 shadow-[0_2px_0_var(--text)] ${currentStroke <= 0 ? 'opacity-40' : ''}`}><Undo2 size={16} /> 1{F("画","かく")}もどす</MotionButton>
+        <MotionButton variant="secondary" onClick={resetPractice} disabled={currentStroke <= 0 || isDrawing} className={`py-2 text-sm border-[2px] border-[var(--text)] flex-1 shadow-[0_2px_0_var(--text)] ${currentStroke <= 0 ? 'opacity-40' : ''}`}><Trash2 size={16} /> ぜんぶけす</MotionButton>
+      </div>
+      <MotionButton variant={currentStroke >= paths.length ? "primary" : "secondary"} disabled={currentStroke < paths.length} onClick={handleNextTry} className={`w-full py-4 md:py-6 text-xl md:text-2xl font-black border-[4px] border-[var(--text)] ${currentStroke >= paths.length ? 'shadow-[0_6px_0_#9f1239] animate-pulse' : 'opacity-50'}`}><Pencil size={24} /> もう1{F("回","かい")}{F("書","か")}く！</MotionButton>
+      <AnimatePresence>{history.length >= 2 && (<motion.div initial={{ opacity: 0, height: 0 }} animate={{ opacity: 1, height: 'auto' }} exit={{ opacity: 0, height: 0 }}><MotionButton variant="success" onClick={onNext} className={`w-full py-3 md:py-4 text-lg md:text-xl font-black border-[4px] border-[var(--text)] shadow-[0_4px_0_#065f46]`}>テストへ{F("進","すす")}む！ <ChevronRight size={24} /></MotionButton></motion.div>)}</AnimatePresence>
+    </div>
+  );
+
+  return <ModeLayout mainContent={main} tabsContent={commonSidebar} infoContent={info} actionContent={action} />;
 };
 
 export default WriteMode;

--- a/src/components/ui/ModeLayout.jsx
+++ b/src/components/ui/ModeLayout.jsx
@@ -1,8 +1,56 @@
-const ModeLayout = ({ mainContent, sidebarContent }) => (
-  <div className="flex flex-col md:flex-row flex-1 min-h-0 gap-4 md:gap-6 w-full h-full overflow-y-auto md:overflow-hidden no-scrollbar">
-    <div className="bg-[var(--bg)] rounded-[20px] border-[4px] border-[var(--text)] flex items-center justify-center overflow-auto p-2 md:p-6 shadow-inner relative shrink-0 h-[40vh] min-h-[200px] md:h-auto md:flex-1 md:min-h-0">{mainContent}</div>
-    <div className="w-full md:w-[360px] flex flex-col shrink-0 md:h-full md:overflow-y-auto no-scrollbar pb-6 md:pb-0">{sidebarContent}</div>
-  </div>
+/**
+ * 学習モード共通レイアウト
+ *
+ * モバイル（< md）:
+ *   ┌──────────────────────┐
+ *   │  tabsContent (固定)   │  ← モード切替タブ
+ *   ├──────────────────────┤
+ *   │  mainContent          │
+ *   │  infoContent          │  ← スクロール可能
+ *   ├──────────────────────┤
+ *   │  actionContent (固定)  │  ← 次へ進むボタン等
+ *   └──────────────────────┘
+ *
+ * タブレット / PC（>= md）:
+ *   ┌────────────┬─────────┐
+ *   │            │ tabs    │
+ *   │  main      │ info    │
+ *   │  Content   │ action  │
+ *   └────────────┴─────────┘
+ */
+const ModeLayout = ({ mainContent, tabsContent, infoContent, actionContent }) => (
+  <>
+    {/* ── Desktop / Tablet ── */}
+    <div className="hidden md:flex md:flex-row flex-1 min-h-0 gap-6 w-full h-full">
+      <div className="flex-1 bg-[var(--bg)] rounded-[20px] border-[4px] border-[var(--text)] flex items-center justify-center overflow-auto p-6 shadow-inner relative min-h-0">
+        {mainContent}
+      </div>
+      <div className="w-[360px] flex flex-col shrink-0 h-full overflow-y-auto no-scrollbar">
+        {tabsContent}
+        {infoContent}
+        {actionContent && <div className="mt-auto pt-4 pb-2">{actionContent}</div>}
+      </div>
+    </div>
+
+    {/* ── Mobile ── */}
+    <div className="flex md:hidden flex-col flex-1 min-h-0 w-full h-full">
+      {/* タブ — 常に表示 */}
+      {tabsContent && <div className="shrink-0">{tabsContent}</div>}
+
+      {/* メインコンテンツ + 情報パネル — スクロール可能 */}
+      <div className="flex-1 flex flex-col min-h-0 overflow-y-auto no-scrollbar gap-3 py-2">
+        <div className="bg-[var(--bg)] rounded-[16px] border-[3px] border-[var(--text)] flex items-center justify-center overflow-hidden p-2 shadow-inner relative shrink-0 mx-auto w-full" style={{ maxHeight: '45vh', minHeight: '180px' }}>
+          {mainContent}
+        </div>
+        {infoContent && <div className="flex flex-col gap-3">{infoContent}</div>}
+      </div>
+
+      {/* アクションボタン — 常に表示 */}
+      {actionContent && (
+        <div className="shrink-0 pt-1 pb-1">{actionContent}</div>
+      )}
+    </div>
+  </>
 );
 
 export default ModeLayout;


### PR DESCRIPTION
学習画面（音読・書き順・なぞる・テスト）のモバイルレイアウトを
「タブ固定／コンテンツスクロール／アクションボタン固定」の
3ゾーン構造に再設計し、操作ボタンが常に画面内に表示されるように修正。

ModeLayout:
- 新API: tabsContent / mainContent / infoContent / actionContent の4スロット
- モバイル: タブ上部固定、メイン+情報スクロール、アクション下部固定
- PC/タブレット: 従来通り左右2カラム（タブ+情報+アクションがサイドバー）

ReadMode / WatchMode / WriteMode / TestMode:
- sidebar一括渡しから、tabs/info/actionの3分割渡しに変更
- モバイルでボタンサイズ・パディングを調整
- TestMode: 評価ボタンをモバイルで2列グリッドに変更

SessionView:
- モードタブのギャップ・マージンをモバイル向けにコンパクト化

https://claude.ai/code/session_01MFRPh7X9fw5656WhzT59hK