### PR TITLE
fix: オフライン学習を可能にするKanjiVGデータの事前キャッシュ

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import { AnimatePresence } from 'framer-motion';
 import { PenTool, Volume2, VolumeX, Settings, Users } from 'lucide-react';
 import { useOnlineStatus } from './hooks/useOnlineStatus';
 import { useIsMobile } from './hooks/useIsMobile';
+import { usePrefetchKanji } from './hooks/usePrefetchKanji';
 import OfflineBanner from './components/ui/OfflineBanner';
 import MobileBottomNav from './components/ui/MobileBottomNav';
 
@@ -124,6 +125,9 @@ export default function App() {
   const [seenHints, setSeenHints] = useState(stats.seenHints || []);
   const isOnline = useOnlineStatus();
   const isMobile = useIsMobile();
+
+  // オンライン時に対象学年の漢字筆順データを事前キャッシュ（オフライン学習対応）
+  usePrefetchKanji(isOnline, stats.targetGrade, KANJI_DATA);
 
   const levelInfo = useMemo(() => getLevelInfo(stats.totalExp, stats.townMap), [stats.totalExp, stats.townMap]);
 

--- a/src/components/ui/OfflineBanner.jsx
+++ b/src/components/ui/OfflineBanner.jsx
@@ -1,11 +1,20 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { WifiOff } from 'lucide-react';
+import { getCachedKanjiCount } from '../../systems/kanjiVg';
 
 /**
  * オフライン状態を画面上部に固定表示するバナー
- * GIGAスクール端末でネットワーク断が発生した際に子供に分かりやすく通知
+ * キャッシュ状況に応じてメッセージを切り替える
  */
 export default function OfflineBanner() {
+  const [cachedCount, setCachedCount] = useState(null);
+
+  useEffect(() => {
+    getCachedKanjiCount().then(setCachedCount).catch(() => setCachedCount(0));
+  }, []);
+
+  const hasCachedData = cachedCount !== null && cachedCount > 0;
+
   return (
     <div
       role="status"
@@ -18,7 +27,11 @@ export default function OfflineBanner() {
       }}
     >
       <WifiOff size={16} strokeWidth={3} />
-      <span>オフラインモード — ネットなしでもべんきょうできるよ！</span>
+      <span>
+        {hasCachedData
+          ? `オフラインモード — ダウンロードずみの ${cachedCount}もじ でべんきょうできるよ！`
+          : 'オフラインモード — ネットにつないで もじデータを ダウンロードしてね'}
+      </span>
     </div>
   );
 }

--- a/src/hooks/usePrefetchKanji.js
+++ b/src/hooks/usePrefetchKanji.js
@@ -1,0 +1,31 @@
+import { useEffect, useRef } from 'react';
+import { prefetchKanjiVg } from '../systems/kanjiVg';
+
+/**
+ * オンライン時に対象学年の漢字データをバックグラウンドで事前キャッシュする
+ * @param {boolean} isOnline - オンライン状態
+ * @param {number} targetGrade - 対象学年
+ * @param {Array<{char: string, grade: number}>} kanjiData - 全漢字データ
+ */
+export function usePrefetchKanji(isOnline, targetGrade, kanjiData) {
+  const hasPrefetched = useRef(new Set());
+
+  useEffect(() => {
+    if (!isOnline || !targetGrade || !kanjiData?.length) return;
+    if (hasPrefetched.current.has(targetGrade)) return;
+    hasPrefetched.current.add(targetGrade);
+
+    // 対象学年の漢字をフィルタ
+    const gradeKanji = kanjiData.filter(k => k.grade <= targetGrade);
+
+    // バックグラウンドで実行（UIをブロックしない）
+    const timer = setTimeout(() => {
+      prefetchKanjiVg(gradeKanji).catch(() => {
+        // 失敗時は次回オンライン時にリトライできるようフラグを解除
+        hasPrefetched.current.delete(targetGrade);
+      });
+    }, 3000); // アプリ起動後3秒待ってから開始
+
+    return () => clearTimeout(timer);
+  }, [isOnline, targetGrade, kanjiData]);
+}

--- a/src/systems/idb-cache.js
+++ b/src/systems/idb-cache.js
@@ -75,6 +75,24 @@ export async function idbSet(key, value) {
 }
 
 /**
+ * IndexedDBに保存されている全キーを取得する
+ * @returns {Promise<string[]>} キーの配列
+ */
+export async function idbGetAllKeys() {
+  try {
+    const db = await openDB();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readonly');
+      const req = tx.objectStore(STORE_NAME).getAllKeys();
+      req.onsuccess = () => resolve(req.result ?? []);
+      req.onerror = () => reject(req.error);
+    });
+  } catch {
+    return [];
+  }
+}
+
+/**
  * localStorageからIndexedDBへキャッシュデータを一括移行する
  * 旧バージョンで蓄積されたlocalStorageのキャッシュを
  * IndexedDBに移行し、localStorage容量を解放する

--- a/src/systems/kanjiVg.js
+++ b/src/systems/kanjiVg.js
@@ -3,7 +3,7 @@
 // 三層キャッシュ: メモリ → IndexedDB → ネットワーク
 // タイムアウト・リトライ・指数バックオフ対応
 // ==========================================
-import { idbGet, idbSet, migrateFromLocalStorage } from './idb-cache';
+import { idbGet, idbSet, idbGetAllKeys, migrateFromLocalStorage } from './idb-cache';
 import { KANJI_VG } from '../constants/gameConfig';
 
 const LEGACY_STORAGE_KEY = 'kanji_vg_cache';
@@ -136,4 +136,54 @@ export async function fetchKanjiVg(char) {
   idbSet(hex, pathStrings);
 
   return { paths: pathStrings, strokeData: buildStrokeData(pathStrings) };
+}
+
+/**
+ * 指定された漢字リストのKanjiVG SVGデータをバックグラウンドで事前キャッシュする
+ * オンライン時に呼び出し、オフライン学習に備える
+ *
+ * @param {Array<{char: string}>} kanjiList - 漢字オブジェクトの配列
+ * @returns {Promise<{cached: number, total: number}>} キャッシュ結果
+ */
+export async function prefetchKanjiVg(kanjiList) {
+  // 既にキャッシュ済みのキーを取得
+  const cachedKeys = new Set(await idbGetAllKeys());
+  const uncached = kanjiList.filter(k => {
+    const hex = k.char.charCodeAt(0).toString(16).padStart(5, '0');
+    return !memoryCache.has(hex) && !cachedKeys.has(hex);
+  });
+
+  let cached = kanjiList.length - uncached.length;
+  for (const k of uncached) {
+    // オフラインになったら中断
+    if (!navigator.onLine) break;
+    const hex = k.char.charCodeAt(0).toString(16).padStart(5, '0');
+    try {
+      const res = await fetchWithTimeout(
+        `${KANJI_VG.CDN_URL}/${hex}.svg`,
+        KANJI_VG.FETCH_TIMEOUT
+      );
+      if (res.ok) {
+        const text = await res.text();
+        const pathStrings = extractPathStrings(text);
+        memoryCache.set(hex, pathStrings);
+        await idbSet(hex, pathStrings);
+        cached++;
+      }
+    } catch {
+      // 個別の失敗は無視して次へ
+    }
+    // サーバー負荷軽減のため少し間隔を空ける
+    await new Promise(r => setTimeout(r, 50));
+  }
+  return { cached, total: kanjiList.length };
+}
+
+/**
+ * キャッシュ済み漢字数を取得する
+ * @returns {Promise<number>}
+ */
+export async function getCachedKanjiCount() {
+  const keys = await idbGetAllKeys();
+  return keys.length;
 }


### PR DESCRIPTION
## Summary

- オフラインモードで漢字の筆順学習ができない問題を修正
- オンライン時に対象学年の漢字KanjiVG SVGデータをバックグラウンドで自動ダウンロード・IndexedDBにキャッシュ
- OfflineBannerの表示を改善し、キャッシュ済み文字数を表示して正確なオフライン対応状況を通知

## 原因

漢字の筆順データ（SVG）はCDN（cdn.jsdelivr.net）から取得されますが、Service Workerのプリキャッシュ対象に含まれておらず、一度もオンラインで表示していない漢字はオフラインで利用できませんでした。バナーには「ネットなしでもべんきょうできるよ！」と表示されていましたが、実際にはキャッシュ済みの漢字しか学習できない状態でした。

## 変更内容

- `idb-cache.js`: `idbGetAllKeys()` を追加（キャッシュ済みキーの一括取得）
- `kanjiVg.js`: `prefetchKanjiVg()` と `getCachedKanjiCount()` を追加
- `usePrefetchKanji.js`: アプリ起動3秒後にバックグラウンドプリフェッチを開始するフック
- `App.jsx`: `usePrefetchKanji` フックを統合
- `OfflineBanner.jsx`: キャッシュ状況に応じたメッセージ表示に変更

## Test plan

- [ ] オンライン状態でアプリを開き、数秒後にDevToolsのIndexedDBにKanjiVGデータが蓄積されることを確認
- [ ] 十分なデータがキャッシュされた後、オフラインに切り替えて学習モード（書き順・なぞり・テスト）が動作することを確認
- [ ] オフライン時のバナーにキャッシュ済み文字数が表示されることを確認
- [ ] キャッシュが空の状態でオフラインにした場合、適切な警告メッセージが表示されることを確認

https://claude.ai/code/session_01FczT7KixvmoiZbLidb1LzH