### PR TITLE
fix: 1分ごとの日付チェックによる不要な再レンダリングを修正

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -132,8 +132,15 @@ export default function App() {
   const levelInfo = useMemo(() => getLevelInfo(stats.totalExp, stats.townMap), [stats.totalExp, stats.townMap]);
 
   // ログインボーナス＆デイリーミッション初期化関数
-  const refreshDailyData = useCallback((currentStats) => {
+  const refreshDailyData = useCallback((currentStats, isInitial = false) => {
     const today = getTodayString();
+
+    // 日付が変わっていなければ何もしない（初回ロード時を除く）
+    const dateChanged = currentStats.dailyMissionsDate !== today
+      || currentStats.lastLoginBonusDate !== today
+      || currentStats.lastCollectionDate !== today;
+    if (!isInitial && !dateChanged) return;
+
     let updatedStats = { ...currentStats };
     let needsSave = false;
 
@@ -143,7 +150,7 @@ export default function App() {
       setDailyMissions(missions);
       updatedStats = { ...updatedStats, dailyMissions: missions, dailyMissionsDate: today };
       needsSave = true;
-    } else {
+    } else if (isInitial) {
       setDailyMissions(updatedStats.dailyMissions || []);
     }
 
@@ -179,7 +186,7 @@ export default function App() {
 
   // 初回ロード時
   useEffect(() => {
-    refreshDailyData(stats);
+    refreshDailyData(stats, true);
   }, []);
 
   // 日付変更の監視（開きっぱなし対策）


### PR DESCRIPTION
## Summary

- `refreshDailyData` が1分ごとのタイマーで呼ばれるたびに、日付が変わっていなくても `setDailyMissions(updatedStats.dailyMissions || [])` で新しい配列参照を生成していた
- これにより App 全体が再レンダリングされ、トップページのマップや ExpBar が毎分再描画・再配置される現象が発生していた
- 日付が変わっていない場合は早期リターンするように修正し、不要な再レンダリングを防止

## Test plan

- [ ] トップページを開いたまま1分以上放置し、マップやExpBarが不要に再描画されないことを確認
- [ ] 日付をまたいだ際にログインボーナス・デイリーミッション・住民収集が正常に動作することを確認
- [ ] 初回ロード時にデイリーミッションが正しく表示されることを確認

https://claude.ai/code/session_019QHn9QmjJJfWCHnY1DJra6