### PR TITLE
Fix deployment issues: URL cleanup, chunk errors, and SPA routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && cp dist/index.html dist/404.html",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
 // マイ漢字タウン Service Worker
 // 戦略キャッシュでGIGAスクール端末のオフライン環境に完全対応
-const CACHE_VERSION = 2;
+const CACHE_VERSION = 3;
 const CACHE_STATIC = `kanji-town-static-v${CACHE_VERSION}`;
 const CACHE_KANJIVG = `kanji-town-kanjivg-v${CACHE_VERSION}`;
 const CACHE_FONTS = `kanji-town-fonts-v${CACHE_VERSION}`;
@@ -79,17 +79,22 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
-  // ── ナビゲーション: Network-first → キャッシュ → オフラインページ ──
+  // ── ナビゲーション(SPA): Network-first → キャッシュ(ルート) → オフラインページ ──
+  // SPAなので全てのナビゲーションをルートページ(index.html)で処理する
   if (request.mode === 'navigate') {
     event.respondWith(
       fetch(request)
         .then((response) => {
-          const clone = response.clone();
-          caches.open(CACHE_STATIC).then((cache) => cache.put(request, clone));
+          // 200のみキャッシュ（404等をキャッシュしない）
+          if (response.ok) {
+            const clone = response.clone();
+            caches.open(CACHE_STATIC).then((cache) => cache.put(BASE, clone));
+          }
           return response;
         })
         .catch(() =>
-          caches.match(request).then((cached) =>
+          // オフライン時はルートページのキャッシュで応答（SPA対応）
+          caches.match(BASE).then((cached) =>
             cached || caches.match(BASE + 'offline.html')
           )
         )

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,11 +3,32 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
 
+// ── URLクリーンアップ: 不正なサブパス（/KANJI_Town/undefined等）をルートに戻す ──
+const BASE_PATH = '/KANJI_Town/';
+if (window.location.pathname !== BASE_PATH && window.location.pathname.startsWith(BASE_PATH)) {
+  // サブパスが存在する場合、クエリパラメータを維持しつつルートにリダイレクト
+  window.history.replaceState({}, '', BASE_PATH + window.location.search);
+}
+
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <App />
   </React.StrictMode>
 );
+
+// ── Viteチャンク読み込みエラー対策 ──
+// 新デプロイ後に古いチャンクが消えた場合、1回だけリロードして最新を取得
+window.addEventListener('vite:preloadError', (event) => {
+  const reloaded = sessionStorage.getItem('kanji_town_chunk_reload');
+  if (!reloaded) {
+    sessionStorage.setItem('kanji_town_chunk_reload', '1');
+    event.preventDefault();
+    window.location.reload();
+  }
+  // 2回目以降はリロードしない（無限ループ防止）
+});
+// リロード後にフラグをクリア（正常読み込み成功時）
+sessionStorage.removeItem('kanji_town_chunk_reload');
 
 // ── Service Worker 登録（PWA対応 + 自動更新） ──
 if ('serviceWorker' in navigator) {
@@ -22,6 +43,14 @@ if ('serviceWorker' in navigator) {
 
         newSW.addEventListener('statechange', () => {
           if (newSW.state === 'activated' && navigator.serviceWorker.controller) {
+            // リロードループ防止: 短時間に複数回リロードしない
+            const lastReload = sessionStorage.getItem('kanji_town_sw_reload');
+            const now = Date.now();
+            if (lastReload && now - Number(lastReload) < 10000) {
+              return; // 10秒以内の再リロードを防止
+            }
+            sessionStorage.setItem('kanji_town_sw_reload', String(now));
+
             // 新SWが有効化 → デバウンス中のデータを即時保存してからリロード
             import('./systems/storage').then(({ StorageAPI }) => {
               try { StorageAPI.saveStatsImmediate(StorageAPI.getStats()); } catch { /* ignore */ }


### PR DESCRIPTION
## Summary
This PR addresses multiple deployment and runtime issues to improve stability on GIGAスクール environments and production deployments. The changes focus on URL handling, chunk loading resilience, Service Worker caching strategy, and SPA routing.

## Key Changes

- **URL Cleanup**: Added logic to redirect invalid subpaths (e.g., `/KANJI_Town/undefined`) back to the base path while preserving query parameters
- **Vite Chunk Error Handling**: Implemented automatic single-reload recovery when old chunks are missing after deployment, with infinite loop prevention via sessionStorage flag
- **Service Worker Reload Loop Prevention**: Added 10-second debounce to prevent rapid successive reloads when new Service Worker activates
- **SPA Navigation Caching**: Updated Service Worker fetch strategy to:
  - Only cache successful (200) responses for navigation requests
  - Route all navigation requests through root `index.html` (proper SPA behavior)
  - Fall back to cached root page or offline page when offline
- **Build Process**: Added automatic `404.html` generation from `index.html` to support client-side routing on static hosts
- **Cache Version Bump**: Incremented Service Worker cache version from 2 to 3 to invalidate old caches

## Implementation Details

- URL cleanup runs before React initialization to ensure clean state
- Chunk reload flag is cleared on successful load to avoid persistent state issues
- Service Worker reload debounce uses timestamp comparison to allow reloads after 10 seconds
- SPA routing fix ensures all navigation requests resolve through the root page, enabling proper client-side routing
- 404.html copy in build script enables hosting on platforms that require this pattern for SPA routing

https://claude.ai/code/session_01A4HMizTh3hQvu9EvUdRLb5