### PR TITLE
学習画面のレスポンシブ化と継続学習導線の改善

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#ef4444" />
     <meta name="description" content="漢字を覚えて街をつくろう！小学生向け漢字学習アプリ" />
     <meta name="mobile-web-app-capable" content="yes" />

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build && cp dist/index.html dist/404.html",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --test"
   },
   "dependencies": {
     "framer-motion": "^12.36.0",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
 // マイ漢字タウン Service Worker
 // 戦略キャッシュでGIGAスクール端末のオフライン環境に完全対応
-const CACHE_VERSION = 4;
+const CACHE_VERSION = 5;
 const CACHE_STATIC = `kanji-town-static-v${CACHE_VERSION}`;
 const CACHE_KANJIVG = `kanji-town-kanjivg-v${CACHE_VERSION}`;
 const CACHE_FONTS = `kanji-town-fonts-v${CACHE_VERSION}`;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ import MobileBottomNav from './components/ui/MobileBottomNav';
 
 import { StorageAPI, getLevelInfo } from './systems/storage';
 import { calculateNextReview, migrateCard } from './systems/srs';
+import { buildLearningPlan } from './systems/learning-plan';
 import { audioCtrl } from './systems/audio';
 import { checkLevelUp, grantExpWithLevelRewards } from './utils/level-system';
 import { SESSION, EXP, RARE_DROP, ECONOMY, DEBOUNCE, TEST } from './constants/gameConfig';
@@ -193,7 +194,7 @@ export default function App() {
           updated.dailyMissionsDate = today;
         }
         if (willCollect && updated.lastCollectionDate !== today) {
-          updated = StorageAPI.updateDaily(updated, 0, { reviewedCount: 0, perfectCount: 0 });
+          updated = StorageAPI.collectDailyTownResources(updated, today);
           if (updated.lastCollectionResult) {
             const sat = updated.satisfaction || 0;
             setResidentCollectionResult({
@@ -304,25 +305,16 @@ export default function App() {
   };
 
   const startSession = (selectedGrade) => {
-    audioCtrl.init(); const now = Date.now();
+    audioCtrl.init();
     const sessionSize = stats.settings?.sessionSize || 'normal';
     const limits = SESSION.SIZE_LIMITS[sessionSize] || SESSION.SIZE_LIMITS.normal;
-    const reviewLimit = limits.review;
-    const newLimit = limits.new;
-    const reviewTargets = KANJI_DATA
-      .filter(k => {
-        const s = stats.kanjiStats?.[k.id];
-        return s && s.status !== 'new' && (s.nextReview || 0) <= now;
-      })
-      .sort((a, b) => (stats.kanjiStats?.[a.id]?.nextReview || 0) - (stats.kanjiStats?.[b.id]?.nextReview || 0))
-      .slice(0, reviewLimit);
-    const newTargets = KANJI_DATA
-      .filter(k => k.grade === selectedGrade && (!stats.kanjiStats?.[k.id] || stats.kanjiStats[k.id].status === 'new'))
-      .sort(() => Math.random() - 0.5)
-      .slice(0, newLimit);
+    const { queue } = buildLearningPlan({
+      kanjiData: KANJI_DATA,
+      kanjiStats: stats.kanjiStats,
+      selectedGrade,
+      limits,
+    });
     const expMultiplier = getSatisfactionMultiplier(calculateSatisfaction(stats));
-    const queue = reviewTargets.length > 0 ? reviewTargets : newTargets;
-    if (queue.length === 0) { const fallback = KANJI_DATA.find(k => k.grade === selectedGrade); if (fallback) queue.push(fallback); }
     if (queue.length > 0) {
       setSessionData(createInitialSessionData({ queue, oldExp: stats.totalExp, expMultiplier }));
       setView('session');
@@ -407,7 +399,7 @@ export default function App() {
   const handleUpdateStat = (kanjiObj, evalType) => {
     const id = kanjiObj.id;
     const cur = migrateCard(stats.kanjiStats?.[id]);
-    if (sessionData.isDrill) { setSessionData(d => ({ ...d, earnedExp: d.earnedExp + (evalType === 'again' ? 0 : EXP.DRILL), reviewedCount: (d.reviewedCount || 0) + 1 })); return evalType !== 'again'; }
+    if (sessionData.isDrill) { setSessionData(d => ({ ...d, earnedExp: d.earnedExp + (evalType === 'again' ? 0 : EXP.DRILL), reviewedCount: (d.reviewedCount || 0) + (evalType === 'again' ? 0 : 1) })); return evalType !== 'again'; }
 
     const next = calculateNextReview(cur, evalType);
     const wasNew = cur.status === 'new';
@@ -461,7 +453,7 @@ export default function App() {
     setSessionData(d => ({
       ...d,
       earnedExp: d.earnedExp + exp,
-      reviewedCount: (d.reviewedCount || 0) + 1,
+      reviewedCount: (d.reviewedCount || 0) + (evalType === 'again' ? 0 : 1),
       newKanjiCount: (d.newKanjiCount || 0) + (wasNew ? 1 : 0),
       masteredCount: (d.masteredCount || 0) + (isMastering && cur.status !== 'mastered' ? 1 : 0),
       unlockedItems: unlockedItem ? [...d.unlockedItems, unlockedItem] : d.unlockedItems,

--- a/src/components/pages/HomeView.jsx
+++ b/src/components/pages/HomeView.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { motion } from 'framer-motion';
-import { Coins, TrendingUp, PenTool, FileText, Download, AlertCircle, Zap, Flame, Ghost, Library, Map, Medal, BarChart3, ShieldAlert, Users, Hammer, Lock, Sparkles } from 'lucide-react';
+import { Coins, TrendingUp, PenTool, FileText, Download, AlertCircle, Zap, Flame, Ghost, Library, Map, Medal, BarChart3, ShieldAlert, Users, Hammer, Lock, Sparkles, Target, CheckCircle2 } from 'lucide-react';
 import { MotionButton } from '../ui';
 import DraggableTownMap from '../town/DraggableTownMap';
 import DailyMissionsPanel from '../tutorial/DailyMissionsPanel';
@@ -11,6 +11,9 @@ import { StorageAPI, calculateProsperity, getLevelInfo } from '../../systems/sto
 import { audioCtrl } from '../../systems/audio';
 import { F } from '../ui/FormatKun';
 import { calculateSatisfaction, getSatisfactionLabel } from '../../systems/residents';
+import { getDailyLearningProgress } from '../../systems/learning-plan';
+import { getTodayString } from '../../utils/date-utils';
+import { SESSION } from '../../constants/gameConfig';
 
 const HomeView = ({ setView, stats, setStats, startSession, startFlashcard, startSurvival, startBossBattle, levelInfo, dailyMissions, onClaimMission, isMobile }) => {
   const currentLevelInfo = levelInfo || getLevelInfo(stats.totalExp, stats.townMap);
@@ -23,6 +26,15 @@ const HomeView = ({ setView, stats, setStats, startSession, startFlashcard, star
     return s && s.status !== 'new' && (s.nextReview || 0) <= now;
   }).length;
   const isReviewNeeded = reviewTargetsCount > 0;
+  const dailyProgress = getDailyLearningProgress(stats, getTodayString());
+  const sessionSize = stats.settings?.sessionSize || 'normal';
+  const sessionLimits = SESSION.SIZE_LIMITS[sessionSize] || SESSION.SIZE_LIMITS.normal;
+  const newTargetsCount = KANJI_DATA.filter(k => {
+    const s = stats.kanjiStats?.[k.id];
+    return k.grade === selectedGrade && (!s || s.status === 'new');
+  }).length;
+  const plannedReviewCount = Math.min(reviewTargetsCount, sessionLimits.review);
+  const plannedNewCount = Math.min(newTargetsCount, sessionLimits.new);
   const prosperity = calculateProsperity(stats.townMap, reviewTargetsCount);
   const learnedCount = KANJI_DATA.filter(k => stats.kanjiStats?.[k.id] && stats.kanjiStats[k.id].status !== 'new').length;
   const isSpecialTrainingUnlocked = learnedCount > 0;
@@ -77,6 +89,31 @@ const HomeView = ({ setView, stats, setStats, startSession, startFlashcard, star
     </div>
   );
 
+  /** 毎日の学習習慣を一目で把握できる進捗カード */
+  const DailyGoalCard = () => (
+    <div className={`bg-[var(--panel)] border-[3px] border-[var(--text)] rounded-2xl p-2.5 md:p-3 shadow-[2px_2px_0_var(--text)] shrink-0 ${dailyProgress.isComplete ? 'ring-2 ring-emerald-300' : ''}`}>
+      <div className="flex items-center justify-between gap-3 mb-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <div className={`w-8 h-8 rounded-xl border-2 border-[var(--text)] flex items-center justify-center shrink-0 ${dailyProgress.isComplete ? 'bg-emerald-400' : 'bg-[var(--accent)]'}`}>
+            {dailyProgress.isComplete ? <CheckCircle2 size={18} /> : <Target size={18} />}
+          </div>
+          <div className="min-w-0">
+            <div className="text-xs md:text-sm font-black text-[var(--text)] truncate">{dailyProgress.isComplete ? 'きょうの目標クリア！' : 'きょうの学習目標'}</div>
+            <div className="text-[10px] font-bold text-[var(--text)] opacity-55">🔥 {stats.streak || 0}日れんぞく</div>
+          </div>
+        </div>
+        <div className="font-black text-[var(--text)] shrink-0"><span className="text-lg text-[var(--primary)]">{dailyProgress.reviewed}</span><span className="text-xs opacity-50"> / {dailyProgress.goal}字</span></div>
+      </div>
+      <div className="h-3 bg-gray-200 rounded-full overflow-hidden border-2 border-[var(--text)]" role="progressbar" aria-label="今日の学習目標" aria-valuemin="0" aria-valuemax={dailyProgress.goal} aria-valuenow={Math.min(dailyProgress.reviewed, dailyProgress.goal)}>
+        <motion.div initial={{ width: 0 }} animate={{ width: `${dailyProgress.percent}%` }} className={`h-full ${dailyProgress.isComplete ? 'bg-emerald-400' : 'bg-[var(--primary)]'}`} />
+      </div>
+      <div className="flex justify-between mt-1.5 text-[10px] font-bold text-[var(--text)] opacity-60">
+        <span>{dailyProgress.isComplete ? 'よくがんばりました！' : `あと ${dailyProgress.remaining}字でクリア`}</span>
+        <span>{reviewTargetsCount > 0 ? `復習 ${reviewTargetsCount}字` : '復習は完了'}</span>
+      </div>
+    </div>
+  );
+
   /** タウンマップ */
   const TownMap = ({ className = '' }) => (
     <div
@@ -109,7 +146,11 @@ const HomeView = ({ setView, stats, setStats, startSession, startFlashcard, star
         ))}
       </div>
       <MotionButton variant={isReviewNeeded ? "danger" : "primary"} className="w-full py-3 md:py-4 text-base md:text-lg font-black border-[3px] border-[var(--text)] shadow-[0_3px_0_rgba(0,0,0,0.3)]" onClick={() => startSession(selectedGrade)}>
-        {isReviewNeeded ? <><ShieldAlert size={20} /> おばけを たいじする！</> : <><PenTool size={20} /> {selectedGrade}{F("年生","ねんせい")}の{F("漢字","かんじ")}を{F("覚","おぼ")}える！</>}
+        {isReviewNeeded
+          ? <><ShieldAlert size={20} /> {F("復習","ふくしゅう")}{plannedReviewCount}＋{F("新出","しんしゅつ")}{plannedNewCount}</>
+          : plannedNewCount > 0
+            ? <><PenTool size={20} /> {F("新出","しんしゅつ")}{F("漢字","かんじ")}{plannedNewCount}{F("文字","もじ")}を{F("覚","おぼ")}える！</>
+            : <><PenTool size={20} /> {selectedGrade}{F("年生","ねんせい")}の{F("漢字","かんじ")}を{F("練習","れんしゅう")}！</>}
       </MotionButton>
     </div>
   );
@@ -175,9 +216,10 @@ const HomeView = ({ setView, stats, setStats, startSession, startFlashcard, star
         {/* ステータスバー */}
         <StatusBar />
         <ExpBar />
+        <DailyGoalCard />
 
         {/* タウンマップ（コンパクト） */}
-        <TownMap className="h-[35vh] min-h-[180px] shrink-0" />
+        <TownMap className="h-[30vh] min-h-[160px] shrink-0" />
 
         {/* コントロール（スクロール可能） */}
         <div className="flex-1 flex flex-col gap-2 overflow-y-auto no-scrollbar pb-2">
@@ -209,6 +251,8 @@ const HomeView = ({ setView, stats, setStats, startSession, startFlashcard, star
 
       {/* === RIGHT: Controls === */}
       <div className="w-[340px] shrink-0 flex flex-col gap-2 h-full overflow-y-auto no-scrollbar">
+        <DailyGoalCard />
+
         {/* Daily missions */}
         {dailyMissions && dailyMissions.length > 0 && (
           <div className="shrink-0">

--- a/src/components/pages/SettingsView.jsx
+++ b/src/components/pages/SettingsView.jsx
@@ -5,6 +5,7 @@ import { MotionButton } from '../ui';
 import { StorageAPI } from '../../systems/storage';
 import { audioCtrl } from '../../systems/audio';
 import { F } from '../ui/FormatKun';
+import { DAILY_GOAL_OPTIONS, getDailyGoal } from '../../systems/learning-plan';
 
 // 手動テーマ選択肢
 const THEME_OPTIONS = [
@@ -68,6 +69,7 @@ const SettingsView = ({ setView, stats, setStats, isMuted, setIsMuted, levelInfo
   const autoPlay = settings.autoPlay !== false;
   const showFurigana = settings.showFurigana !== false;
   const sessionSize = settings.sessionSize || 'normal';
+  const dailyGoal = getDailyGoal(settings);
 
   const updateSettings = (patch) => {
     const newSettings = { ...settings, ...patch };
@@ -254,6 +256,22 @@ const SettingsView = ({ setView, stats, setStats, isMuted, setIsMuted, levelInfo
                   <button key={s.id} onClick={() => { audioCtrl.playSE('click'); updateSettings({ sessionSize: s.id }); }} className={`flex-1 py-2 rounded-xl border-[3px] transition-all text-center ${isActive ? 'border-[var(--primary)] bg-[var(--primary)]/10 shadow-[2px_2px_0_var(--primary)]' : 'border-[var(--text)]/20'}`}>
                     <div className="text-xs font-black text-[var(--text)]">{s.label}</div>
                     <div className="text-[9px] text-[var(--text)] opacity-50">{s.desc}</div>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div>
+            <div className="text-sm font-bold text-[var(--text)] mb-1">1{F("日","にち")}の{F("学習","がくしゅう")}{F("目標","もくひょう")}</div>
+            <div className="text-[10px] text-[var(--text)] opacity-50 mb-2">ホームに{F("表示","ひょうじ")}する、むりなく{F("続","つづ")}けるためのめやす</div>
+            <div className="grid grid-cols-3 gap-2">
+              {DAILY_GOAL_OPTIONS.map((goal) => {
+                const isActive = dailyGoal === goal;
+                return (
+                  <button key={goal} onClick={() => { audioCtrl.playSE('click'); updateSettings({ dailyGoal: goal }); }} className={`py-2.5 rounded-xl border-[3px] transition-all text-center ${isActive ? 'border-[var(--secondary)] bg-[var(--secondary)]/10 shadow-[2px_2px_0_var(--secondary)]' : 'border-[var(--text)]/20'}`}>
+                    <div className="text-base font-black text-[var(--text)]">{goal}<span className="text-[10px] ml-0.5">字</span></div>
+                    <div className="text-[9px] text-[var(--text)] opacity-50">{goal === 5 ? 'ゆったり' : goal === 10 ? 'おすすめ' : 'しっかり'}</div>
                   </button>
                 );
               })}

--- a/src/components/session/ReadMode.jsx
+++ b/src/components/session/ReadMode.jsx
@@ -6,9 +6,9 @@ import ModeLayout from '../ui/ModeLayout';
 import { FormatKun, RubyText, F } from '../ui/FormatKun';
 import { audioCtrl } from '../../systems/audio';
 
-const ReadMode = ({ kanji, onNext, commonSidebar }) => {
+const ReadMode = ({ kanji, onNext, commonSidebar, isStacked }) => {
   const [exampleIdx, setExampleIdx] = useState(Math.floor(Math.random() * kanji.examples.length));
-  const main = (<div className="text-[12rem] md:text-[18rem] lg:text-[22rem] leading-none font-black text-[var(--text)] drop-shadow-md select-none" style={{ fontFamily: "'Klee One', serif" }}>{kanji.char}</div>);
+  const main = (<div className="text-[clamp(10rem,30vmin,22rem)] leading-none font-black text-[var(--text)] drop-shadow-md select-none" style={{ fontFamily: "'Klee One', serif" }}>{kanji.char}</div>);
   const handleNextExample = () => { setExampleIdx((prev) => (prev + 1) % kanji.examples.length); audioCtrl.playSE('click'); };
 
   const info = (
@@ -38,7 +38,7 @@ const ReadMode = ({ kanji, onNext, commonSidebar }) => {
     <MotionButton variant="primary" onClick={onNext} className="w-full py-4 md:py-6 text-xl md:text-2xl font-black border-[4px] border-[var(--text)] shadow-[0_6px_0_#9f1239]">{F("書","か")}き{F("順","じゅん")}をみる <ChevronRight size={28} /></MotionButton>
   );
 
-  return <ModeLayout mainContent={main} tabsContent={commonSidebar} infoContent={info} actionContent={action} />;
+  return <ModeLayout mainContent={main} tabsContent={commonSidebar} infoContent={info} actionContent={action} isStacked={isStacked} />;
 };
 
 export default ReadMode;

--- a/src/components/session/SessionView.jsx
+++ b/src/components/session/SessionView.jsx
@@ -10,16 +10,11 @@ import TestMode from './TestMode';
 import { Analyzer } from '../../systems/analyzer';
 import { fetchKanjiVg } from '../../systems/kanjiVg';
 import { F } from '../ui/FormatKun';
+import { useLearningViewport } from '../../hooks/useLearningViewport';
 
 const SessionView = ({ queue: initialQueue, stats, onUpdateStat, onFinish, onRecordPerfect, onRecordEasy }) => {
   const [queue, setQueue] = useState(initialQueue); const [mode, setMode] = useState('read'); const [paths, setPaths] = useState([]); const [strokeData, setStrokeData] = useState([]); const [crossMatrix, setCrossMatrix] = useState([]); const [isLoading, setIsLoading] = useState(false);
-  // モバイルでは画面幅の 80% を使う（最小 300px・最大 360px）。デスクトップは 400px 固定。
-  const [canvasSize] = useState(() => {
-    if (typeof window === 'undefined') return 400;
-    const w = window.innerWidth;
-    if (w >= 768) return 400;
-    return Math.max(300, Math.min(360, Math.floor(w * 0.8)));
-  });
+  const { canvasSize, isStacked } = useLearningViewport();
   const [activeStamp, setActiveStamp] = useState(null); const [combo, setCombo] = useState(0); const [reachedStep, setReachedStep] = useState(0);
   const currentKanji = queue[0]; const isNew = !stats[currentKanji?.id] || stats[currentKanji?.id].status === 'new'; const MODES = useMemo(() => ['read', 'watch', 'write', 'test'], []);
   const [fetchError, setFetchError] = useState(null);
@@ -84,7 +79,7 @@ const SessionView = ({ queue: initialQueue, stats, onUpdateStat, onFinish, onRec
 
   const commonSidebarTop = (
     <div className="flex flex-col gap-2 md:gap-3 shrink-0 mb-1 md:mb-4">
-      <div className="grid grid-cols-4 lg:grid-cols-2 gap-1.5 md:gap-2">
+      <div className={`grid ${isStacked ? 'grid-cols-4' : 'grid-cols-2'} gap-1.5 md:gap-2`}>
         {[{ id: 'read', icon: <Volume2 size={18} />, label: <>{F("音","おん")}{F("読","どく")}</> }, { id: 'watch', icon: <PlayCircle size={18} />, label: <>{F("書","か")}き{F("順","じゅん")}</> }, { id: 'write', icon: <Pencil size={18} />, label: "なぞる" }, { id: 'test', icon: <CheckCircle2 size={18} />, label: "テスト" }].map((t, idx) => {
           const isDisabled = isNew && idx > reachedStep;
           return (
@@ -106,14 +101,17 @@ const SessionView = ({ queue: initialQueue, stats, onUpdateStat, onFinish, onRec
   );
 
   return (
-    <div className="flex-1 bg-[var(--panel)] rounded-none md:rounded-[24px] shadow-none md:shadow-[6px_6px_0_var(--text)] border-0 md:border-[4px] border-[var(--text)] p-2 md:p-5 flex flex-col h-full overflow-hidden relative">
+    <div className="flex-1 bg-[var(--panel)] rounded-none md:rounded-[24px] shadow-none md:shadow-[6px_6px_0_var(--text)] border-0 md:border-[4px] border-[var(--text)] p-2 md:p-4 xl:p-5 flex flex-col h-full overflow-hidden relative">
       <StampEffect stamp={activeStamp} />
-      <div className="flex justify-between items-center mb-3 shrink-0">
-        <div className="text-[var(--text)] font-bold text-sm bg-[var(--bg)] px-4 py-2 rounded-full border-[3px] border-[var(--text)] shadow-sm flex items-center gap-2">のこり <span className="text-lg font-black">{queue.length}</span> {F("文字","もじ")}</div>
+      <div className="flex justify-between items-center mb-1.5 md:mb-2 shrink-0 gap-2">
+        <div className="text-[var(--text)] font-bold text-xs md:text-sm bg-[var(--bg)] px-2.5 md:px-4 py-1.5 md:py-2 rounded-full border-[3px] border-[var(--text)] shadow-sm flex items-center gap-1.5" aria-live="polite">のこり <span className="text-base md:text-lg font-black">{queue.length}</span> {F("文字","もじ")}</div>
         <div className="flex gap-2">
-          {combo > 1 && <motion.div initial={{ scale: 0 }} animate={{ scale: 1 }} className="text-[var(--text)] font-black text-sm bg-[var(--accent)] px-4 py-2 rounded-full border-[3px] border-[var(--text)] shadow-sm flex items-center gap-1">{combo} COMBO 🔥</motion.div>}
-          {isNew && <div className="text-[var(--panel)] font-bold text-sm bg-[var(--primary)] px-4 py-2 rounded-full flex items-center gap-1 border-[3px] border-[var(--text)] shadow-sm"><Star size={16} /> {F("新出","しんしゅつ")}</div>}
+          {combo > 1 && <motion.div initial={{ scale: 0 }} animate={{ scale: 1 }} className="text-[var(--text)] font-black text-xs md:text-sm bg-[var(--accent)] px-2.5 md:px-4 py-1.5 md:py-2 rounded-full border-[3px] border-[var(--text)] shadow-sm flex items-center gap-1">{combo} COMBO 🔥</motion.div>}
+          {isNew && <div className="text-[var(--panel)] font-bold text-xs md:text-sm bg-[var(--primary)] px-2.5 md:px-4 py-1.5 md:py-2 rounded-full flex items-center gap-1 border-[3px] border-[var(--text)] shadow-sm"><Star size={15} /> {F("新出","しんしゅつ")}</div>}
         </div>
+      </div>
+      <div className="h-2 shrink-0 rounded-full bg-[var(--bg)] border-2 border-[var(--text)] overflow-hidden mb-1.5 md:mb-2" aria-label={`学習の進み具合 ${Math.max(0, initialQueue.length - queue.length)} / ${initialQueue.length}`}>
+        <motion.div className="h-full bg-[var(--secondary)]" animate={{ width: `${Math.max(0, ((initialQueue.length - queue.length) / initialQueue.length) * 100)}%` }} />
       </div>
       <div className="flex-1 min-h-0 w-full relative">
         {fetchError ? (
@@ -142,10 +140,10 @@ const SessionView = ({ queue: initialQueue, stats, onUpdateStat, onFinish, onRec
           </div>
         ) : (
           <>
-            {mode === 'read' && <ReadMode kanji={currentKanji} onNext={() => setMode('watch')} commonSidebar={commonSidebarTop} />}
-            {mode === 'watch' && <WatchMode paths={paths} strokeData={strokeData} isLoading={isLoading} onNext={() => setMode('write')} canvasSize={canvasSize} commonSidebar={commonSidebarTop} />}
-            {mode === 'write' && <WriteMode paths={paths} strokeData={strokeData} crossMatrix={crossMatrix} onNext={() => setMode('test')} canvasSize={canvasSize} commonSidebar={commonSidebarTop} onRecordPerfect={onRecordPerfect} />}
-            {mode === 'test' && <TestMode kanji={currentKanji} strokeData={strokeData} onEvaluate={handleEvaluation} canvasSize={canvasSize} commonSidebar={commonSidebarTop} />}
+            {mode === 'read' && <ReadMode kanji={currentKanji} onNext={() => setMode('watch')} commonSidebar={commonSidebarTop} isStacked={isStacked} />}
+            {mode === 'watch' && <WatchMode paths={paths} strokeData={strokeData} isLoading={isLoading} onNext={() => setMode('write')} canvasSize={canvasSize} commonSidebar={commonSidebarTop} isStacked={isStacked} />}
+            {mode === 'write' && <WriteMode paths={paths} strokeData={strokeData} crossMatrix={crossMatrix} onNext={() => setMode('test')} canvasSize={canvasSize} commonSidebar={commonSidebarTop} onRecordPerfect={onRecordPerfect} isStacked={isStacked} />}
+            {mode === 'test' && <TestMode kanji={currentKanji} strokeData={strokeData} onEvaluate={handleEvaluation} canvasSize={canvasSize} commonSidebar={commonSidebarTop} isStacked={isStacked} />}
           </>
         )}
       </div>

--- a/src/components/session/TestMode.jsx
+++ b/src/components/session/TestMode.jsx
@@ -32,7 +32,7 @@ const EVAL_BUTTONS = [
   { key: 'again', variant: 'danger', label: '忘れた💦', hint: 'もう一度', shadow: 'shadow-[0_4px_0_#334155]' },
 ];
 
-const TestMode = ({ kanji, strokeData, onEvaluate, canvasSize, commonSidebar }) => {
+const TestMode = ({ kanji, strokeData, onEvaluate, canvasSize, commonSidebar, isStacked }) => {
   const [showAnswer, setShowAnswer] = useState(false);
   const canvasRef = useRef(null);
   const [isDrawing, setIsDrawing] = useState(false);
@@ -243,7 +243,7 @@ const TestMode = ({ kanji, strokeData, onEvaluate, canvasSize, commonSidebar }) 
     </div>
   );
 
-  return <ModeLayout mainContent={main} tabsContent={commonSidebar} infoContent={info} actionContent={action} />;
+  return <ModeLayout mainContent={main} tabsContent={commonSidebar} infoContent={info} actionContent={action} isStacked={isStacked} />;
 };
 
 export default TestMode;

--- a/src/components/session/WatchMode.jsx
+++ b/src/components/session/WatchMode.jsx
@@ -4,7 +4,7 @@ import MotionButton from '../ui/MotionButton';
 import ModeLayout from '../ui/ModeLayout';
 import { F } from '../ui/FormatKun';
 
-const WatchMode = ({ paths, strokeData, isLoading, onNext, canvasSize, commonSidebar }) => {
+const WatchMode = ({ paths, strokeData, isLoading, onNext, canvasSize, commonSidebar, isStacked }) => {
   const [key, setKey] = useState(0);
   const main = isLoading ? <div className="animate-pulse font-bold text-2xl text-[var(--text)] opacity-50">ロード中...</div> : (
     <div className="relative border-[4px] border-[var(--text)] rounded-[20px] bg-[var(--panel)] transition-all duration-200 shrink-0 shadow-[8px_8px_0_var(--text)]" style={{ width: canvasSize, maxWidth: '100%', maxHeight: '100%', aspectRatio: '1/1' }}>
@@ -36,7 +36,7 @@ const WatchMode = ({ paths, strokeData, isLoading, onNext, canvasSize, commonSid
     </div>
   );
 
-  return <ModeLayout mainContent={main} tabsContent={commonSidebar} infoContent={info} actionContent={action} />;
+  return <ModeLayout mainContent={main} tabsContent={commonSidebar} infoContent={info} actionContent={action} isStacked={isStacked} />;
 };
 
 export default WatchMode;

--- a/src/components/session/WriteMode.jsx
+++ b/src/components/session/WriteMode.jsx
@@ -9,7 +9,7 @@ import { audioCtrl } from '../../systems/audio';
 import { F } from '../ui/FormatKun';
 import { STROKE_THRESHOLDS } from '../../constants/strokeConfig';
 
-const WriteMode = ({ paths, strokeData, crossMatrix, onNext, canvasSize, commonSidebar, onRecordPerfect }) => {
+const WriteMode = ({ paths, strokeData, crossMatrix, onNext, canvasSize, commonSidebar, onRecordPerfect, isStacked }) => {
   const guideRef = useRef(null); const inkRef = useRef(null); const writeRef = useRef(null);
   const [currentStroke, setCurrentStroke] = useState(0); const [isDrawing, setIsDrawing] = useState(false);
   const [count, setCount] = useState(0); const [statusMsg, setStatusMsg] = useState("１かくめ をかこう！");
@@ -142,7 +142,7 @@ const WriteMode = ({ paths, strokeData, crossMatrix, onNext, canvasSize, commonS
     </div>
   );
 
-  return <ModeLayout mainContent={main} tabsContent={commonSidebar} infoContent={info} actionContent={action} />;
+  return <ModeLayout mainContent={main} tabsContent={commonSidebar} infoContent={info} actionContent={action} isStacked={isStacked} />;
 };
 
 export default WriteMode;

--- a/src/components/ui/ModeLayout.jsx
+++ b/src/components/ui/ModeLayout.jsx
@@ -22,23 +22,8 @@
  * レンダリングすると ref が最後の DOM 要素を指してしまい描画が壊れる。
  * そのため JS でレイアウトを切り替え、canvas は常に1か所だけ描画する。
  */
-import { useState, useEffect } from 'react';
-
-const useIsMobile = () => {
-  const [isMobile, setIsMobile] = useState(() => window.innerWidth < 768);
-  useEffect(() => {
-    const mq = window.matchMedia('(max-width: 767px)');
-    const handler = (e) => setIsMobile(e.matches);
-    mq.addEventListener('change', handler);
-    return () => mq.removeEventListener('change', handler);
-  }, []);
-  return isMobile;
-};
-
-const ModeLayout = ({ mainContent, tabsContent, infoContent, actionContent }) => {
-  const isMobile = useIsMobile();
-
-  if (isMobile) {
+const ModeLayout = ({ mainContent, tabsContent, infoContent, actionContent, isStacked }) => {
+  if (isStacked) {
     return (
       <div className="flex flex-col flex-1 min-h-0 w-full h-full">
         {/* タブ — 常に表示 */}
@@ -46,7 +31,7 @@ const ModeLayout = ({ mainContent, tabsContent, infoContent, actionContent }) =>
 
         {/* メインコンテンツ + 情報パネル — スクロール可能 */}
         <div className="flex-1 flex flex-col min-h-0 overflow-y-auto no-scrollbar gap-3 py-2">
-          <div className="bg-[var(--bg)] rounded-[16px] border-[3px] border-[var(--text)] flex items-center justify-center overflow-hidden p-2 shadow-inner relative shrink-0 mx-auto w-full" style={{ maxHeight: '45vh', minHeight: '180px' }}>
+          <div className="bg-[var(--bg)] rounded-[16px] border-[3px] border-[var(--text)] flex items-center justify-center overflow-hidden p-2 shadow-inner relative shrink-0 mx-auto w-full h-[min(50dvh,560px)] min-h-[220px] max-h-[560px]">
             {mainContent}
           </div>
           {infoContent && <div className="flex flex-col gap-3">{infoContent}</div>}
@@ -61,11 +46,11 @@ const ModeLayout = ({ mainContent, tabsContent, infoContent, actionContent }) =>
   }
 
   return (
-    <div className="flex flex-row flex-1 min-h-0 gap-6 w-full h-full">
-      <div className="flex-1 bg-[var(--bg)] rounded-[20px] border-[4px] border-[var(--text)] flex items-center justify-center overflow-auto p-6 shadow-inner relative min-h-0">
+    <div className="flex flex-row flex-1 min-h-0 gap-3 lg:gap-5 xl:gap-6 w-full h-full">
+      <div className="flex-1 bg-[var(--bg)] rounded-[20px] border-[4px] border-[var(--text)] flex items-center justify-center overflow-auto p-3 lg:p-5 xl:p-6 shadow-inner relative min-h-0">
         {mainContent}
       </div>
-      <div className="w-[360px] flex flex-col shrink-0 h-full overflow-y-auto no-scrollbar">
+      <div className="w-[clamp(280px,28vw,360px)] flex flex-col shrink-0 h-full overflow-y-auto no-scrollbar">
         {tabsContent}
         {infoContent}
         {actionContent && <div className="mt-auto pt-4 pb-2">{actionContent}</div>}

--- a/src/components/ui/PageWrapper.jsx
+++ b/src/components/ui/PageWrapper.jsx
@@ -1,6 +1,6 @@
 import { motion } from 'framer-motion';
 
 const PageWrapper = ({ children, keyName, wide }) => (<motion.div key={keyName} initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: -20 }} transition={{ duration: 0.25 }} className={`absolute inset-0 flex flex-col overflow-y-auto overflow-x-hidden p-2 md:p-4 no-scrollbar ${wide ? '' : ''}`}><div className={`m-auto w-full h-full ${wide ? 'max-w-7xl' : 'max-w-lg'}`}>{children}</div></motion.div>);
-const FullScreenWrapper = ({ children, keyName }) => (<motion.div key={keyName} initial={{ opacity: 0, scale: 0.98 }} animate={{ opacity: 1, scale: 1 }} exit={{ opacity: 0, scale: 0.98 }} transition={{ duration: 0.25 }} className="absolute inset-0 flex flex-col p-0 md:p-6 overflow-hidden"><div className="w-full h-full max-w-7xl mx-auto flex flex-col">{children}</div></motion.div>);
+const FullScreenWrapper = ({ children, keyName }) => (<motion.div key={keyName} initial={{ opacity: 0, scale: 0.98 }} animate={{ opacity: 1, scale: 1 }} exit={{ opacity: 0, scale: 0.98 }} transition={{ duration: 0.25 }} className="absolute inset-0 flex flex-col p-0 md:p-6 overflow-hidden safe-area-screen"><div className="w-full h-full max-w-7xl mx-auto flex flex-col">{children}</div></motion.div>);
 
 export { PageWrapper, FullScreenWrapper };

--- a/src/hooks/useLearningViewport.js
+++ b/src/hooks/useLearningViewport.js
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+import { calculateLearningViewport } from '../utils/learning-viewport';
+
+const readViewport = () => {
+  if (typeof window === 'undefined') return calculateLearningViewport(1024, 768);
+  const viewport = window.visualViewport;
+  return calculateLearningViewport(
+    viewport?.width || window.innerWidth,
+    viewport?.height || window.innerHeight,
+  );
+};
+
+/** 画面回転・分割表示・ブラウザーUIの伸縮に追従する学習領域情報。 */
+export function useLearningViewport() {
+  const [viewport, setViewport] = useState(readViewport);
+
+  useEffect(() => {
+    let frame = 0;
+    const update = () => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => {
+        const next = readViewport();
+        setViewport((current) => {
+          if (current.isStacked === next.isStacked && Math.abs(current.canvasSize - next.canvasSize) < 24) {
+            return current;
+          }
+          return next;
+        });
+      });
+    };
+    const visualViewport = window.visualViewport;
+    window.addEventListener('resize', update);
+    window.addEventListener('orientationchange', update);
+    visualViewport?.addEventListener('resize', update);
+    return () => {
+      cancelAnimationFrame(frame);
+      window.removeEventListener('resize', update);
+      window.removeEventListener('orientationchange', update);
+      visualViewport?.removeEventListener('resize', update);
+    };
+  }, []);
+
+  return viewport;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -9,6 +9,15 @@
   --panel: #ffffff;
 }
 
+html,
+body,
+#root {
+  width: 100%;
+  height: 100%;
+  min-height: 100%;
+  overflow: hidden;
+}
+
 body {
   font-family: 'Zen Maru Gothic', sans-serif;
   background-color: var(--bg);
@@ -17,6 +26,7 @@ body {
   transition: background-color 0.3s ease;
   margin: 0;
   padding: 0;
+  overscroll-behavior: none;
 }
 
 .no-scrollbar::-webkit-scrollbar {
@@ -68,6 +78,13 @@ ruby.survival-blank rt {
 
 /* モバイルでフッターを非表示（ボトムナビ表示時にスペースを節約） */
 @media (max-width: 767px) {
+  .safe-area-screen {
+    padding-top: env(safe-area-inset-top, 0px);
+    padding-right: env(safe-area-inset-right, 0px);
+    padding-bottom: env(safe-area-inset-bottom, 0px);
+    padding-left: env(safe-area-inset-left, 0px);
+  }
+
   footer {
     display: none;
   }

--- a/src/systems/learning-plan.js
+++ b/src/systems/learning-plan.js
@@ -1,0 +1,81 @@
+export const DAILY_GOAL_OPTIONS = [5, 10, 20];
+export const DEFAULT_DAILY_GOAL = 10;
+
+const asLimit = (value) => Math.max(0, Math.floor(Number(value) || 0));
+
+function shuffle(items, random) {
+  const result = [...items];
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(random() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result;
+}
+
+export function getDailyGoal(settings) {
+  const value = Number(settings?.dailyGoal);
+  return DAILY_GOAL_OPTIONS.includes(value) ? value : DEFAULT_DAILY_GOAL;
+}
+
+export function getDailyLearningProgress(stats, today) {
+  const goal = getDailyGoal(stats?.settings);
+  const reviewed = Math.max(0, Number(stats?.daily?.[today]?.reviewed) || 0);
+  const remaining = Math.max(0, goal - reviewed);
+  return {
+    goal,
+    reviewed,
+    remaining,
+    percent: Math.min(100, Math.round((reviewed / goal) * 100)),
+    isComplete: reviewed >= goal,
+  };
+}
+
+/**
+ * 復習を最優先しつつ、設定された新出漢字も同じセッションに加える。
+ * 既存UIの「復習N＋新出N」という表示と実際の出題数を一致させる。
+ */
+export function buildLearningPlan({
+  kanjiData,
+  kanjiStats = {},
+  selectedGrade,
+  limits,
+  now = Date.now(),
+  random = Math.random,
+}) {
+  const reviewLimit = asLimit(limits?.review);
+  const newLimit = asLimit(limits?.new);
+
+  const dueReviews = kanjiData
+    .filter((kanji) => {
+      const stat = kanjiStats[kanji.id];
+      return stat && stat.status !== 'new' && (stat.nextReview || 0) <= now;
+    })
+    .sort((a, b) => {
+      const aStat = kanjiStats[a.id] || {};
+      const bStat = kanjiStats[b.id] || {};
+      const dueOrder = (aStat.nextReview || 0) - (bStat.nextReview || 0);
+      return dueOrder || (bStat.mistakes || 0) - (aStat.mistakes || 0);
+    });
+
+  const newCandidates = kanjiData.filter((kanji) => {
+    const stat = kanjiStats[kanji.id];
+    return kanji.grade === selectedGrade && (!stat || stat.status === 'new');
+  });
+
+  const reviewTargets = dueReviews.slice(0, reviewLimit);
+  const newTargets = shuffle(newCandidates, random).slice(0, newLimit);
+  const queue = [...reviewTargets, ...newTargets];
+
+  if (queue.length === 0) {
+    const fallback = kanjiData.find((kanji) => kanji.grade === selectedGrade);
+    if (fallback) queue.push(fallback);
+  }
+
+  return {
+    queue,
+    dueCount: dueReviews.length,
+    reviewCount: reviewTargets.length,
+    newCount: newTargets.length,
+    newAvailableCount: newCandidates.length,
+  };
+}

--- a/src/systems/storage.js
+++ b/src/systems/storage.js
@@ -201,6 +201,7 @@ const StorageAPI = {
     totalExp: stats.totalExp || 0,
     streak: stats.streak || 0,
     lastDate: stats.lastDate || '',
+    lastNeglectAppliedDate: stats.lastNeglectAppliedDate || '',
     coins: stats.coins || 0,
     targetGrade: stats.targetGrade || 1,
     townMap: stats.townMap || {},
@@ -335,6 +336,7 @@ const StorageAPI = {
         totalExp: 0,
         streak: 0,
         lastDate: '',
+        lastNeglectAppliedDate: '',
         coins: ECONOMY.INITIAL_COINS,
         targetGrade: 1,
         townMap: map,
@@ -365,6 +367,7 @@ const StorageAPI = {
       exploredRadius: MAP.INITIAL_EXPLORE_RADIUS,
       materials: {},
       lastCollectionDate: '',
+      lastNeglectAppliedDate: '',
     };
     for (const [field, defaultVal] of Object.entries(defaults)) {
       if (!stats[field]) stats[field] = defaultVal;
@@ -454,12 +457,13 @@ const StorageAPI = {
     stats.coins = Math.max(0, stats.coins);
 
     // ── サボり検出：街が廃れる仕組み ──
-    StorageAPI._applyNeglectPenalties(stats);
+    const neglectApplied = StorageAPI._applyNeglectPenalties(stats);
 
     // ── 実績の進捗を起動時に一括更新（新規追加分も反映） ──
     if (!stats.achievements) stats.achievements = {};
     StorageAPI._updateAchievements(stats);
 
+    if (neglectApplied) StorageAPI.saveStatsImmediate(stats);
     return stats;
   },
 
@@ -469,18 +473,31 @@ const StorageAPI = {
    */
   _applyNeglectPenalties: (stats) => {
     const todayStr = getTodayString();
-    if (!stats.lastDate || stats.lastDate === todayStr) return;
+    if (!stats.lastDate || stats.lastDate === todayStr) return false;
+    if (stats.lastNeglectAppliedDate === todayStr) return false;
 
-    const last = new Date(stats.lastDate);
-    if (isNaN(last.getTime())) return;
+    const last = new Date(`${stats.lastDate}T00:00:00`);
+    const today = new Date(`${todayStr}T00:00:00`);
+    if (isNaN(last.getTime()) || isNaN(today.getTime())) return false;
 
-    const diffDays = Math.floor((new Date() - last) / 86400000);
+    const diffDays = Math.max(0, Math.floor((today - last) / 86400000));
+    let previouslyAppliedDays = 0;
+    if (stats.lastNeglectAppliedDate) {
+      const previous = new Date(`${stats.lastNeglectAppliedDate}T00:00:00`);
+      if (!isNaN(previous.getTime())) {
+        previouslyAppliedDays = Math.max(0, Math.min(diffDays, Math.floor((previous - last) / 86400000)));
+      }
+    }
 
     // 雑草の発生
     if (diffDays >= NEGLECT.WEED_DAYS) {
       const clearedKeys = Object.keys(stats.townMap).filter(k => stats.townMap[k] === 't_cleared');
+      const newlyElapsedPenaltyDays = Math.max(
+        0,
+        diffDays - Math.max(previouslyAppliedDays, NEGLECT.WEED_DAYS - 1),
+      );
       const weedCount = Math.min(
-        diffDays * NEGLECT.WEEDS_PER_DAY,
+        newlyElapsedPenaltyDays * NEGLECT.WEEDS_PER_DAY,
         Math.floor(clearedKeys.length * NEGLECT.WEED_MAX_RATIO)
       );
       // Fisher-Yates シャッフル（偏りのないランダム選択）
@@ -495,27 +512,56 @@ const StorageAPI = {
     }
 
     // 住民の離脱
-    if (diffDays >= NEGLECT.LEAVE_DAYS && stats.population > 0) {
+    if (previouslyAppliedDays < NEGLECT.LEAVE_DAYS && diffDays >= NEGLECT.LEAVE_DAYS && stats.population > 0) {
       const leave = Math.max(1, Math.floor(stats.population * NEGLECT.LEAVE_RATIO));
       stats.population = Math.max(0, stats.population - leave);
       stats.villagers = stats.villagers.slice(leave);
     }
 
     // 建物の荒廃
-    if (diffDays >= NEGLECT.DECAY_DAYS && stats.population > 0) {
+    if (previouslyAppliedDays < NEGLECT.DECAY_DAYS && diffDays >= NEGLECT.DECAY_DAYS && stats.population > 0) {
       const buildingKeys = Object.keys(stats.townMap).filter(k => {
         const item = findTownItem(stats.townMap[k]);
         return item && (item.type === 'building' || item.type === 'special');
       });
       const decayCount = Math.min(NEGLECT.DECAY_MAX_BUILDINGS, buildingKeys.length);
+      const shuffledBuildings = [...buildingKeys];
+      for (let i = shuffledBuildings.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [shuffledBuildings[i], shuffledBuildings[j]] = [shuffledBuildings[j], shuffledBuildings[i]];
+      }
       for (let i = 0; i < decayCount; i++) {
-        const k = buildingKeys[Math.floor(Math.random() * buildingKeys.length)];
+        const k = shuffledBuildings[i];
         if (k) {
           stats.townItems[stats.townMap[k]] = (stats.townItems[stats.townMap[k]] || 0) + 1;
           stats.townMap[k] = 't_roughland';
         }
       }
     }
+
+    // 同じ日にgetStatsが複数回呼ばれてもペナルティを重複適用しない。
+    stats.lastNeglectAppliedDate = todayStr;
+    return true;
+  },
+
+  /**
+   * 住民の1日1回の収集だけを実行する。
+   * 学習記録・ストリークは更新しないため、アプリを開くだけで学習日にならない。
+   */
+  collectDailyTownResources: (stats, today = getTodayString()) => {
+    if (stats.lastCollectionDate === today || (stats.villagers || []).length === 0) return stats;
+
+    const { materials: collected, coins: collectedCoins } = collectDailyResources(stats);
+    if (!stats.materials) stats.materials = {};
+    Object.entries(collected).forEach(([matId, amount]) => {
+      stats.materials[matId] = (stats.materials[matId] || 0) + amount;
+    });
+    const maintenanceCost = calculateMaintenanceCost(stats);
+    stats.coins = Math.max(0, (stats.coins || 0) + collectedCoins - maintenanceCost);
+    stats.lastCollectionDate = today;
+    stats.lastCollectionResult = { materials: collected, coins: collectedCoins, maintenanceCost };
+    stats.satisfaction = calculateSatisfaction(stats);
+    return stats;
   },
 
   /**
@@ -527,14 +573,20 @@ const StorageAPI = {
    */
   updateDaily: (stats, exp, sessionData) => {
     const today = getTodayString();
-    if (!stats.daily) stats.daily = {};
-    if (!stats.daily[today]) stats.daily[today] = { exp: 0, reviewed: 0, perfects: 0 };
+    const reviewedCount = sessionData.reviewedCount || 0;
+    const perfectCount = sessionData.perfectCount || 0;
+    const hasLearningActivity = exp > 0 || reviewedCount > 0;
 
-    stats.daily[today].exp += exp;
-    stats.daily[today].reviewed = (stats.daily[today].reviewed || 0) + (sessionData.reviewedCount || 0);
-    stats.daily[today].perfects = (stats.daily[today].perfects || 0) + (sessionData.perfectCount || 0);
-    stats.totalExp += exp;
-    stats.perfectCountTotal = (stats.perfectCountTotal || 0) + (sessionData.perfectCount || 0);
+    if (hasLearningActivity) {
+      if (!stats.daily) stats.daily = {};
+      if (!stats.daily[today]) stats.daily[today] = { exp: 0, reviewed: 0, perfects: 0 };
+
+      stats.daily[today].exp += exp;
+      stats.daily[today].reviewed = (stats.daily[today].reviewed || 0) + reviewedCount;
+      stats.daily[today].perfects = (stats.daily[today].perfects || 0) + perfectCount;
+      stats.totalExp += exp;
+      stats.perfectCountTotal = (stats.perfectCountTotal || 0) + perfectCount;
+    }
 
     // 学習による雑草除去
     if (exp > 0) {
@@ -546,7 +598,7 @@ const StorageAPI = {
     }
 
     // ストリーク更新
-    if (stats.lastDate !== today) {
+    if (hasLearningActivity && stats.lastDate !== today) {
       if (stats.lastDate) {
         const yesterday = new Date();
         yesterday.setDate(yesterday.getDate() - 1);
@@ -556,21 +608,11 @@ const StorageAPI = {
         stats.streak = 1;
       }
       stats.lastDate = today;
+      stats.lastNeglectAppliedDate = today;
     }
 
     // ── 住民の自動素材収集（1日1回）──
-    if (stats.lastCollectionDate !== today && (stats.villagers || []).length > 0) {
-      const { materials: collected, coins: collectedCoins } = collectDailyResources(stats);
-      if (!stats.materials) stats.materials = {};
-      Object.entries(collected).forEach(([matId, amount]) => {
-        stats.materials[matId] = (stats.materials[matId] || 0) + amount;
-      });
-      const maintenanceCost = calculateMaintenanceCost(stats);
-      const netCoins = collectedCoins - maintenanceCost;
-      stats.coins = Math.max(0, (stats.coins || 0) + netCoins);
-      stats.lastCollectionDate = today;
-      stats.lastCollectionResult = { materials: collected, coins: collectedCoins, maintenanceCost };
-    }
+    StorageAPI.collectDailyTownResources(stats, today);
 
     // 満足度更新
     stats.satisfaction = calculateSatisfaction(stats);

--- a/src/utils/learning-viewport.js
+++ b/src/utils/learning-viewport.js
@@ -1,0 +1,31 @@
+const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
+
+/**
+ * 学習画面のレイアウトと正方形キャンバスの論理サイズを算出する。
+ * 幅だけでなく高さと縦横比も考慮し、タブレット縦持ちでサイドバーが
+ * 学習領域を圧迫しないようにする。
+ */
+export function calculateLearningViewport(width, height) {
+  const safeWidth = Number.isFinite(width) && width > 0 ? width : 1024;
+  const safeHeight = Number.isFinite(height) && height > 0 ? height : 768;
+  const isPortrait = safeHeight >= safeWidth;
+  const isStacked = safeWidth < 768 || (isPortrait && safeWidth < 960);
+
+  if (isStacked) {
+    const availableWidth = safeWidth - 32;
+    const availableHeight = safeHeight * (safeHeight < 620 ? 0.42 : 0.5);
+    return {
+      isStacked,
+      canvasSize: Math.round(clamp(Math.min(availableWidth, availableHeight), 220, 520)),
+    };
+  }
+
+  const sidebarWidth = safeWidth >= 1200 ? 360 : 300;
+  const availableWidth = safeWidth - sidebarWidth - 96;
+  const availableHeight = safeHeight - (safeHeight < 620 ? 112 : 148);
+
+  return {
+    isStacked,
+    canvasSize: Math.round(clamp(Math.min(availableWidth, availableHeight), 240, 560)),
+  };
+}

--- a/test/learning-plan.test.js
+++ b/test/learning-plan.test.js
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildLearningPlan,
+  getDailyGoal,
+  getDailyLearningProgress,
+} from '../src/systems/learning-plan.js';
+import { calculateLearningViewport } from '../src/utils/learning-viewport.js';
+
+const kanjiData = [
+  { id: 'a', grade: 1 },
+  { id: 'b', grade: 1 },
+  { id: 'c', grade: 1 },
+  { id: 'd', grade: 2 },
+];
+
+test('復習と新出漢字を同じセッションへ復習優先で組み込む', () => {
+  const plan = buildLearningPlan({
+    kanjiData,
+    kanjiStats: {
+      a: { status: 'review', nextReview: 100, mistakes: 1 },
+      b: { status: 'learning', nextReview: 50, mistakes: 2 },
+    },
+    selectedGrade: 1,
+    limits: { review: 2, new: 1 },
+    now: 200,
+    random: () => 0.5,
+  });
+
+  assert.deepEqual(plan.queue.map((kanji) => kanji.id), ['b', 'a', 'c']);
+  assert.equal(plan.reviewCount, 2);
+  assert.equal(plan.newCount, 1);
+});
+
+test('学習目標は安全な既定値と当日進捗を返す', () => {
+  assert.equal(getDailyGoal({ dailyGoal: 999 }), 10);
+  assert.deepEqual(
+    getDailyLearningProgress({ settings: { dailyGoal: 5 }, daily: { '2026-07-21': { reviewed: 7 } } }, '2026-07-21'),
+    { goal: 5, reviewed: 7, remaining: 0, percent: 100, isComplete: true },
+  );
+});
+
+test('タブレット縦持ちは積層、横持ちは広い学習面を使う', () => {
+  const portrait = calculateLearningViewport(768, 1024);
+  const landscape = calculateLearningViewport(1024, 768);
+  assert.equal(portrait.isStacked, true);
+  assert.ok(portrait.canvasSize >= 480);
+  assert.equal(landscape.isStacked, false);
+  assert.ok(landscape.canvasSize >= 500);
+});
+
+test('小型スマートフォンでもキャンバスが画面幅を越えない', () => {
+  const viewport = calculateLearningViewport(320, 568);
+  assert.equal(viewport.isStacked, true);
+  assert.ok(viewport.canvasSize <= 288);
+  assert.ok(viewport.canvasSize >= 220);
+});


### PR DESCRIPTION
## 概要

スマートフォン・タブレット・PCで学習領域を広く保ちながら、復習と新出漢字を組み合わせた毎日の学習習慣を作りやすくする改善です。既存の世界観と主要UIは維持しています。

## 主な変更

- 画面幅・高さ・向きに応じて学習キャンバスを `220–560px` で最適化
- 縦持ち／横持ちで説明・操作領域の配置を切り替え、主要学習領域を優先
- Safe Area対応とブラウザー拡大操作のアクセシビリティ改善
- 復習対象を優先しつつ、新出漢字を設定数だけ同じセッションへ組み込む学習計画
- ホームに「今日の目標」カードを追加し、設定で1日5・10・20字を選択可能に
- アプリを開いただけでは連続学習日数を増やさないよう記録処理を修正
- 学習しなかった日のペナルティが同日に重複適用されないよう修正
- 「もう一度」の試行を完了字数として数えないよう進捗集計を修正
- Service Workerキャッシュ更新と学習計画・レスポンシブ計算の自動テスト追加

## 確認

- `npm test` — 4 tests passed
- `npm run build` — passed
- `git diff --check HEAD^ HEAD` — passed

## 次の開発候補

本番ビルドは成功していますが、メインchunkが約628 kBで警告閾値を超えています。次フェーズでは画面単位の遅延読込みと依存関係の分割を進めます。
