### PR TITLE
苦手漢字を自動選定する集中復習モードを追加

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,8 +9,8 @@ import StorageErrorBanner from './components/ui/StorageErrorBanner';
 import MobileBottomNav from './components/ui/MobileBottomNav';
 
 import { StorageAPI, getLevelInfo } from './systems/storage';
-import { calculateNextReview, migrateCard } from './systems/srs';
-import { buildLearningPlan } from './systems/learning-plan';
+import { calculateNextReview, migrateCard, recordPracticeAttempt } from './systems/srs';
+import { buildLearningPlan, buildWeakKanjiPlan } from './systems/learning-plan';
 import { audioCtrl } from './systems/audio';
 import { checkLevelUp, grantExpWithLevelRewards } from './utils/level-system';
 import { SESSION, EXP, RARE_DROP, ECONOMY, DEBOUNCE, TEST } from './constants/gameConfig';
@@ -369,6 +369,25 @@ export default function App() {
     setView('flashcard');
   };
 
+  const startWeakSession = () => {
+    audioCtrl.init();
+    const { queue } = buildWeakKanjiPlan({
+      kanjiData: KANJI_DATA,
+      kanjiStats: stats.kanjiStats,
+    });
+    if (queue.length === 0) return;
+
+    const expMultiplier = getSatisfactionMultiplier(calculateSatisfaction(stats));
+    setSessionData(createInitialSessionData({
+      queue,
+      oldExp: stats.totalExp,
+      expMultiplier,
+      isDrill: true,
+      isWeakPractice: true,
+    }));
+    setView('session');
+  };
+
   const startSurvival = () => {
     audioCtrl.init();
     const learned = KANJI_DATA.filter(k => stats.kanjiStats?.[k.id] && stats.kanjiStats[k.id].status !== 'new');
@@ -398,7 +417,27 @@ export default function App() {
   const handleUpdateStat = (kanjiObj, evalType) => {
     const id = kanjiObj.id;
     const cur = migrateCard(stats.kanjiStats?.[id]);
-    if (sessionData.isDrill) { setSessionData(d => ({ ...d, earnedExp: d.earnedExp + (evalType === 'again' ? 0 : EXP.DRILL), reviewedCount: (d.reviewedCount || 0) + (evalType === 'again' ? 0 : 1) })); return evalType !== 'again'; }
+    if (sessionData.isDrill) {
+      setStats(s => {
+        const latest = migrateCard(s.kanjiStats?.[id]);
+        return {
+          ...s,
+          kanjiStats: {
+            ...s.kanjiStats,
+            [id]: {
+              ...latest,
+              ...recordPracticeAttempt(latest, evalType),
+            },
+          },
+        };
+      });
+      setSessionData(d => ({
+        ...d,
+        earnedExp: d.earnedExp + (evalType === 'again' ? 0 : EXP.DRILL),
+        reviewedCount: (d.reviewedCount || 0) + (evalType === 'again' ? 0 : 1),
+      }));
+      return evalType !== 'again';
+    }
 
     const next = calculateNextReview(cur, evalType);
     const wasNew = cur.status === 'new';
@@ -446,7 +485,16 @@ export default function App() {
 
     setStats(s => ({
       ...s,
-      kanjiStats: { ...s.kanjiStats, [id]: { ...cur, ...next, status: newStatus, mistakes: evalType === 'again' ? (cur.mistakes || 0) + 1 : (cur.mistakes || 0) } },
+      kanjiStats: {
+        ...s.kanjiStats,
+        [id]: {
+          ...cur,
+          ...next,
+          status: newStatus,
+          mistakes: evalType === 'again' ? (cur.mistakes || 0) + 1 : (cur.mistakes || 0),
+          ...recordPracticeAttempt(cur, evalType),
+        },
+      },
       ...(newVillager ? { population: (s.population || 0) + 1, villagers: [...(s.villagers || []), newVillager] } : {}),
     }));
     setSessionData(d => ({
@@ -667,7 +715,7 @@ export default function App() {
                 });
               }} /></ErrorBoundary></PageWrapper>}
           {view === 'achievements' && <PageWrapper key="achievements"><ErrorBoundary onReset={() => setView('home')}><FeatureHint featureKey="achievements" seenHints={seenHints} onDismiss={handleDismissHint} /><AchievementView setView={setView} stats={stats} setStats={setStats} /></ErrorBoundary></PageWrapper>}
-          {view === 'stats' && <PageWrapper key="stats"><ErrorBoundary onReset={() => setView('home')}><FeatureHint featureKey="stats" seenHints={seenHints} onDismiss={handleDismissHint} /><StatsView setView={setView} stats={stats} /></ErrorBoundary></PageWrapper>}
+          {view === 'stats' && <PageWrapper key="stats"><ErrorBoundary onReset={() => setView('home')}><FeatureHint featureKey="stats" seenHints={seenHints} onDismiss={handleDismissHint} /><StatsView setView={setView} stats={stats} startWeakSession={startWeakSession} /></ErrorBoundary></PageWrapper>}
           {view === 'settings' && <PageWrapper key="settings"><ErrorBoundary onReset={() => setView('home')}><SettingsView setView={setView} stats={stats} setStats={setStats} isMuted={isMuted} setIsMuted={setIsMuted} levelInfo={levelInfo} /></ErrorBoundary></PageWrapper>}
           {view === 'myDrills' && <PageWrapper key="myDrills"><ErrorBoundary onReset={() => setView('home')}><MyDrillsView setView={setView} stats={stats} setStats={setStats} startDrillSession={startDrillSession} startDrillTest={startDrillTest} setHostDrill={setHostDrill} /></ErrorBoundary></PageWrapper>}
           {view === 'drillEditor' && <PageWrapper key="drillEditor" wide><ErrorBoundary onReset={() => setView('home')}><DrillEditorView setView={setView} stats={stats} setStats={setStats} /></ErrorBoundary></PageWrapper>}

--- a/src/components/pages/StatsView.jsx
+++ b/src/components/pages/StatsView.jsx
@@ -1,10 +1,11 @@
 import React, { useMemo } from 'react';
-import { BarChart3, TrendingUp, AlertCircle, ArrowLeft } from 'lucide-react';
+import { BarChart3, TrendingUp, AlertCircle, ArrowLeft, Target } from 'lucide-react';
 import { F } from '../ui/FormatKun';
 import { KANJI_DATA } from '../../data/kanji-data';
 import { formatDate } from '../../utils/date-utils';
+import { buildWeakKanjiPlan, WEAK_PRACTICE_SUCCESS_TARGET } from '../../systems/learning-plan';
 
-const StatsView = ({ setView, stats }) => {
+const StatsView = ({ setView, stats, startWeakSession }) => {
   const kanjiList = KANJI_DATA.map(k => ({ ...k, stat: stats.kanjiStats?.[k.id] }));
   const mastered = kanjiList.filter(k => k.stat?.status === 'mastered').length;
   const learning = kanjiList.filter(k => k.stat?.status === 'learning' || k.stat?.status === 'review').length;
@@ -25,11 +26,14 @@ const StatsView = ({ setView, stats }) => {
 
   const maxExp = Math.max(...dailyData.map(d => d.exp), 1);
 
-  // 苦手な漢字 top5
-  const weakKanji = kanjiList
-    .filter(k => k.stat && (k.stat.mistakes || 0) > 0)
-    .sort((a, b) => (b.stat.mistakes || 0) - (a.stat.mistakes || 0))
-    .slice(0, 5);
+  // 復習期限・つまずき・連続正解数を加味した苦手漢字 top5
+  const weakKanji = useMemo(() => {
+    const { queue } = buildWeakKanjiPlan({
+      kanjiData: KANJI_DATA,
+      kanjiStats: stats.kanjiStats,
+    });
+    return queue.map(k => ({ ...k, stat: stats.kanjiStats?.[k.id] }));
+  }, [stats.kanjiStats]);
 
   return (
     <div className="flex flex-col gap-4 pb-8">
@@ -90,16 +94,31 @@ const StatsView = ({ setView, stats }) => {
       {/* 苦手な漢字 */}
       {weakKanji.length > 0 && (
         <div className="bg-[var(--panel)] border-[4px] border-[var(--text)] rounded-2xl p-4 shadow-sm">
-          <div className="text-sm font-black text-[var(--text)] mb-3 flex items-center gap-2"><AlertCircle size={16} className="text-rose-500" /> {F("苦手","にがて")}な{F("漢字","かんじ")} TOP5</div>
+          <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+            <div className="text-sm font-black text-[var(--text)] flex items-center gap-2"><AlertCircle size={16} className="text-rose-500" /> {F("苦手","にがて")}な{F("漢字","かんじ")} TOP5</div>
+            <button
+              type="button"
+              onClick={startWeakSession}
+              className="min-h-[44px] rounded-xl border-[2px] border-[var(--text)] bg-rose-400 px-3 py-2 text-xs font-black text-white shadow-[0_2px_0_var(--text)] transition-transform hover:-translate-y-0.5 active:translate-y-0 focus:outline-none focus:ring-2 focus:ring-rose-300"
+              aria-label={`苦手な漢字${weakKanji.length}字の集中練習を始める`}
+            >
+              <span className="flex items-center gap-1.5"><Target size={16} aria-hidden="true" /> にがて{F("特訓","とっくん")} {weakKanji.length}{F("字","じ")}</span>
+            </button>
+          </div>
           <div className="flex flex-col gap-2">
-            {weakKanji.map((k, i) => (
+            {weakKanji.map((k) => (
               <div key={k.id} className="flex items-center gap-3 bg-[var(--bg)] rounded-xl px-3 py-2">
                 <span className="text-2xl font-black" style={{ fontFamily: "'Klee One', serif" }}>{k.char}</span>
                 <div className="flex-1">
                   <div className="text-sm font-bold text-[var(--text)]">{k.on[0] || k.kun[0] || ''}</div>
-                  <div className="text-xs text-rose-500 font-bold">ミス {k.stat.mistakes}{F("回","かい")}</div>
+                  <div className="text-xs text-rose-500 font-bold">
+                    ミス {k.stat.mistakes || 0}{F("回","かい")}
+                    {(k.stat.lapses || 0) > 0 && `・つまずき ${k.stat.lapses}回`}
+                  </div>
                 </div>
-                <div className="text-lg">{'😅'.repeat(Math.min(i + 1, 3))}</div>
+                <div className="shrink-0 rounded-lg bg-[var(--panel)] px-2 py-1 text-[10px] font-black text-[var(--text)] opacity-70" aria-label={`連続正解${k.stat.practiceStreak || 0}回、目標${WEAK_PRACTICE_SUCCESS_TARGET}回`}>
+                  できた {k.stat.practiceStreak || 0}/{WEAK_PRACTICE_SUCCESS_TARGET}
+                </div>
               </div>
             ))}
           </div>

--- a/src/systems/learning-plan.js
+++ b/src/systems/learning-plan.js
@@ -1,5 +1,7 @@
 export const DAILY_GOAL_OPTIONS = [5, 10, 20];
 export const DEFAULT_DAILY_GOAL = 10;
+export const DEFAULT_WEAK_SESSION_LIMIT = 5;
+export const WEAK_PRACTICE_SUCCESS_TARGET = 3;
 
 const asLimit = (value) => Math.max(0, Math.floor(Number(value) || 0));
 
@@ -27,6 +29,52 @@ export function getDailyLearningProgress(stats, today) {
     remaining,
     percent: Math.min(100, Math.round((reviewed / goal) * 100)),
     isComplete: reviewed >= goal,
+  };
+}
+
+/**
+ * 過去につまずいた漢字から、短い集中練習用のキューを作る。
+ * 復習期限、ラプス、ミス、連続正解数、容易度の順で優先する。
+ * 3回連続で正解した漢字は一度キューから外し、成功体験を可視化する。
+ */
+export function buildWeakKanjiPlan({
+  kanjiData,
+  kanjiStats = {},
+  limit = DEFAULT_WEAK_SESSION_LIMIT,
+  now = Date.now(),
+}) {
+  const safeLimit = asLimit(limit);
+  const candidates = kanjiData
+    .filter((kanji) => {
+      const stat = kanjiStats[kanji.id];
+      if (!stat || stat.status === 'new') return false;
+
+      const hasDifficultySignal = (stat.mistakes || 0) > 0
+        || (stat.lapses || 0) > 0
+        || (stat.ease ?? 2.5) < 2.5;
+      return hasDifficultySignal
+        && (stat.practiceStreak || 0) < WEAK_PRACTICE_SUCCESS_TARGET;
+    })
+    .sort((a, b) => {
+      const aStat = kanjiStats[a.id] || {};
+      const bStat = kanjiStats[b.id] || {};
+      const aDue = (aStat.nextReview || 0) <= now ? 1 : 0;
+      const bDue = (bStat.nextReview || 0) <= now ? 1 : 0;
+
+      return (bDue - aDue)
+        || ((bStat.lapses || 0) - (aStat.lapses || 0))
+        || ((bStat.mistakes || 0) - (aStat.mistakes || 0))
+        || ((aStat.practiceStreak || 0) - (bStat.practiceStreak || 0))
+        || ((aStat.ease ?? 2.5) - (bStat.ease ?? 2.5))
+        || ((aStat.nextReview || 0) - (bStat.nextReview || 0))
+        || String(a.id).localeCompare(String(b.id));
+    });
+
+  const queue = candidates.slice(0, safeLimit);
+  return {
+    queue,
+    availableCount: candidates.length,
+    dueCount: candidates.filter((kanji) => (kanjiStats[kanji.id]?.nextReview || 0) <= now).length,
   };
 }
 

--- a/src/systems/srs.js
+++ b/src/systems/srs.js
@@ -43,6 +43,9 @@ const INTERVAL_MODIFIER = 1.0;
  * @property {number} [lapses] - ラプス（卒業後に再度失敗した回数）
  * @property {string} [status] - 'new'|'learning'|'review'|'mastered'
  * @property {number} [mistakes] - 総ミス回数
+ * @property {number} [practiceStreak] - 通常学習・特訓を通した連続正解数
+ * @property {number} [practiceAttempts] - 練習した総回数
+ * @property {number} [lastPracticedAt] - 最後に練習した時刻(Unix ms)
  */
 
 /**
@@ -210,6 +213,18 @@ function sanitizeNextReview(card) {
 }
 
 /**
+ * 通常学習と特訓で共通の練習進捗を記録する。
+ * 「もう一度」で連続正解をリセットし、それ以外は1つ進める。
+ */
+export function recordPracticeAttempt(card, evaluation, now = Date.now()) {
+  return {
+    practiceStreak: evaluation === 'again' ? 0 : (card?.practiceStreak || 0) + 1,
+    practiceAttempts: (card?.practiceAttempts || 0) + 1,
+    lastPracticedAt: now,
+  };
+}
+
+/**
  * 古いカードデータを現在のスキーマに移行する
  * @param {object|null} card
  * @returns {CardState}
@@ -225,15 +240,28 @@ export const migrateCard = (card) => {
       status: 'new',
       mistakes: 0,
       lapses: 0,
+      practiceStreak: 0,
+      practiceAttempts: 0,
+      lastPracticedAt: 0,
     };
   }
   // easeフィールドがあれば移行済み
-  if (card.ease !== undefined) return sanitizeNextReview(card);
+  if (card.ease !== undefined) {
+    return sanitizeNextReview({
+      practiceStreak: 0,
+      practiceAttempts: 0,
+      lastPracticedAt: 0,
+      ...card,
+    });
+  }
   return sanitizeNextReview({
     ...card,
     ease: DEFAULT_EASE,
     graduated: (card.interval || 0) >= GRADUATING_INTERVAL,
     stepIdx: 0,
     lapses: 0,
+    practiceStreak: 0,
+    practiceAttempts: 0,
+    lastPracticedAt: 0,
   });
 };

--- a/test/learning-plan.test.js
+++ b/test/learning-plan.test.js
@@ -2,8 +2,10 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
   buildLearningPlan,
+  buildWeakKanjiPlan,
   getDailyGoal,
   getDailyLearningProgress,
+  WEAK_PRACTICE_SUCCESS_TARGET,
 } from '../src/systems/learning-plan.js';
 import { calculateLearningViewport } from '../src/utils/learning-viewport.js';
 
@@ -38,6 +40,24 @@ test('学習目標は安全な既定値と当日進捗を返す', () => {
     getDailyLearningProgress({ settings: { dailyGoal: 5 }, daily: { '2026-07-21': { reviewed: 7 } } }, '2026-07-21'),
     { goal: 5, reviewed: 7, remaining: 0, percent: 100, isComplete: true },
   );
+});
+
+test('苦手特訓は期限内のつまずきを優先し、3回連続正解した漢字を外す', () => {
+  const plan = buildWeakKanjiPlan({
+    kanjiData,
+    kanjiStats: {
+      a: { status: 'review', nextReview: 100, mistakes: 5, lapses: 0, practiceStreak: 0 },
+      b: { status: 'learning', nextReview: 50, mistakes: 1, lapses: 2, practiceStreak: 1 },
+      c: { status: 'review', nextReview: 0, mistakes: 10, lapses: 3, practiceStreak: WEAK_PRACTICE_SUCCESS_TARGET },
+      d: { status: 'review', nextReview: 500, mistakes: 20, lapses: 4, practiceStreak: 0 },
+    },
+    now: 200,
+    limit: 5,
+  });
+
+  assert.deepEqual(plan.queue.map((kanji) => kanji.id), ['b', 'a', 'd']);
+  assert.equal(plan.availableCount, 3);
+  assert.equal(plan.dueCount, 2);
 });
 
 test('タブレット縦持ちは積層、横持ちは広い学習面を使う', () => {

--- a/test/srs.test.js
+++ b/test/srs.test.js
@@ -1,0 +1,47 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { migrateCard, recordPracticeAttempt } from '../src/systems/srs.js';
+
+test('既存カードへ苦手特訓の進捗フィールドを安全に追加する', () => {
+  const migrated = migrateCard({
+    status: 'review',
+    graduated: true,
+    interval: 86_400_000,
+    nextReview: Date.now() + 60_000,
+    ease: 2.3,
+    mistakes: 2,
+  });
+
+  assert.equal(migrated.practiceStreak, 0);
+  assert.equal(migrated.practiceAttempts, 0);
+  assert.equal(migrated.lastPracticedAt, 0);
+  assert.equal(migrated.mistakes, 2);
+});
+
+test('保存済みの苦手特訓進捗を移行時に維持する', () => {
+  const migrated = migrateCard({
+    status: 'learning',
+    graduated: false,
+    interval: 600_000,
+    nextReview: Date.now() + 60_000,
+    ease: 2.1,
+    practiceStreak: 2,
+    practiceAttempts: 7,
+    lastPracticedAt: 12345,
+  });
+
+  assert.equal(migrated.practiceStreak, 2);
+  assert.equal(migrated.practiceAttempts, 7);
+  assert.equal(migrated.lastPracticedAt, 12345);
+});
+
+test('正解で連続記録を進め、もう一度でリセットする', () => {
+  assert.deepEqual(
+    recordPracticeAttempt({ practiceStreak: 1, practiceAttempts: 4 }, 'good', 200),
+    { practiceStreak: 2, practiceAttempts: 5, lastPracticedAt: 200 },
+  );
+  assert.deepEqual(
+    recordPracticeAttempt({ practiceStreak: 2, practiceAttempts: 5 }, 'again', 300),
+    { practiceStreak: 0, practiceAttempts: 6, lastPracticedAt: 300 },
+  );
+});


### PR DESCRIPTION
## 概要

学習記録に表示されていた「苦手な漢字」を、見るだけの情報から、その場で集中復習できる学習導線へ進化させます。通常の間隔反復スケジュールを変更せず、短い補助ドリルとして利用できます。

## 主な変更

- 復習期限、ラプス、ミス回数、連続正解数、容易度から苦手漢字を自動選定
- 優先度の高い最大5字で「にがて特訓」を開始
- 学習記録画面へ44px以上のタッチ操作ボタンを追加
- 通常学習・ドリル共通で連続正解数と練習回数を記録
- 3回連続正解した漢字を苦手候補から一度外し、次の課題へ移行
- 「もう一度」を選ぶと連続正解数をリセット
- 既存保存データへ新しい練習進捗フィールドを安全に追加

## 学習設計

「にがて特訓」は `isDrill` として実行するため、予定より早い練習でSRSの次回復習日時が後ろへずれることはありません。一方、正解した文字数は毎日の学習進捗へ反映されます。

## 確認

- `npm test` — 8 tests passed
- `npm run build` — passed
- バンドル予算 — 161.5 KiB / 220 KiB
- `git diff --check HEAD^ HEAD` — passed
- GitHub公開ブランチとローカルのファイルツリー一致を確認
