### PR TITLE
週単位の学習目標と正答率を可視化

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -103,6 +103,8 @@ function createInitialSessionData(overrides = {}) {
     perfectCount: 0,
     easyCount: 0,
     reviewedCount: 0,
+    attemptCount: 0,
+    correctCount: 0,
     newKanjiCount: 0,
     unlockedItems: [],
     rareDrop: null,
@@ -435,6 +437,8 @@ export default function App() {
         ...d,
         earnedExp: d.earnedExp + (evalType === 'again' ? 0 : EXP.DRILL),
         reviewedCount: (d.reviewedCount || 0) + (evalType === 'again' ? 0 : 1),
+        attemptCount: (d.attemptCount || 0) + 1,
+        correctCount: (d.correctCount || 0) + (evalType === 'again' ? 0 : 1),
       }));
       return evalType !== 'again';
     }
@@ -501,6 +505,8 @@ export default function App() {
       ...d,
       earnedExp: d.earnedExp + exp,
       reviewedCount: (d.reviewedCount || 0) + (evalType === 'again' ? 0 : 1),
+      attemptCount: (d.attemptCount || 0) + 1,
+      correctCount: (d.correctCount || 0) + (evalType === 'again' ? 0 : 1),
       newKanjiCount: (d.newKanjiCount || 0) + (wasNew ? 1 : 0),
       masteredCount: (d.masteredCount || 0) + (isMastering && cur.status !== 'mastered' ? 1 : 0),
       unlockedItems: unlockedItem ? [...d.unlockedItems, unlockedItem] : d.unlockedItems,
@@ -554,6 +560,10 @@ export default function App() {
       earnedExp: totalExp, 
       rareDrop, 
       perfectCount: sessionData.perfectCount + (additionalResults.perfectCount || 0),
+      reviewedCount: sessionData.reviewedCount + (additionalResults.reviewedCount || 0),
+      attemptCount: sessionData.attemptCount + (additionalResults.attemptCount || 0),
+      correctCount: sessionData.correctCount
+        + (additionalResults.correctCount ?? additionalResults.reviewedCount ?? 0),
       unlockedItems: unlockedItemsThisSession,
       levelUpData // ResultViewに渡すレベルアップ情報
     };

--- a/src/components/pages/StatsView.jsx
+++ b/src/components/pages/StatsView.jsx
@@ -2,8 +2,7 @@ import React, { useMemo } from 'react';
 import { BarChart3, TrendingUp, AlertCircle, ArrowLeft, Target } from 'lucide-react';
 import { F } from '../ui/FormatKun';
 import { KANJI_DATA } from '../../data/kanji-data';
-import { formatDate } from '../../utils/date-utils';
-import { buildWeakKanjiPlan, WEAK_PRACTICE_SUCCESS_TARGET } from '../../systems/learning-plan';
+import { buildWeakKanjiPlan, getWeeklyLearningSummary, WEAK_PRACTICE_SUCCESS_TARGET } from '../../systems/learning-plan';
 
 const StatsView = ({ setView, stats, startWeakSession }) => {
   const kanjiList = KANJI_DATA.map(k => ({ ...k, stat: stats.kanjiStats?.[k.id] }));
@@ -12,17 +11,14 @@ const StatsView = ({ setView, stats, startWeakSession }) => {
   const notYet = kanjiList.filter(k => !k.stat || k.stat?.status === 'new').length;
   const totalKanji = KANJI_DATA.length;
 
-  // 直近7日の学習データ
-  const dailyData = useMemo(() => {
-    const days = [];
-    for (let i = 6; i >= 0; i--) {
-      const d = new Date(); d.setDate(d.getDate() - i);
-      const key = formatDate(d);
-      const label = i === 0 ? '今日' : i === 1 ? '昨日' : `${d.getDate()}日`;
-      days.push({ label, exp: stats.daily?.[key]?.exp || 0, reviewed: stats.daily?.[key]?.reviewed || 0 });
-    }
-    return days;
-  }, [stats.daily]);
+  const weeklySummary = useMemo(
+    () => getWeeklyLearningSummary(stats),
+    [stats.daily, stats.settings],
+  );
+  const dailyData = weeklySummary.days.map((day, index) => ({
+    ...day,
+    label: index === 6 ? '今日' : index === 5 ? '昨日' : `${day.date.getDate()}日`,
+  }));
 
   const maxExp = Math.max(...dailyData.map(d => d.exp), 1);
 
@@ -64,7 +60,7 @@ const StatsView = ({ setView, stats, startWeakSession }) => {
         </div>
       </div>
 
-      {/* 連続学習ストリーク */}
+      {/* 学習習慣サマリー */}
       <div className="grid grid-cols-2 gap-3">
         <div className="bg-[var(--panel)] border-[4px] border-[var(--text)] rounded-2xl p-4 shadow-sm text-center">
           <div className="text-3xl mb-1">🔥</div>
@@ -76,16 +72,31 @@ const StatsView = ({ setView, stats, startWeakSession }) => {
           <div className="text-3xl font-black text-amber-500">{(stats.totalExp || 0).toLocaleString()}</div>
           <div className="text-xs font-bold text-[var(--text)] opacity-60">{F("累計","るいけい")}EXP</div>
         </div>
+        <div className="bg-[var(--panel)] border-[4px] border-[var(--text)] rounded-2xl p-4 shadow-sm text-center">
+          <div className="text-3xl mb-1">🎯</div>
+          <div className="text-3xl font-black text-emerald-500">{weeklySummary.goalDays}<span className="text-base text-[var(--text)] opacity-40"> / 7</span></div>
+          <div className="text-xs font-bold text-[var(--text)] opacity-60">{F("今週","こんしゅう")}の{F("目標","もくひょう")}{F("達成","たっせい")}</div>
+        </div>
+        <div className="bg-[var(--panel)] border-[4px] border-[var(--text)] rounded-2xl p-4 shadow-sm text-center">
+          <div className="text-3xl mb-1">✍️</div>
+          <div className="text-3xl font-black text-sky-500">{weeklySummary.accuracy === null ? '—' : `${weeklySummary.accuracy}%`}</div>
+          <div className="text-xs font-bold text-[var(--text)] opacity-60">7{F("日","にち")}の{F("正答率","せいとうりつ")}</div>
+        </div>
       </div>
 
       {/* 7日間の学習グラフ */}
       <div className="bg-[var(--panel)] border-[4px] border-[var(--text)] rounded-2xl p-4 shadow-sm">
-        <div className="text-sm font-black text-[var(--text)] mb-3 flex items-center gap-2"><TrendingUp size={16} className="text-[var(--secondary)]" /> {F("直近","ちょっきん")}7{F("日","にち")}の{F("学習","がくしゅう")}EXP</div>
+        <div className="text-sm font-black text-[var(--text)] mb-1 flex items-center gap-2"><TrendingUp size={16} className="text-[var(--secondary)]" /> {F("直近","ちょっきん")}7{F("日","にち")}の{F("学習","がくしゅう")}EXP</div>
+        <div className="mb-3 text-[10px] font-bold text-[var(--text)] opacity-50">緑のバーは1日{weeklySummary.goal}{F("字","じ")}の{F("目標","もくひょう")}クリア</div>
         <div className="flex items-end gap-2 h-24">
           {dailyData.map((day, i) => (
             <div key={i} className="flex-1 flex flex-col items-center gap-1">
-              <div className="w-full rounded-t-lg bg-[var(--secondary)] opacity-80 transition-all" style={{ height: `${Math.max((day.exp / maxExp) * 80, day.exp > 0 ? 8 : 2)}px` }} />
-              <div className="text-[9px] font-bold text-[var(--text)] opacity-50 truncate w-full text-center">{day.label}</div>
+              <div
+                className={`w-full rounded-t-lg transition-all ${day.goalComplete ? 'bg-emerald-400' : 'bg-[var(--secondary)] opacity-80'}`}
+                style={{ height: `${Math.max((day.exp / maxExp) * 80, day.exp > 0 ? 8 : 2)}px` }}
+                title={`${day.label}: ${day.exp} EXP・${day.reviewed}字`}
+              />
+              <div className={`text-[9px] font-bold truncate w-full text-center ${day.goalComplete ? 'text-emerald-600' : 'text-[var(--text)] opacity-50'}`}>{day.goalComplete ? '✓' : ''}{day.label}</div>
             </div>
           ))}
         </div>

--- a/src/components/training/FlashcardView.jsx
+++ b/src/components/training/FlashcardView.jsx
@@ -4,14 +4,14 @@ import { Timer } from 'lucide-react';
 import MotionButton from '../ui/MotionButton';
 import { audioCtrl } from '../../systems/audio';
 import { F, FormatKun } from '../ui/FormatKun';
-import { migrateCard, calculateNextReview } from '../../systems/srs';
+import { migrateCard, calculateNextReview, recordPracticeAttempt } from '../../systems/srs';
 import { StorageAPI } from '../../systems/storage';
 
 const FlashcardView = ({ queue, stats, setStats, onFinish }) => {
   const [idx, setIdx] = useState(0);
   const [elapsed, setElapsed] = useState(0);
   const [revealed, setRevealed] = useState(false);
-  const earnedRef = useRef({ exp: 0, coins: 0, perfectCount: 0 });
+  const earnedRef = useRef({ exp: 0, coins: 0, perfectCount: 0, reviewedCount: 0, attemptCount: 0, correctCount: 0 });
   const [displayEarned, setDisplayEarned] = useState({ exp: 0, coins: 0 });
   const isDoneRef = useRef(false);
   const touchStartX = useRef(0);
@@ -42,24 +42,44 @@ const FlashcardView = ({ queue, stats, setStats, onFinish }) => {
 
   const handleAnswer = useCallback((isKnown) => {
     if (!kanji || !revealed) return;
-    if (!isKnown) {
-      const cur = migrateCard(stats.kanjiStats[kanji.id]);
+    const evaluation = isKnown ? 'good' : 'again';
+    earnedRef.current = {
+      ...earnedRef.current,
+      exp: earnedRef.current.exp + (isKnown ? 2 : 0),
+      coins: earnedRef.current.coins + (isKnown ? 1 : 0),
+      reviewedCount: earnedRef.current.reviewedCount + (isKnown ? 1 : 0),
+      attemptCount: earnedRef.current.attemptCount + 1,
+      correctCount: earnedRef.current.correctCount + (isKnown ? 1 : 0),
+    };
+
+    setStats(currentStats => {
+      const cur = migrateCard(currentStats.kanjiStats?.[kanji.id]);
+      const card = isKnown
+        ? { ...cur, ...recordPracticeAttempt(cur, evaluation) }
+        : {
+          ...cur,
+          ...calculateNextReview(cur, evaluation),
+          status: 'learning',
+          mistakes: (cur.mistakes || 0) + 1,
+          ...recordPracticeAttempt(cur, evaluation),
+        };
       const newStats = {
-        ...stats,
-        kanjiStats: {
-          ...stats.kanjiStats,
-          [kanji.id]: { ...cur, ...calculateNextReview(cur, 'again'), status: 'learning', mistakes: (cur.mistakes || 0) + 1 },
-        },
+        ...currentStats,
+        kanjiStats: { ...currentStats.kanjiStats, [kanji.id]: card },
       };
-      setStats(newStats); StorageAPI.saveStats(newStats); audioCtrl.playSE('stamp_bad');
-    } else {
-      earnedRef.current = { ...earnedRef.current, exp: earnedRef.current.exp + 2, coins: earnedRef.current.coins + 1 };
+      StorageAPI.saveStats(newStats);
+      return newStats;
+    });
+
+    if (isKnown) {
       setDisplayEarned({ ...earnedRef.current });
       audioCtrl.playSE('stamp_good');
+    } else {
+      audioCtrl.playSE('stamp_bad');
     }
     setRevealed(false);
     setIdx(prev => prev + 1);
-  }, [kanji, revealed, stats, setStats]);
+  }, [kanji, revealed, setStats]);
 
   // スワイプ操作（読み表示後のみ）
   const handleTouchStart = (e) => { touchStartX.current = e.touches[0].clientX; };

--- a/src/systems/learning-plan.js
+++ b/src/systems/learning-plan.js
@@ -1,3 +1,5 @@
+import { formatDate } from '../utils/date-utils.js';
+
 export const DAILY_GOAL_OPTIONS = [5, 10, 20];
 export const DEFAULT_DAILY_GOAL = 10;
 export const DEFAULT_WEAK_SESSION_LIMIT = 5;
@@ -29,6 +31,59 @@ export function getDailyLearningProgress(stats, today) {
     remaining,
     percent: Math.min(100, Math.round((reviewed / goal) * 100)),
     isComplete: reviewed >= goal,
+  };
+}
+
+/**
+ * 指定日までの7日間を、現在の1日目標と学習実績から集計する。
+ * 旧データに挑戦数がない場合は正答率へ含めず、推測値を表示しない。
+ */
+export function getWeeklyLearningSummary(stats, endDate = new Date()) {
+  const parsedEnd = new Date(endDate);
+  const end = Number.isNaN(parsedEnd.getTime()) ? new Date() : parsedEnd;
+  end.setHours(12, 0, 0, 0);
+
+  const goal = getDailyGoal(stats?.settings);
+  const days = [];
+
+  for (let offset = 6; offset >= 0; offset--) {
+    const date = new Date(end);
+    date.setDate(end.getDate() - offset);
+    const key = formatDate(date);
+    const record = stats?.daily?.[key] || {};
+    const exp = Math.max(0, Number(record.exp) || 0);
+    const reviewed = Math.max(0, Number(record.reviewed) || 0);
+    const attempts = Math.max(0, Number(record.attempts) || 0);
+    const correct = Math.min(attempts, Math.max(0, Number(record.correct) || 0));
+
+    days.push({
+      key,
+      date,
+      exp,
+      reviewed,
+      attempts,
+      correct,
+      studied: exp > 0 || reviewed > 0 || attempts > 0,
+      goalComplete: reviewed >= goal,
+    });
+  }
+
+  const totals = days.reduce((summary, day) => ({
+    studiedDays: summary.studiedDays + (day.studied ? 1 : 0),
+    goalDays: summary.goalDays + (day.goalComplete ? 1 : 0),
+    reviewed: summary.reviewed + day.reviewed,
+    attempts: summary.attempts + day.attempts,
+    correct: summary.correct + day.correct,
+  }), { studiedDays: 0, goalDays: 0, reviewed: 0, attempts: 0, correct: 0 });
+
+  return {
+    ...totals,
+    goal,
+    days,
+    consistencyPercent: Math.round((totals.goalDays / days.length) * 100),
+    accuracy: totals.attempts > 0
+      ? Math.round((totals.correct / totals.attempts) * 100)
+      : null,
   };
 }
 

--- a/src/systems/storage.js
+++ b/src/systems/storage.js
@@ -575,15 +575,19 @@ const StorageAPI = {
     const today = getTodayString();
     const reviewedCount = sessionData.reviewedCount || 0;
     const perfectCount = sessionData.perfectCount || 0;
-    const hasLearningActivity = exp > 0 || reviewedCount > 0;
+    const attemptCount = Math.max(0, Number(sessionData.attemptCount) || 0);
+    const correctCount = Math.min(attemptCount, Math.max(0, Number(sessionData.correctCount) || 0));
+    const hasLearningActivity = exp > 0 || reviewedCount > 0 || attemptCount > 0;
 
     if (hasLearningActivity) {
       if (!stats.daily) stats.daily = {};
-      if (!stats.daily[today]) stats.daily[today] = { exp: 0, reviewed: 0, perfects: 0 };
+      if (!stats.daily[today]) stats.daily[today] = { exp: 0, reviewed: 0, perfects: 0, attempts: 0, correct: 0 };
 
       stats.daily[today].exp += exp;
       stats.daily[today].reviewed = (stats.daily[today].reviewed || 0) + reviewedCount;
       stats.daily[today].perfects = (stats.daily[today].perfects || 0) + perfectCount;
+      stats.daily[today].attempts = (stats.daily[today].attempts || 0) + attemptCount;
+      stats.daily[today].correct = (stats.daily[today].correct || 0) + correctCount;
       stats.totalExp += exp;
       stats.perfectCountTotal = (stats.perfectCountTotal || 0) + perfectCount;
     }

--- a/test/learning-plan.test.js
+++ b/test/learning-plan.test.js
@@ -5,6 +5,7 @@ import {
   buildWeakKanjiPlan,
   getDailyGoal,
   getDailyLearningProgress,
+  getWeeklyLearningSummary,
   WEAK_PRACTICE_SUCCESS_TARGET,
 } from '../src/systems/learning-plan.js';
 import { calculateLearningViewport } from '../src/utils/learning-viewport.js';
@@ -40,6 +41,35 @@ test('学習目標は安全な既定値と当日進捗を返す', () => {
     getDailyLearningProgress({ settings: { dailyGoal: 5 }, daily: { '2026-07-21': { reviewed: 7 } } }, '2026-07-21'),
     { goal: 5, reviewed: 7, remaining: 0, percent: 100, isComplete: true },
   );
+});
+
+test('週次サマリーは目標達成日と記録済み回答の正答率を集計する', () => {
+  const summary = getWeeklyLearningSummary({
+    settings: { dailyGoal: 5 },
+    daily: {
+      '2026-07-15': { exp: 40, reviewed: 5, attempts: 6, correct: 5 },
+      '2026-07-16': { exp: 20, reviewed: 3, attempts: 5, correct: 3 },
+      '2026-07-21': { exp: 0, reviewed: 0, attempts: 2, correct: 0 },
+    },
+  }, new Date(2026, 6, 21, 12));
+
+  assert.equal(summary.studiedDays, 3);
+  assert.equal(summary.goalDays, 1);
+  assert.equal(summary.reviewed, 8);
+  assert.equal(summary.attempts, 13);
+  assert.equal(summary.correct, 8);
+  assert.equal(summary.accuracy, 62);
+  assert.equal(summary.consistencyPercent, 14);
+});
+
+test('挑戦数のない旧日次データから正答率を推測しない', () => {
+  const summary = getWeeklyLearningSummary({
+    settings: { dailyGoal: 5 },
+    daily: { '2026-07-21': { exp: 30, reviewed: 5 } },
+  }, new Date(2026, 6, 21, 12));
+
+  assert.equal(summary.goalDays, 1);
+  assert.equal(summary.accuracy, null);
 });
 
 test('苦手特訓は期限内のつまずきを優先し、3回連続正解した漢字を外す', () => {


### PR DESCRIPTION
## 概要

児童が「今週どれだけ学べたか」と「どの程度定着しているか」を一目で確認できるよう、7日間の学習目標達成状況と正答率を学習記録画面に追加します。

## 変更内容

- 通常練習・苦手漢字練習・フラッシュカードで、回答数と正答数を共通形式で記録
- 直近7日間の目標達成日数と正答率をサマリー表示
- 日別EXPグラフで、目標達成日を緑色とチェックマークで明示
- 全問不正解でも学習を行った日として記録
- フラッシュカードの回答を日次復習数と漢字ごとの練習履歴に反映
- 過去の保存データとの互換性を維持し、回答履歴がない期間の正答率は推測せず「—」と表示
- 週次集計と旧データ互換性の自動テストを追加

## ユーザーへの効果

短期的な成果だけでなく、毎日の目標達成と正答率を継続して確認できるため、学習習慣と漢字定着の両方を意識しやすくなります。

## 検証

- `npm test`（10件すべて成功）
- `npm run build`
- バンドル上限チェック成功（163.0 KiB / 220 KiB）
- `git diff --check`
- 公開後のリモートツリーとローカルツリーの一致を確認
