### PR TITLE
1日の目標に合わせて学習セッションを自動調整

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,7 +10,7 @@ import MobileBottomNav from './components/ui/MobileBottomNav';
 
 import { StorageAPI, getLevelInfo } from './systems/storage';
 import { calculateNextReview, migrateCard, recordPracticeAttempt } from './systems/srs';
-import { buildLearningPlan, buildWeakKanjiPlan } from './systems/learning-plan';
+import { buildLearningPlan, buildWeakKanjiPlan, getDailyLearningProgress, getGoalAwareSessionLimits } from './systems/learning-plan';
 import { audioCtrl } from './systems/audio';
 import { checkLevelUp, grantExpWithLevelRewards } from './utils/level-system';
 import { SESSION, EXP, RARE_DROP, ECONOMY, DEBOUNCE, TEST } from './constants/gameConfig';
@@ -308,7 +308,9 @@ export default function App() {
   const startSession = (selectedGrade) => {
     audioCtrl.init();
     const sessionSize = stats.settings?.sessionSize || 'normal';
-    const limits = SESSION.SIZE_LIMITS[sessionSize] || SESSION.SIZE_LIMITS.normal;
+    const baseLimits = SESSION.SIZE_LIMITS[sessionSize] || SESSION.SIZE_LIMITS.normal;
+    const dailyProgress = getDailyLearningProgress(stats, getTodayString());
+    const limits = getGoalAwareSessionLimits(baseLimits, dailyProgress);
     const { queue } = buildLearningPlan({
       kanjiData: KANJI_DATA,
       kanjiStats: stats.kanjiStats,
@@ -737,7 +739,7 @@ export default function App() {
           {view === 'survival' && <FullScreenWrapper key="survival"><ErrorBoundary onReset={() => setView('home')}><SurvivalView queue={sessionData.queue} onUpdateStat={handleUpdateStat} onFinish={handleFinishSession} /></ErrorBoundary></FullScreenWrapper>}
           {view === 'boss' && <FullScreenWrapper key="boss"><ErrorBoundary onReset={() => setView('home')}><BossBattleView queue={sessionData.queue} onUpdateStat={handleUpdateStat} onFinish={handleFinishSession} onBossDefeat={handleBossDefeat} /></ErrorBoundary></FullScreenWrapper>}
           {view === 'drillTest' && <FullScreenWrapper key="drillTest"><ErrorBoundary onReset={() => setView('home')}><DrillTestView queue={sessionData.queue} stats={stats} onUpdateStat={handleUpdateStat} onFinish={handleFinishSession} startDrillSession={startDrillSession} setView={setView} setSessionData={setSessionData} createInitialSessionData={createInitialSessionData} /></ErrorBoundary></FullScreenWrapper>}
-          {view === 'result' && <PageWrapper key="result"><ErrorBoundary onReset={() => setView('home')}><ResultView sessionMetrics={sessionData} oldExp={sessionData.oldExp} setView={setView} stats={stats} setStats={setStats} /></ErrorBoundary></PageWrapper>}
+          {view === 'result' && <PageWrapper key="result"><ErrorBoundary onReset={() => setView('home')}><ResultView sessionMetrics={sessionData} oldExp={sessionData.oldExp} setView={setView} stats={stats} setStats={setStats} onContinueLearning={() => startSession(stats.targetGrade || 1)} /></ErrorBoundary></PageWrapper>}
         </AnimatePresence>
         </Suspense>
       </main>

--- a/src/components/pages/HomeView.jsx
+++ b/src/components/pages/HomeView.jsx
@@ -1,4 +1,4 @@
-import React, { lazy, Suspense, useState } from 'react';
+import React, { lazy, Suspense, useMemo, useState } from 'react';
 import { motion } from 'framer-motion';
 import { Coins, TrendingUp, PenTool, FileText, Download, AlertCircle, Zap, Flame, Ghost, Library, Map, Medal, BarChart3, ShieldAlert, Users, Hammer, Lock, Sparkles, Target, CheckCircle2 } from 'lucide-react';
 import { MotionButton } from '../ui';
@@ -10,7 +10,7 @@ import { StorageAPI, calculateProsperity, getLevelInfo } from '../../systems/sto
 import { audioCtrl } from '../../systems/audio';
 import { F } from '../ui/FormatKun';
 import { calculateSatisfaction, getSatisfactionLabel } from '../../systems/residents';
-import { getDailyLearningProgress } from '../../systems/learning-plan';
+import { buildLearningPlan, getDailyLearningProgress, getGoalAwareSessionLimits } from '../../systems/learning-plan';
 import { getTodayString } from '../../utils/date-utils';
 import { SESSION } from '../../constants/gameConfig';
 
@@ -32,23 +32,25 @@ const TownMapFallback = () => (
 const HomeView = ({ setView, stats, setStats, startSession, startFlashcard, startSurvival, startBossBattle, levelInfo, dailyMissions, onClaimMission, isMobile }) => {
   const currentLevelInfo = levelInfo || getLevelInfo(stats.totalExp, stats.townMap);
   const { level, title, badge, progress, remainingExp, targetReward, isMaxLevel } = currentLevelInfo;
-  const now = Date.now();
   const [selectedGrade, setSelectedGrade] = useState(stats.targetGrade || 1);
   const handleGradeChange = (g) => { setSelectedGrade(g); let newStats = { ...stats, targetGrade: g }; setStats(newStats); StorageAPI.saveStats(newStats); };
-  const reviewTargetsCount = KANJI_DATA.filter(k => {
-    const s = stats.kanjiStats?.[k.id];
-    return s && s.status !== 'new' && (s.nextReview || 0) <= now;
-  }).length;
-  const isReviewNeeded = reviewTargetsCount > 0;
   const dailyProgress = getDailyLearningProgress(stats, getTodayString());
   const sessionSize = stats.settings?.sessionSize || 'normal';
-  const sessionLimits = SESSION.SIZE_LIMITS[sessionSize] || SESSION.SIZE_LIMITS.normal;
-  const newTargetsCount = KANJI_DATA.filter(k => {
-    const s = stats.kanjiStats?.[k.id];
-    return k.grade === selectedGrade && (!s || s.status === 'new');
-  }).length;
-  const plannedReviewCount = Math.min(reviewTargetsCount, sessionLimits.review);
-  const plannedNewCount = Math.min(newTargetsCount, sessionLimits.new);
+  const baseSessionLimits = SESSION.SIZE_LIMITS[sessionSize] || SESSION.SIZE_LIMITS.normal;
+  const sessionLimits = getGoalAwareSessionLimits(baseSessionLimits, dailyProgress);
+  const learningPlan = useMemo(() => buildLearningPlan({
+    kanjiData: KANJI_DATA,
+    kanjiStats: stats.kanjiStats,
+    selectedGrade,
+    limits: sessionLimits,
+    now: Date.now(),
+    random: () => 0.5,
+  }), [stats.kanjiStats, selectedGrade, sessionLimits.review, sessionLimits.new, sessionLimits.total]);
+  const reviewTargetsCount = learningPlan.dueCount;
+  const plannedReviewCount = learningPlan.reviewCount;
+  const plannedNewCount = learningPlan.newCount;
+  const plannedTotalCount = plannedReviewCount + plannedNewCount;
+  const isReviewNeeded = reviewTargetsCount > 0;
   const prosperity = calculateProsperity(stats.townMap, reviewTargetsCount);
   const learnedCount = KANJI_DATA.filter(k => stats.kanjiStats?.[k.id] && stats.kanjiStats[k.id].status !== 'new').length;
   const isSpecialTrainingUnlocked = learnedCount > 0;
@@ -161,8 +163,10 @@ const HomeView = ({ setView, stats, setStats, startSession, startFlashcard, star
           <button key={g} onClick={() => { audioCtrl.playSE('click'); handleGradeChange(g); }} className={`flex-1 py-1.5 md:py-2 font-black text-sm md:text-base rounded-xl border-[2px] transition-all ${selectedGrade === g ? 'bg-[var(--text)] text-[var(--panel)] border-[var(--text)]' : 'bg-[var(--bg)] text-[var(--text)] border-transparent opacity-60 hover:opacity-100'}`}>{g}年</button>
         ))}
       </div>
-      <MotionButton variant={isReviewNeeded ? "danger" : "primary"} className="w-full py-3 md:py-4 text-base md:text-lg font-black border-[3px] border-[var(--text)] shadow-[0_3px_0_rgba(0,0,0,0.3)]" onClick={() => startSession(selectedGrade)}>
-        {isReviewNeeded
+      <MotionButton variant={isReviewNeeded ? "danger" : "primary"} className="w-full py-3 md:py-4 text-sm sm:text-base md:text-lg font-black border-[3px] border-[var(--text)] shadow-[0_3px_0_rgba(0,0,0,0.3)]" onClick={() => startSession(selectedGrade)}>
+        {!dailyProgress.isComplete && plannedTotalCount > 0
+          ? <><Target size={20} /> きょうの{plannedTotalCount}{F("字","じ")}：{F("復習","ふくしゅう")}{plannedReviewCount}＋{F("新出","しんしゅつ")}{plannedNewCount}</>
+          : isReviewNeeded
           ? <><ShieldAlert size={20} /> {F("復習","ふくしゅう")}{plannedReviewCount}＋{F("新出","しんしゅつ")}{plannedNewCount}</>
           : plannedNewCount > 0
             ? <><PenTool size={20} /> {F("新出","しんしゅつ")}{F("漢字","かんじ")}{plannedNewCount}{F("文字","もじ")}を{F("覚","おぼ")}える！</>

--- a/src/components/pages/ResultView.jsx
+++ b/src/components/pages/ResultView.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Gift, Sparkles, Coins, Map, ChevronRight } from 'lucide-react';
+import { Gift, Sparkles, Coins, Map, ChevronRight, Target, CheckCircle2 } from 'lucide-react';
 import MotionButton from '../ui/MotionButton';
 import AnimatedCounter from '../ui/AnimatedCounter';
 import Confetti from '../ui/Confetti';
@@ -12,16 +12,19 @@ import { F } from '../ui/FormatKun';
 import { audioCtrl } from '../../systems/audio';
 import { getOccupation } from '../../data/residents';
 import { getLevelInfoFromExp } from '../../utils/level-system';
+import { getDailyLearningProgress } from '../../systems/learning-plan';
+import { getTodayString } from '../../utils/date-utils';
 
 import { gachaRoll, isRareItem } from '../../systems/gacha';
 
-const ResultView = ({ sessionMetrics, oldExp, setView, stats, setStats }) => {
+const ResultView = ({ sessionMetrics, oldExp, setView, stats, setStats, onContinueLearning }) => {
   const { earnedExp, perfectCount, unlockedItems, rareDrop, newVillager, levelUpData } = sessionMetrics;
   const [showConfetti, setShowConfetti] = useState(earnedExp > 20 || !!newVillager || levelUpData?.isLevelUp);
   const [showLevelUpModal, setShowLevelUpModal] = useState(false);
   const [gachaResult, setGachaResult] = useState(null);
   const [gachaPhase, setGachaPhase] = useState('idle');
   const coinBonus = Math.floor(earnedExp / 4);
+  const dailyProgress = getDailyLearningProgress(stats, getTodayString());
 
   const oldLevelInfo = getLevelInfoFromExp(oldExp);
   const newLevelInfo = getLevelInfoFromExp(oldExp + earnedExp);
@@ -121,6 +124,30 @@ const ResultView = ({ sessionMetrics, oldExp, setView, stats, setStats }) => {
             {F("次","つぎ")}の報酬まで あと {newLevelInfo.remainingExp} EXP
           </div>
         )}
+      </motion.div>
+
+      {/* 今日の目標：結果を次の学習行動につなげる */}
+      <motion.div
+        initial={{ opacity: 0, y: -12 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.08 }}
+        className={`bg-[var(--panel)] border-[4px] rounded-2xl p-4 shadow-[4px_4px_0_var(--text)] ${dailyProgress.isComplete ? 'border-emerald-400' : 'border-[var(--text)]'}`}
+      >
+        <div className="flex items-center justify-between gap-3 mb-2">
+          <div className="flex items-center gap-2 min-w-0">
+            <div className={`w-10 h-10 rounded-xl border-[3px] border-[var(--text)] flex items-center justify-center shrink-0 ${dailyProgress.isComplete ? 'bg-emerald-400' : 'bg-[var(--accent)]'}`}>
+              {dailyProgress.isComplete ? <CheckCircle2 size={22} /> : <Target size={22} />}
+            </div>
+            <div className="min-w-0">
+              <div className="font-black text-[var(--text)]">{dailyProgress.isComplete ? 'きょうの目標クリア！' : `あと ${dailyProgress.remaining}字で目標クリア`}</div>
+              <div className="text-xs font-bold text-[var(--text)] opacity-55">学習した漢字は毎日の記録にのこります</div>
+            </div>
+          </div>
+          <div className="font-black text-[var(--text)] shrink-0"><span className="text-xl text-[var(--primary)]">{dailyProgress.reviewed}</span><span className="text-xs opacity-50"> / {dailyProgress.goal}字</span></div>
+        </div>
+        <div className="h-3 bg-gray-200 rounded-full overflow-hidden border-2 border-[var(--text)]" role="progressbar" aria-label="今日の学習目標" aria-valuemin="0" aria-valuemax={dailyProgress.goal} aria-valuenow={Math.min(dailyProgress.reviewed, dailyProgress.goal)}>
+          <motion.div initial={{ width: 0 }} animate={{ width: `${dailyProgress.percent}%` }} className={`h-full ${dailyProgress.isComplete ? 'bg-emerald-400' : 'bg-[var(--primary)]'}`} />
+        </div>
       </motion.div>
 
       {/* ストーリーナレーション */}
@@ -234,7 +261,12 @@ const ResultView = ({ sessionMetrics, oldExp, setView, stats, setStats }) => {
 
       {/* ボタン */}
       <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.8 }} className="flex flex-col gap-3">
-        <MotionButton variant="primary" onClick={() => setView('home')} className="w-full py-6 text-2xl font-black border-[4px] border-[var(--text)] shadow-[0_6px_0_#9f1239]">まちに もどる 🏠</MotionButton>
+        {!dailyProgress.isComplete && onContinueLearning && (
+          <MotionButton variant="primary" onClick={onContinueLearning} className="w-full py-5 text-xl font-black border-[4px] border-[var(--text)] shadow-[0_6px_0_#9f1239]">
+            <Target size={24} /> あと{dailyProgress.remaining}字 学習をつづける
+          </MotionButton>
+        )}
+        <MotionButton variant={dailyProgress.isComplete ? "primary" : "secondary"} onClick={() => setView('home')} className="w-full py-5 text-xl font-black border-[4px] border-[var(--text)] shadow-[0_5px_0_var(--text)]">まちに もどる 🏠</MotionButton>
         <MotionButton variant="secondary" onClick={() => setView('townEditor')} className="w-full py-4 text-lg border-[3px] border-[var(--text)] shadow-[0_4px_0_var(--text)]">
           <Map size={20} /> まちをつくる
         </MotionButton>

--- a/src/systems/learning-plan.js
+++ b/src/systems/learning-plan.js
@@ -35,6 +35,24 @@ export function getDailyLearningProgress(stats, today) {
 }
 
 /**
+ * 1日の残り目標に合わせて、次の通常セッションを短く区切る。
+ * 目標達成後は設定済みのセッション量へ戻し、自由に学習を続けられる。
+ */
+export function getGoalAwareSessionLimits(limits, dailyProgress) {
+  const review = asLimit(limits?.review);
+  const newLimit = asLimit(limits?.new);
+  const configuredTotal = review + newLimit;
+  const remaining = asLimit(dailyProgress?.remaining);
+  const shouldCapToGoal = !dailyProgress?.isComplete && remaining > 0;
+
+  return {
+    review,
+    new: newLimit,
+    total: shouldCapToGoal ? Math.min(configuredTotal, remaining) : configuredTotal,
+  };
+}
+
+/**
  * 指定日までの7日間を、現在の1日目標と学習実績から集計する。
  * 旧データに挑戦数がない場合は正答率へ含めず、推測値を表示しない。
  */
@@ -147,6 +165,9 @@ export function buildLearningPlan({
 }) {
   const reviewLimit = asLimit(limits?.review);
   const newLimit = asLimit(limits?.new);
+  const totalLimit = limits?.total === undefined
+    ? reviewLimit + newLimit
+    : asLimit(limits.total);
 
   const dueReviews = kanjiData
     .filter((kanji) => {
@@ -165,8 +186,9 @@ export function buildLearningPlan({
     return kanji.grade === selectedGrade && (!stat || stat.status === 'new');
   });
 
-  const reviewTargets = dueReviews.slice(0, reviewLimit);
-  const newTargets = shuffle(newCandidates, random).slice(0, newLimit);
+  const reviewTargets = dueReviews.slice(0, Math.min(reviewLimit, totalLimit));
+  const remainingSlots = Math.max(0, totalLimit - reviewTargets.length);
+  const newTargets = shuffle(newCandidates, random).slice(0, Math.min(newLimit, remainingSlots));
   const queue = [...reviewTargets, ...newTargets];
 
   if (queue.length === 0) {

--- a/test/learning-plan.test.js
+++ b/test/learning-plan.test.js
@@ -5,6 +5,7 @@ import {
   buildWeakKanjiPlan,
   getDailyGoal,
   getDailyLearningProgress,
+  getGoalAwareSessionLimits,
   getWeeklyLearningSummary,
   WEAK_PRACTICE_SUCCESS_TARGET,
 } from '../src/systems/learning-plan.js';
@@ -40,6 +41,39 @@ test('学習目標は安全な既定値と当日進捗を返す', () => {
   assert.deepEqual(
     getDailyLearningProgress({ settings: { dailyGoal: 5 }, daily: { '2026-07-21': { reviewed: 7 } } }, '2026-07-21'),
     { goal: 5, reviewed: 7, remaining: 0, percent: 100, isComplete: true },
+  );
+});
+
+test('通常セッションは今日の残り目標を超えず、復習を優先して短く区切る', () => {
+  const limits = getGoalAwareSessionLimits(
+    { review: 20, new: 5 },
+    { remaining: 3, isComplete: false },
+  );
+  const plan = buildLearningPlan({
+    kanjiData,
+    kanjiStats: {
+      a: { status: 'review', nextReview: 100 },
+      b: { status: 'learning', nextReview: 50 },
+    },
+    selectedGrade: 1,
+    limits,
+    now: 200,
+    random: () => 0.5,
+  });
+
+  assert.equal(limits.total, 3);
+  assert.deepEqual(plan.queue.map((kanji) => kanji.id), ['b', 'a', 'c']);
+  assert.equal(plan.reviewCount, 2);
+  assert.equal(plan.newCount, 1);
+});
+
+test('今日の目標達成後は設定済みのセッション量へ戻す', () => {
+  assert.deepEqual(
+    getGoalAwareSessionLimits(
+      { review: 20, new: 5 },
+      { remaining: 0, isComplete: true },
+    ),
+    { review: 20, new: 5, total: 25 },
   );
 });
 


### PR DESCRIPTION
## 概要

1日の学習目標を「表示するだけ」で終わらせず、次の通常セッションの出題数と結果画面の行動導線へ連動させます。児童が残り字数を意識しながら、短い区切りで無理なく目標達成まで進められる改善です。

## 変更内容

- 今日の残り目標を超えないよう、通常セッションの出題総数を自動調整
- 出題枠は復習期限を迎えた漢字へ優先配分し、残りを新出漢字で補完
- 目標達成後は設定済みのセッション量へ戻し、自由な追加学習を維持
- ホームのメインボタンに、実際に出題する総数・復習数・新出数を表示
- 結果画面に今日の目標進捗と残り字数を表示
- 目標未達成時は結果画面から次の通常学習へ直接進めるボタンを追加
- ホームの学習計画計算をメモ化し、不要な再計算を抑制
- 目標連動の上限と目標達成後の挙動を自動テストで保証

## ユーザーへの効果

大きなセッションを一度に始める心理的負担を減らし、スマートフォンでも短時間の学習を積み重ねやすくなります。結果を見た直後に次の行動が明確になるため、日次目標の達成と学習習慣の定着につながります。

保存データ形式は変更していないため、既存ユーザーのデータへ影響しません。

## 検証

- `npm test`（12件すべて成功）
- `npm run build`
- バンドル上限チェック成功（163.5 KiB / 220 KiB）
- `git diff --check`
- 公開後のリモートツリーとローカルツリーの一致を確認
