### PR TITLE
中断した学習セッションを続きから再開

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo, lazy, Suspense } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, useRef, lazy, Suspense } from 'react';
 import { AnimatePresence } from 'framer-motion';
 import { PenTool, Volume2, VolumeX, Settings, Users } from 'lucide-react';
 import { useOnlineStatus } from './hooks/useOnlineStatus';
@@ -11,6 +11,7 @@ import MobileBottomNav from './components/ui/MobileBottomNav';
 import { StorageAPI, getLevelInfo } from './systems/storage';
 import { calculateNextReview, migrateCard, recordPracticeAttempt } from './systems/srs';
 import { buildLearningPlan, buildWeakKanjiPlan, getDailyLearningProgress, getGoalAwareSessionLimits } from './systems/learning-plan';
+import { createSessionCheckpoint, restoreSessionCheckpoint } from './systems/session-checkpoint';
 import { audioCtrl } from './systems/audio';
 import { checkLevelUp, grantExpWithLevelRewards } from './utils/level-system';
 import { SESSION, EXP, RARE_DROP, ECONOMY, DEBOUNCE, TEST } from './constants/gameConfig';
@@ -95,8 +96,9 @@ const VOLUME_VALUES = { off: 0, low: 0.3, mid: 0.6, high: 1.0 };
 
 /** セッションデータの初期値を生成する */
 function createInitialSessionData(overrides = {}) {
-  return {
+  const data = {
     queue: [],
+    remainingQueue: null,
     earnedExp: 0,
     oldExp: 0,
     expMultiplier: 1,
@@ -106,12 +108,18 @@ function createInitialSessionData(overrides = {}) {
     attemptCount: 0,
     correctCount: 0,
     newKanjiCount: 0,
+    masteredCount: 0,
     unlockedItems: [],
     rareDrop: null,
     isDrill: false,
     isTest: false,
+    isWeakPractice: false,
     newVillager: null,
     ...overrides,
+  };
+  return {
+    ...data,
+    remainingQueue: Array.isArray(data.remainingQueue) ? data.remainingQueue : data.queue,
   };
 }
 
@@ -128,10 +136,25 @@ export default function App() {
     return null;
   }, []);
 
-  const [view, setView] = useState(connectParam ? 'peerClient' : 'home');
+  const [initialAppState] = useState(() => {
+    const loadedStats = StorageAPI.getStats();
+    const savedCheckpoint = StorageAPI.getActiveSession();
+    const restoredSession = restoreSessionCheckpoint(savedCheckpoint, KANJI_DATA);
+    if (savedCheckpoint && !restoredSession) StorageAPI.clearActiveSession();
+    return { loadedStats, restoredSession };
+  });
+
+  const [view, setView] = useState(connectParam ? 'peerClient' : initialAppState.restoredSession ? 'session' : 'home');
   const [isMuted, setIsMuted] = useState(audioCtrl.muted);
-  const [stats, setStats] = useState(StorageAPI.getStats());
-  const [sessionData, setSessionData] = useState(createInitialSessionData);
+  const [stats, setStats] = useState(initialAppState.loadedStats);
+  const [sessionData, setSessionDataState] = useState(() => createInitialSessionData(initialAppState.restoredSession || {}));
+  const sessionDataRef = useRef(sessionData);
+  const setSessionData = useCallback((update) => {
+    const next = typeof update === 'function' ? update(sessionDataRef.current) : update;
+    sessionDataRef.current = next;
+    setSessionDataState(next);
+  }, []);
+  const [isResumedSession, setIsResumedSession] = useState(Boolean(initialAppState.restoredSession));
   const [hostDrill, setHostDrill] = useState(null);
 
   // Phase 5: チュートリアル
@@ -153,6 +176,15 @@ export default function App() {
   usePrefetchKanji(isOnline, stats.targetGrade, KANJI_DATA);
 
   const levelInfo = useMemo(() => getLevelInfo(stats.totalExp, stats.townMap), [stats.totalExp, stats.townMap]);
+
+  // コア学習中は回答記録と残りキューを同じタイミングで端末へ保存する。
+  useEffect(() => {
+    if (view !== 'session' || !sessionData.remainingQueue?.length) return;
+    const checkpoint = createSessionCheckpoint(sessionData);
+    if (!checkpoint) return;
+    StorageAPI.saveStatsImmediate(stats);
+    StorageAPI.saveActiveSession(checkpoint);
+  }, [view, stats, sessionData]);
 
   // ログインボーナス＆デイリーミッション初期化関数
   // 関数型 setStats を使い、stale な currentStats を上書きしないようにする
@@ -305,6 +337,23 @@ export default function App() {
     StorageAPI.saveStats(newStats);
   };
 
+  const beginSession = useCallback((nextView, overrides) => {
+    StorageAPI.clearActiveSession();
+    setIsResumedSession(false);
+    setSessionData(createInitialSessionData(overrides));
+    setView(nextView);
+  }, [setSessionData]);
+
+  const handleSessionProgress = useCallback((remainingQueue) => {
+    setSessionData((current) => ({ ...current, remainingQueue }));
+  }, [setSessionData]);
+
+  const abandonLearningSession = useCallback(() => {
+    StorageAPI.clearActiveSession();
+    setIsResumedSession(false);
+    setView('home');
+  }, []);
+
   const startSession = (selectedGrade) => {
     audioCtrl.init();
     const sessionSize = stats.settings?.sessionSize || 'normal';
@@ -319,8 +368,7 @@ export default function App() {
     });
     const expMultiplier = getSatisfactionMultiplier(calculateSatisfaction(stats));
     if (queue.length > 0) {
-      setSessionData(createInitialSessionData({ queue, oldExp: stats.totalExp, expMultiplier }));
-      setView('session');
+      beginSession('session', { queue, oldExp: stats.totalExp, expMultiplier });
     }
   };
 
@@ -329,8 +377,7 @@ export default function App() {
     const queue = KANJI_DATA.filter(k => drill.kanjis?.includes(k.id));
     const expMultiplier = getSatisfactionMultiplier(calculateSatisfaction(stats));
     if (queue.length > 0) {
-      setSessionData(createInitialSessionData({ queue, oldExp: stats.totalExp, expMultiplier, isDrill: true }));
-      setView('session');
+      beginSession('session', { queue, oldExp: stats.totalExp, expMultiplier, isDrill: true });
     }
   };
 
@@ -351,16 +398,14 @@ export default function App() {
     candidates.sort(() => Math.random() - 0.5);
     const expMultiplier = getSatisfactionMultiplier(calculateSatisfaction(stats));
     if (candidates.length > 0) {
-      setSessionData(createInitialSessionData({ queue: candidates, oldExp: stats.totalExp, expMultiplier, isDrill: true, isTest: true }));
-      setView('drillTest');
+      beginSession('drillTest', { queue: candidates, oldExp: stats.totalExp, expMultiplier, isDrill: true, isTest: true });
     }
   };
 
   const startSingleSession = (kanji) => {
     audioCtrl.init();
     const expMultiplier = getSatisfactionMultiplier(calculateSatisfaction(stats));
-    setSessionData(createInitialSessionData({ queue: [kanji], oldExp: stats.totalExp, expMultiplier }));
-    setView('session');
+    beginSession('session', { queue: [kanji], oldExp: stats.totalExp, expMultiplier });
   };
 
   const startFlashcard = () => {
@@ -369,8 +414,7 @@ export default function App() {
     if (learned.length === 0) return;
     const queue = [...learned].sort(() => Math.random() - 0.5).slice(0, 10);
     const expMultiplier = getSatisfactionMultiplier(calculateSatisfaction(stats));
-    setSessionData(createInitialSessionData({ queue, oldExp: stats.totalExp, expMultiplier }));
-    setView('flashcard');
+    beginSession('flashcard', { queue, oldExp: stats.totalExp, expMultiplier });
   };
 
   const startWeakSession = () => {
@@ -382,14 +426,13 @@ export default function App() {
     if (queue.length === 0) return;
 
     const expMultiplier = getSatisfactionMultiplier(calculateSatisfaction(stats));
-    setSessionData(createInitialSessionData({
+    beginSession('session', {
       queue,
       oldExp: stats.totalExp,
       expMultiplier,
       isDrill: true,
       isWeakPractice: true,
-    }));
-    setView('session');
+    });
   };
 
   const startSurvival = () => {
@@ -398,8 +441,7 @@ export default function App() {
     if (learned.length === 0) return;
     const queue = [...learned].sort(() => Math.random() - 0.5);
     const expMultiplier = getSatisfactionMultiplier(calculateSatisfaction(stats));
-    setSessionData(createInitialSessionData({ queue, oldExp: stats.totalExp, expMultiplier }));
-    setView('survival');
+    beginSession('survival', { queue, oldExp: stats.totalExp, expMultiplier });
   };
 
   const startBossBattle = () => {
@@ -414,8 +456,7 @@ export default function App() {
       queue.push(queue[Math.floor(Math.random() * queue.length)]);
     }
     const expMultiplier = getSatisfactionMultiplier(calculateSatisfaction(stats));
-    setSessionData(createInitialSessionData({ queue, oldExp: stats.totalExp, expMultiplier }));
-    setView('boss');
+    beginSession('boss', { queue, oldExp: stats.totalExp, expMultiplier });
   };
 
   const handleUpdateStat = (kanjiObj, evalType) => {
@@ -527,7 +568,9 @@ export default function App() {
   const handleRecordEasy = useCallback(() => { setSessionData(d => ({ ...d, easyCount: d.easyCount + 1 })); }, []);
 
   const handleFinishSession = (additionalResults = {}) => {
-    const totalExp = sessionData.earnedExp + (additionalResults.exp || 0);
+    // setSessionData はrefも同期更新するため、最後の回答直後でも最新集計を確定できる。
+    const activeSession = sessionDataRef.current;
+    const totalExp = activeSession.earnedExp + (additionalResults.exp || 0);
     const coinBonus = Math.floor(totalExp / ECONOMY.EXP_TO_COIN_DIVISOR) + (additionalResults.coins || 0);
     const rareChance = RARE_DROP.BASE_CHANCE + (stats.streak * RARE_DROP.STREAK_BONUS);
     let rareDrop = additionalResults.rareDrop || null;
@@ -536,12 +579,12 @@ export default function App() {
     }
     
     // レベルアップ判定と報酬計算
-    const oldExp = sessionData.oldExp;
+    const oldExp = activeSession.oldExp;
     const newExp = oldExp + totalExp;
     const levelUpData = checkLevelUp(oldExp, newExp);
     
     let earnedCoins = coinBonus;
-    const unlockedItemsThisSession = [...sessionData.unlockedItems];
+    const unlockedItemsThisSession = [...activeSession.unlockedItems];
     let addedRadius = 0;
 
     if (levelUpData.isLevelUp) {
@@ -558,13 +601,13 @@ export default function App() {
     }
 
     const finalSessionData = { 
-      ...sessionData, 
+      ...activeSession,
       earnedExp: totalExp, 
       rareDrop, 
-      perfectCount: sessionData.perfectCount + (additionalResults.perfectCount || 0),
-      reviewedCount: sessionData.reviewedCount + (additionalResults.reviewedCount || 0),
-      attemptCount: sessionData.attemptCount + (additionalResults.attemptCount || 0),
-      correctCount: sessionData.correctCount
+      perfectCount: activeSession.perfectCount + (additionalResults.perfectCount || 0),
+      reviewedCount: activeSession.reviewedCount + (additionalResults.reviewedCount || 0),
+      attemptCount: activeSession.attemptCount + (additionalResults.attemptCount || 0),
+      correctCount: activeSession.correctCount
         + (additionalResults.correctCount ?? additionalResults.reviewedCount ?? 0),
       unlockedItems: unlockedItemsThisSession,
       levelUpData // ResultViewに渡すレベルアップ情報
@@ -583,7 +626,7 @@ export default function App() {
       // learningフェーズの漢字がセッション直後にお化けとして出ないよう、
       // nextReviewに猶予を持たせる
       const minNextReview = Date.now() + SESSION.GRACE_PERIOD;
-      sessionData.queue.forEach(k => {
+      activeSession.queue.forEach(k => {
         const ks = newStats.kanjiStats?.[k.id];
         if (ks && !ks.graduated && ks.status !== 'new' && ks.nextReview < minNextReview) {
           ks.nextReview = minNextReview;
@@ -596,10 +639,10 @@ export default function App() {
 
     // デイリーミッション進捗更新
     setDailyMissions(prev => {
-      const reviewCount = sessionData.reviewedCount + (additionalResults.reviewedCount || 0);
-      const perfectCount = sessionData.perfectCount + (additionalResults.perfectCount || 0);
-      const newKanjiCount = (sessionData.newKanjiCount || 0) + (additionalResults.newKanjiCount || 0);
-      const masteredCount = (sessionData.masteredCount || 0) + (additionalResults.masteredCount || 0);
+      const reviewCount = activeSession.reviewedCount + (additionalResults.reviewedCount || 0);
+      const perfectCount = activeSession.perfectCount + (additionalResults.perfectCount || 0);
+      const newKanjiCount = (activeSession.newKanjiCount || 0) + (additionalResults.newKanjiCount || 0);
+      const masteredCount = (activeSession.masteredCount || 0) + (additionalResults.masteredCount || 0);
       let updated = updateMissionProgress(prev, 'session', 1);
       updated = updateMissionProgress(updated, 'review', reviewCount);
       updated = updateMissionProgress(updated, 'perfect', perfectCount);
@@ -612,6 +655,8 @@ export default function App() {
       return updated;
     });
 
+    StorageAPI.clearActiveSession();
+    setIsResumedSession(false);
     setView('result');
   };
 
@@ -734,7 +779,7 @@ export default function App() {
           {view === 'peerHost' && <PageWrapper key="peerHost"><ErrorBoundary onReset={() => setView('home')}><TeacherHostView setView={setView} drill={hostDrill} /></ErrorBoundary></PageWrapper>}
           {view === 'peerClient' && <PageWrapper key="peerClient"><ErrorBoundary onReset={() => setView('home')}><StudentClientView setView={setView} stats={stats} setStats={setStats} initialConnectId={connectParam} /></ErrorBoundary></PageWrapper>}
           {view === 'gacha' && <PageWrapper key="gacha"><ErrorBoundary onReset={() => setView('home')}><GachaView stats={stats} setStats={setStats} onBack={() => setView('home')} /></ErrorBoundary></PageWrapper>}
-          {view === 'session' && <FullScreenWrapper key="session"><ErrorBoundary onReset={() => setView('home')}><SessionView queue={sessionData.queue} stats={stats.kanjiStats || {}} onUpdateStat={handleUpdateStat} onFinish={handleFinishSession} onRecordPerfect={handleRecordPerfect} onRecordEasy={handleRecordEasy} /></ErrorBoundary></FullScreenWrapper>}
+          {view === 'session' && <FullScreenWrapper key="session"><ErrorBoundary onReset={abandonLearningSession}><SessionView queue={sessionData.remainingQueue || sessionData.queue} totalCount={sessionData.queue.length} stats={stats.kanjiStats || {}} onUpdateStat={handleUpdateStat} onProgress={handleSessionProgress} onFinish={handleFinishSession} onRecordPerfect={handleRecordPerfect} onRecordEasy={handleRecordEasy} isResumed={isResumedSession} /></ErrorBoundary></FullScreenWrapper>}
           {view === 'flashcard' && <FullScreenWrapper key="flashcard"><ErrorBoundary onReset={() => setView('home')}><FlashcardView queue={sessionData.queue} stats={stats} setStats={setStats} onFinish={handleFinishSession} /></ErrorBoundary></FullScreenWrapper>}
           {view === 'survival' && <FullScreenWrapper key="survival"><ErrorBoundary onReset={() => setView('home')}><SurvivalView queue={sessionData.queue} onUpdateStat={handleUpdateStat} onFinish={handleFinishSession} /></ErrorBoundary></FullScreenWrapper>}
           {view === 'boss' && <FullScreenWrapper key="boss"><ErrorBoundary onReset={() => setView('home')}><BossBattleView queue={sessionData.queue} onUpdateStat={handleUpdateStat} onFinish={handleFinishSession} onBossDefeat={handleBossDefeat} /></ErrorBoundary></FullScreenWrapper>}

--- a/src/components/session/SessionView.jsx
+++ b/src/components/session/SessionView.jsx
@@ -12,12 +12,21 @@ import { fetchKanjiVg } from '../../systems/kanjiVg';
 import { F } from '../ui/FormatKun';
 import { useLearningViewport } from '../../hooks/useLearningViewport';
 
-const SessionView = ({ queue: initialQueue, stats, onUpdateStat, onFinish, onRecordPerfect, onRecordEasy }) => {
+const SessionView = ({ queue: initialQueue, totalCount, stats, onUpdateStat, onProgress, onFinish, onRecordPerfect, onRecordEasy, isResumed = false }) => {
   const [queue, setQueue] = useState(initialQueue); const [mode, setMode] = useState('read'); const [paths, setPaths] = useState([]); const [strokeData, setStrokeData] = useState([]); const [crossMatrix, setCrossMatrix] = useState([]); const [isLoading, setIsLoading] = useState(false);
   const { canvasSize, isStacked } = useLearningViewport();
   const [activeStamp, setActiveStamp] = useState(null); const [combo, setCombo] = useState(0); const [reachedStep, setReachedStep] = useState(0);
   const currentKanji = queue[0]; const isNew = !stats[currentKanji?.id] || stats[currentKanji?.id].status === 'new'; const MODES = useMemo(() => ['read', 'watch', 'write', 'test'], []);
   const [fetchError, setFetchError] = useState(null);
+  const [showResumeNotice, setShowResumeNotice] = useState(isResumed);
+  const sessionTotal = Math.max(Number(totalCount) || 0, initialQueue.length, 1);
+  const completedCount = Math.max(0, sessionTotal - queue.length);
+
+  useEffect(() => {
+    if (!showResumeNotice) return undefined;
+    const timer = setTimeout(() => setShowResumeNotice(false), 3200);
+    return () => clearTimeout(timer);
+  }, [showResumeNotice]);
 
   useEffect(() => {
     if (!currentKanji) return; setMode(isNew ? 'read' : 'test'); setReachedStep(isNew ? 0 : 3);
@@ -71,8 +80,17 @@ const SessionView = ({ queue: initialQueue, stats, onUpdateStat, onFinish, onRec
     setTimeout(() => {
       setActiveStamp(null);
       const success = onUpdateStat(currentKanji, evalType);
-      if (success) { const nextQueue = queue.slice(1); if (nextQueue.length === 0) onFinish(); else setQueue(nextQueue); }
-      else { const nextQueue = [...queue.slice(1), currentKanji]; setQueue(nextQueue); setMode('watch'); }
+      if (success) {
+        const nextQueue = queue.slice(1);
+        onProgress?.(nextQueue);
+        if (nextQueue.length === 0) onFinish();
+        else setQueue(nextQueue);
+      } else {
+        const nextQueue = [...queue.slice(1), currentKanji];
+        onProgress?.(nextQueue);
+        setQueue(nextQueue);
+        setMode('watch');
+      }
     }, evalType === 'again' ? 1500 : 900); // again以外は短めに
   };
   if (!currentKanji) return null;
@@ -102,6 +120,19 @@ const SessionView = ({ queue: initialQueue, stats, onUpdateStat, onFinish, onRec
 
   return (
     <div className="flex-1 bg-[var(--panel)] rounded-none md:rounded-[24px] shadow-none md:shadow-[6px_6px_0_var(--text)] border-0 md:border-[4px] border-[var(--text)] p-2 md:p-4 xl:p-5 flex flex-col h-full overflow-hidden relative">
+      <AnimatePresence>
+        {showResumeNotice && (
+          <motion.div
+            initial={{ opacity: 0, y: -12, x: '-50%' }}
+            animate={{ opacity: 1, y: 0, x: '-50%' }}
+            exit={{ opacity: 0, y: -8, x: '-50%' }}
+            role="status"
+            className="absolute top-14 md:top-16 left-1/2 z-40 whitespace-nowrap rounded-full border-[3px] border-[var(--text)] bg-emerald-100 px-4 py-2 text-xs md:text-sm font-black text-emerald-800 shadow-[3px_3px_0_var(--text)]"
+          >
+            ✓ つづきから再開しました
+          </motion.div>
+        )}
+      </AnimatePresence>
       <StampEffect stamp={activeStamp} />
       <div className="flex justify-between items-center mb-1.5 md:mb-2 shrink-0 gap-2">
         <div className="text-[var(--text)] font-bold text-xs md:text-sm bg-[var(--bg)] px-2.5 md:px-4 py-1.5 md:py-2 rounded-full border-[3px] border-[var(--text)] shadow-sm flex items-center gap-1.5" aria-live="polite">のこり <span className="text-base md:text-lg font-black">{queue.length}</span> {F("文字","もじ")}</div>
@@ -110,8 +141,8 @@ const SessionView = ({ queue: initialQueue, stats, onUpdateStat, onFinish, onRec
           {isNew && <div className="text-[var(--panel)] font-bold text-xs md:text-sm bg-[var(--primary)] px-2.5 md:px-4 py-1.5 md:py-2 rounded-full flex items-center gap-1 border-[3px] border-[var(--text)] shadow-sm"><Star size={15} /> {F("新出","しんしゅつ")}</div>}
         </div>
       </div>
-      <div className="h-2 shrink-0 rounded-full bg-[var(--bg)] border-2 border-[var(--text)] overflow-hidden mb-1.5 md:mb-2" aria-label={`学習の進み具合 ${Math.max(0, initialQueue.length - queue.length)} / ${initialQueue.length}`}>
-        <motion.div className="h-full bg-[var(--secondary)]" animate={{ width: `${Math.max(0, ((initialQueue.length - queue.length) / initialQueue.length) * 100)}%` }} />
+      <div className="h-2 shrink-0 rounded-full bg-[var(--bg)] border-2 border-[var(--text)] overflow-hidden mb-1.5 md:mb-2" role="progressbar" aria-label="学習の進み具合" aria-valuemin="0" aria-valuemax={sessionTotal} aria-valuenow={completedCount}>
+        <motion.div className="h-full bg-[var(--secondary)]" animate={{ width: `${(completedCount / sessionTotal) * 100}%` }} />
       </div>
       <div className="flex-1 min-h-0 w-full relative">
         {fetchError ? (

--- a/src/systems/session-checkpoint.js
+++ b/src/systems/session-checkpoint.js
@@ -1,0 +1,125 @@
+export const SESSION_CHECKPOINT_VERSION = 1;
+export const SESSION_CHECKPOINT_MAX_AGE_MS = 12 * 60 * 60 * 1000;
+
+const NUMBER_FIELDS = [
+  'earnedExp',
+  'oldExp',
+  'perfectCount',
+  'easyCount',
+  'reviewedCount',
+  'attemptCount',
+  'correctCount',
+  'newKanjiCount',
+  'masteredCount',
+];
+
+const BOOLEAN_FIELDS = ['isDrill', 'isTest', 'isWeakPractice'];
+
+const asNonNegativeNumber = (value) => {
+  const number = Number(value);
+  return Number.isFinite(number) ? Math.max(0, number) : 0;
+};
+
+const asMultiplier = (value) => {
+  const number = Number(value);
+  return Number.isFinite(number) ? Math.min(10, Math.max(0, number)) : 1;
+};
+
+function getQueueIds(queue) {
+  if (!Array.isArray(queue)) return [];
+  return queue
+    .map((kanji) => kanji?.id)
+    .filter((id) => typeof id === 'string' && id.length > 0);
+}
+
+/**
+ * 学習セッションを小さなIDベースのチェックポイントへ変換する。
+ * 漢字データ本体は保存せず、アプリ更新後も現在のマスターデータから復元する。
+ */
+export function createSessionCheckpoint(sessionData, now = Date.now()) {
+  const queueIds = getQueueIds(sessionData?.queue);
+  const remainingQueueIds = getQueueIds(
+    Array.isArray(sessionData?.remainingQueue)
+      ? sessionData.remainingQueue
+      : sessionData?.queue,
+  );
+
+  if (queueIds.length === 0 || remainingQueueIds.length === 0) return null;
+
+  const metrics = {};
+  NUMBER_FIELDS.forEach((field) => {
+    metrics[field] = asNonNegativeNumber(sessionData?.[field]);
+  });
+  BOOLEAN_FIELDS.forEach((field) => {
+    metrics[field] = Boolean(sessionData?.[field]);
+  });
+
+  return {
+    version: SESSION_CHECKPOINT_VERSION,
+    savedAt: Number(now),
+    queueIds,
+    remainingQueueIds,
+    metrics: {
+      ...metrics,
+      expMultiplier: asMultiplier(sessionData?.expMultiplier),
+      unlockedItems: Array.isArray(sessionData?.unlockedItems)
+        ? sessionData.unlockedItems.filter((id) => typeof id === 'string')
+        : [],
+      rareDrop: typeof sessionData?.rareDrop === 'string' ? sessionData.rareDrop : null,
+      newVillager: sessionData?.newVillager && typeof sessionData.newVillager === 'object'
+        ? sessionData.newVillager
+        : null,
+    },
+  };
+}
+
+/**
+ * 保存済みチェックポイントを検証し、現在の漢字データへ安全に再接続する。
+ */
+export function restoreSessionCheckpoint(checkpoint, kanjiData, now = Date.now()) {
+  if (!checkpoint || checkpoint.version !== SESSION_CHECKPOINT_VERSION) return null;
+
+  const savedAt = Number(checkpoint.savedAt);
+  const age = Number(now) - savedAt;
+  if (!Number.isFinite(savedAt) || age < -5 * 60 * 1000 || age > SESSION_CHECKPOINT_MAX_AGE_MS) {
+    return null;
+  }
+
+  if (!Array.isArray(checkpoint.queueIds) || !Array.isArray(checkpoint.remainingQueueIds)) {
+    return null;
+  }
+
+  const originalIds = new Set(checkpoint.queueIds);
+  if (!checkpoint.remainingQueueIds.every((id) => originalIds.has(id))) return null;
+
+  const byId = new Map((kanjiData || []).map((kanji) => [kanji.id, kanji]));
+  const queue = checkpoint.queueIds.map((id) => byId.get(id));
+  const remainingQueue = checkpoint.remainingQueueIds.map((id) => byId.get(id));
+
+  if (queue.length === 0 || remainingQueue.length === 0 || queue.some((kanji) => !kanji) || remainingQueue.some((kanji) => !kanji)) {
+    return null;
+  }
+
+  const savedMetrics = checkpoint.metrics || {};
+  const metrics = {};
+  NUMBER_FIELDS.forEach((field) => {
+    metrics[field] = asNonNegativeNumber(savedMetrics[field]);
+  });
+  BOOLEAN_FIELDS.forEach((field) => {
+    metrics[field] = Boolean(savedMetrics[field]);
+  });
+
+  return {
+    queue,
+    remainingQueue,
+    ...metrics,
+    expMultiplier: asMultiplier(savedMetrics.expMultiplier),
+    unlockedItems: Array.isArray(savedMetrics.unlockedItems)
+      ? savedMetrics.unlockedItems.filter((id) => typeof id === 'string')
+      : [],
+    rareDrop: typeof savedMetrics.rareDrop === 'string' ? savedMetrics.rareDrop : null,
+    newVillager: savedMetrics.newVillager && typeof savedMetrics.newVillager === 'object'
+      ? savedMetrics.newVillager
+      : null,
+  };
+}

--- a/src/systems/storage.js
+++ b/src/systems/storage.js
@@ -36,6 +36,7 @@ function logStorageError(context, error) {
 
 // ── ストレージキー定数 ──
 const STORAGE_KEY = 'kanji_town_v7';
+const ACTIVE_SESSION_KEY = 'kanji_town_active_session_v1';
 const LEGACY_KEYS = ['kanji_mega_builder_final_v6', 'kanji_mega_builder_final_v5'];
 
 // ── TOWN_ITEMSのルックアップマップ（O(1)検索用） ──
@@ -177,7 +178,7 @@ const StorageAPI = {
    */
   _purgeUnrelatedKeys: () => {
     try {
-      const KEEP = new Set([STORAGE_KEY, ...LEGACY_KEYS, 'kanji_town_resident_mode']);
+      const KEEP = new Set([STORAGE_KEY, ACTIVE_SESSION_KEY, ...LEGACY_KEYS, 'kanji_town_resident_mode']);
       const removable = [];
       for (let i = 0; i < window.localStorage.length; i++) {
         const k = window.localStorage.key(i);
@@ -256,6 +257,30 @@ const StorageAPI = {
       _saveDebounceTimer = null;
     }
     StorageAPI.safeSet(STORAGE_KEY, stats);
+  },
+
+  /** 学習途中の小さなチェックポイントを即時保存する。 */
+  saveActiveSession: (checkpoint) => {
+    try {
+      window.localStorage.setItem(ACTIVE_SESSION_KEY, JSON.stringify(checkpoint));
+      return true;
+    } catch (error) {
+      logStorageError('saveActiveSession', error);
+      _notifySaveError('active-session');
+      return false;
+    }
+  },
+
+  /** 保存済みの学習チェックポイントを取得する。 */
+  getActiveSession: () => StorageAPI.safeGet(ACTIVE_SESSION_KEY, null),
+
+  /** 完了・破棄された学習チェックポイントを削除する。 */
+  clearActiveSession: () => {
+    try {
+      window.localStorage.removeItem(ACTIVE_SESSION_KEY);
+    } catch (error) {
+      logStorageError('clearActiveSession', error);
+    }
   },
 
   GRID_SIZE: MAP.GRID_SIZE,

--- a/test/session-checkpoint.test.js
+++ b/test/session-checkpoint.test.js
@@ -1,0 +1,60 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createSessionCheckpoint,
+  restoreSessionCheckpoint,
+  SESSION_CHECKPOINT_MAX_AGE_MS,
+} from '../src/systems/session-checkpoint.js';
+
+const kanjiData = [
+  { id: 'one', char: '一' },
+  { id: 'two', char: '二' },
+  { id: 'three', char: '三' },
+];
+
+test('学習途中の残りキューと獲得記録をIDベースで復元する', () => {
+  const now = Date.UTC(2026, 6, 21, 12);
+  const checkpoint = createSessionCheckpoint({
+    queue: kanjiData,
+    remainingQueue: [kanjiData[1], kanjiData[2]],
+    earnedExp: 15,
+    reviewedCount: 1,
+    attemptCount: 2,
+    correctCount: 1,
+    expMultiplier: 1.15,
+    isDrill: true,
+    unlockedItems: ['t_tree'],
+  }, now);
+
+  assert.deepEqual(checkpoint.queueIds, ['one', 'two', 'three']);
+  assert.deepEqual(checkpoint.remainingQueueIds, ['two', 'three']);
+
+  const restored = restoreSessionCheckpoint(checkpoint, kanjiData, now + 60_000);
+  assert.deepEqual(restored.queue.map((kanji) => kanji.id), ['one', 'two', 'three']);
+  assert.deepEqual(restored.remainingQueue.map((kanji) => kanji.id), ['two', 'three']);
+  assert.equal(restored.earnedExp, 15);
+  assert.equal(restored.attemptCount, 2);
+  assert.equal(restored.isDrill, true);
+  assert.equal(restored.expMultiplier, 1.15);
+});
+
+test('期限切れまたは未知の漢字を含むチェックポイントは復元しない', () => {
+  const now = Date.UTC(2026, 6, 21, 12);
+  const checkpoint = createSessionCheckpoint({
+    queue: kanjiData,
+    remainingQueue: [kanjiData[2]],
+  }, now);
+
+  assert.equal(
+    restoreSessionCheckpoint(checkpoint, kanjiData, now + SESSION_CHECKPOINT_MAX_AGE_MS + 1),
+    null,
+  );
+  assert.equal(
+    restoreSessionCheckpoint({ ...checkpoint, remainingQueueIds: ['unknown'] }, kanjiData, now),
+    null,
+  );
+  assert.equal(
+    restoreSessionCheckpoint({ ...checkpoint, queueIds: ['one'], remainingQueueIds: ['two'] }, kanjiData, now),
+    null,
+  );
+});


### PR DESCRIPTION
## 概要

スマートフォンやタブレットでOSによるタブ破棄、ページ再読み込み、通信状態の変化が起きても、通常学習・にがて特訓・マイドリルの途中から安全に再開できるようにします。

## 変更内容

- コア学習セッションの元キュー・残りキュー・獲得EXP・回答集計を端末内へ即時保存
- 漢字データ本体ではなくIDだけを保存し、容量を抑えつつ現在のマスターデータから復元
- 再読み込み後は残っていた漢字から自動再開
- 再開時もセッション全体を基準にした進捗バーを維持
- 「つづきから再開しました」を一時表示し、復元されたことを明確化
- 回答ごとの漢字進捗とチェックポイントを同じ更新後に保存
- セッション完了時またはエラーによる破棄時にチェックポイントを削除
- 保存から12時間を超えたデータ、未知の漢字、異常なキュー構成、旧バージョンは復元せず安全に破棄
- セッション状態を同期参照できるようにし、最後の1問直後でもEXP・正答数・復習数を欠かさず確定

## データ安全性

既存の学習データ形式は変更せず、専用の小さなローカルストレージキーへチェックポイントを分離しています。チェックポイントが保存できない場合でも、既存の学習フローはそのまま継続します。

## ユーザーへの効果

移動中のスマートフォン利用や学校端末のメモリ制限でも、途中までの努力を失わず学習を再開できます。短い時間を積み重ねやすくなり、前PRで追加した日次目標達成ループを端末トラブルから保護します。

## 検証

- `npm test`（14件すべて成功）
- `npm run build`
- バンドル上限チェック成功（166.7 KiB / 220 KiB）
- `git diff --check`
- 公開後のリモートツリーとローカルツリーの一致を確認
