### PR TITLE
間隔反復の7日間復習予報を追加

### DIFF
--- a/src/components/pages/HomeView.jsx
+++ b/src/components/pages/HomeView.jsx
@@ -10,7 +10,7 @@ import { StorageAPI, calculateProsperity, getLevelInfo } from '../../systems/sto
 import { audioCtrl } from '../../systems/audio';
 import { F } from '../ui/FormatKun';
 import { calculateSatisfaction, getSatisfactionLabel } from '../../systems/residents';
-import { buildLearningPlan, getDailyLearningProgress, getGoalAwareSessionLimits } from '../../systems/learning-plan';
+import { buildLearningPlan, getDailyLearningProgress, getGoalAwareSessionLimits, getReviewForecast } from '../../systems/learning-plan';
 import { getTodayString } from '../../utils/date-utils';
 import { SESSION } from '../../constants/gameConfig';
 
@@ -51,6 +51,22 @@ const HomeView = ({ setView, stats, setStats, startSession, startFlashcard, star
   const plannedNewCount = learningPlan.newCount;
   const plannedTotalCount = plannedReviewCount + plannedNewCount;
   const isReviewNeeded = reviewTargetsCount > 0;
+  const reviewForecast = useMemo(
+    () => getReviewForecast(stats.kanjiStats),
+    [stats.kanjiStats],
+  );
+  const nextForecastDay = reviewForecast.days.slice(2).find((day) => day.count > 0);
+  const nextReviewHint = reviewTargetsCount > 0
+    ? `復習 ${reviewTargetsCount}字`
+    : reviewForecast.todayCount > 0
+      ? `きょう後で ${reviewForecast.todayCount}字`
+      : reviewForecast.tomorrowCount > 0
+        ? `あした 復習${reviewForecast.tomorrowCount}字`
+        : nextForecastDay
+          ? `${nextForecastDay.date.getMonth() + 1}/${nextForecastDay.date.getDate()} 復習${nextForecastDay.count}字`
+          : reviewForecast.nextReviewAt
+            ? `次は ${new Date(reviewForecast.nextReviewAt).getMonth() + 1}/${new Date(reviewForecast.nextReviewAt).getDate()}`
+            : '復習は完了';
   const prosperity = calculateProsperity(stats.townMap, reviewTargetsCount);
   const learnedCount = KANJI_DATA.filter(k => stats.kanjiStats?.[k.id] && stats.kanjiStats[k.id].status !== 'new').length;
   const isSpecialTrainingUnlocked = learnedCount > 0;
@@ -125,7 +141,7 @@ const HomeView = ({ setView, stats, setStats, startSession, startFlashcard, star
       </div>
       <div className="flex justify-between mt-1.5 text-[10px] font-bold text-[var(--text)] opacity-60">
         <span>{dailyProgress.isComplete ? 'よくがんばりました！' : `あと ${dailyProgress.remaining}字でクリア`}</span>
-        <span>{reviewTargetsCount > 0 ? `復習 ${reviewTargetsCount}字` : '復習は完了'}</span>
+        <span>{nextReviewHint}</span>
       </div>
     </div>
   );

--- a/src/components/pages/StatsView.jsx
+++ b/src/components/pages/StatsView.jsx
@@ -1,8 +1,8 @@
 import React, { useMemo } from 'react';
-import { BarChart3, TrendingUp, AlertCircle, ArrowLeft, Target } from 'lucide-react';
+import { BarChart3, TrendingUp, AlertCircle, ArrowLeft, Target, CalendarClock } from 'lucide-react';
 import { F } from '../ui/FormatKun';
 import { KANJI_DATA } from '../../data/kanji-data';
-import { buildWeakKanjiPlan, getWeeklyLearningSummary, WEAK_PRACTICE_SUCCESS_TARGET } from '../../systems/learning-plan';
+import { buildWeakKanjiPlan, getReviewForecast, getWeeklyLearningSummary, WEAK_PRACTICE_SUCCESS_TARGET } from '../../systems/learning-plan';
 
 const StatsView = ({ setView, stats, startWeakSession }) => {
   const kanjiList = KANJI_DATA.map(k => ({ ...k, stat: stats.kanjiStats?.[k.id] }));
@@ -21,6 +21,17 @@ const StatsView = ({ setView, stats, startWeakSession }) => {
   }));
 
   const maxExp = Math.max(...dailyData.map(d => d.exp), 1);
+  const reviewForecast = useMemo(
+    () => getReviewForecast(stats.kanjiStats),
+    [stats.kanjiStats],
+  );
+  const forecastData = reviewForecast.days.map((day, index) => ({
+    ...day,
+    label: index === 0 ? '今日' : index === 1 ? '明日' : `${day.date.getMonth() + 1}/${day.date.getDate()}`,
+  }));
+  const nextReviewLabel = reviewForecast.nextReviewAt
+    ? `${new Date(reviewForecast.nextReviewAt).getMonth() + 1}月${new Date(reviewForecast.nextReviewAt).getDate()}日`
+    : null;
 
   // 復習期限・つまずき・連続正解数を加味した苦手漢字 top5
   const weakKanji = useMemo(() => {
@@ -97,6 +108,41 @@ const StatsView = ({ setView, stats, startWeakSession }) => {
                 title={`${day.label}: ${day.exp} EXP・${day.reviewed}字`}
               />
               <div className={`text-[9px] font-bold truncate w-full text-center ${day.goalComplete ? 'text-emerald-600' : 'text-[var(--text)] opacity-50'}`}>{day.goalComplete ? '✓' : ''}{day.label}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* 間隔反復の復習予報 */}
+      <div className="bg-[var(--panel)] border-[4px] border-[var(--text)] rounded-2xl p-4 shadow-sm">
+        <div className="mb-1 flex flex-wrap items-center justify-between gap-2">
+          <div className="text-sm font-black text-[var(--text)] flex items-center gap-2"><CalendarClock size={17} className="text-sky-500" /> 7{F("日間","にちかん")}の{F("復習","ふくしゅう")}{F("予報","よほう")}</div>
+          <div className="rounded-full bg-sky-50 border-2 border-sky-200 px-2.5 py-1 text-xs font-black text-sky-700">{reviewForecast.weekCount}{F("字","じ")}</div>
+        </div>
+        <div className={`mb-3 text-[11px] font-bold ${reviewForecast.overdueCount > 0 ? 'text-rose-600' : 'text-[var(--text)] opacity-55'}`}>
+          {reviewForecast.overdueCount > 0
+            ? `${reviewForecast.overdueCount}字が復習を待っています`
+            : reviewForecast.todayCount > 0
+              ? `きょうは ${reviewForecast.todayCount}字の復習予定です`
+              : reviewForecast.tomorrowCount > 0
+                ? `あしたは ${reviewForecast.tomorrowCount}字の復習予定です`
+                : nextReviewLabel
+                  ? `次の復習は ${nextReviewLabel} です`
+                  : '学習した漢字が増えると、ここに予定が表示されます'}
+        </div>
+        <div className="flex items-end gap-2 h-28" role="list" aria-label={`7日間の復習予定、合計${reviewForecast.weekCount}字`}>
+          {forecastData.map((day, index) => (
+            <div key={day.key} role="listitem" aria-label={`${day.label}、復習${day.count}字`} className="flex-1 flex h-full flex-col items-center justify-end gap-1">
+              <div className={`text-[10px] font-black ${day.count > 0 ? 'text-sky-700' : 'text-[var(--text)] opacity-35'}`}>{day.count}</div>
+              <div className="flex h-16 w-full items-end">
+                <div
+                  className={`w-full rounded-t-lg transition-all ${index === 0 && reviewForecast.overdueCount > 0 ? 'bg-rose-400' : 'bg-sky-400'}`}
+                  style={{ height: `${Math.max((day.count / reviewForecast.maxCount) * 64, day.count > 0 ? 8 : 2)}px`, opacity: day.count > 0 ? 1 : 0.25 }}
+                  title={`${day.label}: ${day.count}字`}
+                  aria-hidden="true"
+                />
+              </div>
+              <div className={`w-full truncate text-center text-[9px] font-bold ${index < 2 ? 'text-[var(--text)]' : 'text-[var(--text)] opacity-50'}`}>{day.label}</div>
             </div>
           ))}
         </div>

--- a/src/systems/learning-plan.js
+++ b/src/systems/learning-plan.js
@@ -106,6 +106,57 @@ export function getWeeklyLearningSummary(stats, endDate = new Date()) {
 }
 
 /**
+ * 間隔反復の次回日時をローカル日付へまとめ、今日からの復習量を予報する。
+ * 期限超過分は今日へ含め、学習前のカードや不正な日時は集計しない。
+ */
+export function getReviewForecast(kanjiStats = {}, now = new Date(), dayCount = 7) {
+  const parsedNow = new Date(now);
+  const current = Number.isNaN(parsedNow.getTime()) ? new Date() : parsedNow;
+  const currentTime = current.getTime();
+  const safeDayCount = Math.min(31, Math.max(1, Math.floor(Number(dayCount) || 7)));
+  const firstDay = new Date(current);
+  firstDay.setHours(0, 0, 0, 0);
+
+  const days = Array.from({ length: safeDayCount }, (_, index) => {
+    const date = new Date(firstDay);
+    date.setDate(firstDay.getDate() + index);
+    date.setHours(12, 0, 0, 0);
+    return { key: formatDate(date), date, count: 0 };
+  });
+  const dayIndex = new Map(days.map((day, index) => [day.key, index]));
+  let overdueCount = 0;
+  let nextReviewAt = null;
+
+  Object.values(kanjiStats || {}).forEach((stat) => {
+    if (!stat || stat.status === 'new') return;
+    const dueAt = Number(stat.nextReview);
+    if (!Number.isFinite(dueAt)) return;
+    const dueDate = new Date(dueAt);
+    if (Number.isNaN(dueDate.getTime())) return;
+
+    if (dueAt <= currentTime) overdueCount += 1;
+    if (dueAt > currentTime && (nextReviewAt === null || dueAt < nextReviewAt)) {
+      nextReviewAt = dueAt;
+    }
+
+    const dueKey = formatDate(dueDate);
+    const index = dueKey < days[0].key ? 0 : dayIndex.get(dueKey);
+    if (index !== undefined) days[index].count += 1;
+  });
+
+  const weekCount = days.reduce((total, day) => total + day.count, 0);
+  return {
+    days,
+    overdueCount,
+    todayCount: days[0]?.count || 0,
+    tomorrowCount: days[1]?.count || 0,
+    weekCount,
+    maxCount: Math.max(...days.map((day) => day.count), 1),
+    nextReviewAt,
+  };
+}
+
+/**
  * 過去につまずいた漢字から、短い集中練習用のキューを作る。
  * 復習期限、ラプス、ミス、連続正解数、容易度の順で優先する。
  * 3回連続で正解した漢字は一度キューから外し、成功体験を可視化する。

--- a/test/learning-plan.test.js
+++ b/test/learning-plan.test.js
@@ -6,6 +6,7 @@ import {
   getDailyGoal,
   getDailyLearningProgress,
   getGoalAwareSessionLimits,
+  getReviewForecast,
   getWeeklyLearningSummary,
   WEAK_PRACTICE_SUCCESS_TARGET,
 } from '../src/systems/learning-plan.js';
@@ -104,6 +105,25 @@ test('挑戦数のない旧日次データから正答率を推測しない', ()
 
   assert.equal(summary.goalDays, 1);
   assert.equal(summary.accuracy, null);
+});
+
+test('復習予報は期限超過を今日へまとめ、学習前カードを除外する', () => {
+  const now = new Date(2026, 6, 21, 12, 0, 0);
+  const forecast = getReviewForecast({
+    overdue: { status: 'review', nextReview: new Date(2026, 6, 20, 9).getTime() },
+    laterToday: { status: 'learning', nextReview: new Date(2026, 6, 21, 18).getTime() },
+    tomorrow: { status: 'mastered', nextReview: new Date(2026, 6, 22, 8).getTime() },
+    newCard: { status: 'new', nextReview: new Date(2026, 6, 21, 10).getTime() },
+    beyondForecast: { status: 'review', nextReview: new Date(2026, 6, 30, 8).getTime() },
+    invalid: { status: 'review', nextReview: 'not-a-date' },
+  }, now);
+
+  assert.equal(forecast.overdueCount, 1);
+  assert.equal(forecast.todayCount, 2);
+  assert.equal(forecast.tomorrowCount, 1);
+  assert.equal(forecast.weekCount, 3);
+  assert.equal(forecast.days.length, 7);
+  assert.equal(forecast.nextReviewAt, new Date(2026, 6, 21, 18).getTime());
 });
 
 test('苦手特訓は期限内のつまずきを優先し、3回連続正解した漢字を外す', () => {


### PR DESCRIPTION
## 概要

間隔反復の予定を「今すぐ復習する漢字」だけでなく、今日の後半・明日・直近7日間まで見える復習予報として可視化します。児童が次にアプリへ戻る時期を理解し、復習の間隔を守りやすくする改善です。

## 変更内容

- 学習済み漢字の `nextReview` をローカル日付単位で7日間へ集計
- 期限超過した漢字は今日の復習予定へまとめて表示
- 学習前カード、不正な日時、予報期間外の件数を安全に分離
- 学習記録画面へ日別の復習予報グラフを追加
- 今日・明日・7日合計・期限超過件数・次回復習日を状況に応じて案内
- ホームの今日の目標カードへ「今日の後半」「明日」「次の予定日」を表示
- 予報グラフへ日別件数の読み上げ情報を追加
- 日付境界と期限超過の集計を自動テストで保証

## ユーザーへの効果

復習が0字のときも「次はいつ学べばよいか」が分かるため、必要以上の詰め込みを避けながら間隔反復を継続できます。復習量が多い日も事前に見えるため、学習習慣を計画しやすくなります。

保存データ形式は変更していません。

## 検証

- `npm test`（15件すべて成功）
- `npm run build`
- バンドル上限チェック成功（168.0 KiB / 220 KiB）
- `git diff --check`
- 公開後のリモートツリーとローカルツリーの一致を確認
