### PR TITLE
端末設定に連動する動き軽減モードを追加

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef, lazy, Suspense } from 'react';
-import { AnimatePresence } from 'framer-motion';
+import { AnimatePresence, MotionConfig } from 'framer-motion';
 import { PenTool, Volume2, VolumeX, Settings, Users } from 'lucide-react';
 import { useOnlineStatus } from './hooks/useOnlineStatus';
 import { useIsMobile } from './hooks/useIsMobile';
@@ -24,6 +24,7 @@ import { calculateMaterialDrops } from './systems/crafting';
 import { getDailyMissions, updateMissionProgress } from './data/daily-missions';
 import { getLoginBonusDay, getLoginBonusReward, applyLoginBonus } from './data/login-bonus';
 import { getTodayString } from './utils/date-utils';
+import { getMotionPreference, shouldReduceMotion } from './utils/motion-preference';
 
 // UI
 import { PageWrapper, FullScreenWrapper, ErrorBoundary, Footer } from './components/ui';
@@ -84,10 +85,13 @@ const THEME_VARS = {
   gold: `--bg: #fefce8; --primary: #b45309; --secondary: #eab308; --accent: #fef08a; --text: #713f12; --panel: #ffffff;`,
 };
 
-const GlobalStyle = ({ themeName }) => {
+const GlobalStyle = ({ themeName, reducedMotion }) => {
   const tv = THEME_VARS[themeName] || THEME_VARS.default;
+  const reducedMotionStyle = reducedMotion
+    ? `body { transition: none; } [data-reduced-motion="true"] *, [data-reduced-motion="true"] *::before, [data-reduced-motion="true"] *::after { animation-duration: 0.001ms !important; animation-iteration-count: 1 !important; transition-duration: 0.001ms !important; scroll-behavior: auto !important; }`
+    : '';
   return (
-    <style>{`:root { ${tv} } body { font-family: 'Zen Maru Gothic', sans-serif; background-color: var(--bg); color: var(--text); touch-action: manipulation; transition: background-color 0.3s ease; } .no-scrollbar::-webkit-scrollbar { display: none; } .no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; } ::selection { background-color: var(--accent); color: var(--text); } ruby { ruby-align: center; ruby-position: over; vertical-align: baseline; } ruby rt { font-size: 0.5em; font-weight: 500; letter-spacing: 0; line-height: 1; } ruby rt:empty { display: inline-block; height: 0; overflow: hidden; } .ruby-text { line-height: 2.5; }`}</style>
+    <style>{`:root { ${tv} } body { font-family: 'Zen Maru Gothic', sans-serif; background-color: var(--bg); color: var(--text); touch-action: manipulation; transition: background-color 0.3s ease; } .no-scrollbar::-webkit-scrollbar { display: none; } .no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; } ::selection { background-color: var(--accent); color: var(--text); } ruby { ruby-align: center; ruby-position: over; vertical-align: baseline; } ruby rt { font-size: 0.5em; font-weight: 500; letter-spacing: 0; line-height: 1; } ruby rt:empty { display: inline-block; height: 0; overflow: hidden; } .ruby-text { line-height: 2.5; } ${reducedMotionStyle}`}</style>
   );
 };
 
@@ -171,6 +175,30 @@ export default function App() {
   const [seenHints, setSeenHints] = useState(stats.seenHints || []);
   const isOnline = useOnlineStatus();
   const isMobile = useIsMobile();
+  const [systemPrefersReducedMotion, setSystemPrefersReducedMotion] = useState(() => (
+    typeof window.matchMedia === 'function'
+      ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
+      : false
+  ));
+  const motionPreference = getMotionPreference(stats.settings);
+  const isReducedMotion = shouldReduceMotion(motionPreference, systemPrefersReducedMotion);
+
+  useEffect(() => {
+    if (typeof window.matchMedia !== 'function') return undefined;
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const handleChange = (event) => setSystemPrefersReducedMotion(event.matches);
+    handleChange(mediaQuery);
+    if (typeof mediaQuery.addEventListener === 'function') {
+      mediaQuery.addEventListener('change', handleChange);
+      return () => mediaQuery.removeEventListener('change', handleChange);
+    }
+    if (typeof mediaQuery.addListener === 'function') {
+      mediaQuery.addListener(handleChange);
+      return () => mediaQuery.removeListener(handleChange);
+    }
+
+    return undefined;
+  }, []);
 
   // オンライン時に対象学年の漢字筆順データを事前キャッシュ（オフライン学習対応）
   usePrefetchKanji(isOnline, stats.targetGrade, KANJI_DATA);
@@ -688,8 +716,9 @@ export default function App() {
   const activeThemeName = themeOverride === 'auto' ? levelInfo.themeName : themeOverride;
 
   return (
-    <div className="flex flex-col h-[100dvh] w-full bg-[var(--bg)] relative overflow-hidden transition-colors duration-500">
-      <GlobalStyle themeName={activeThemeName} />
+    <MotionConfig reducedMotion={isReducedMotion ? 'always' : 'never'}>
+      <div data-reduced-motion={isReducedMotion ? 'true' : 'false'} className="flex flex-col h-[100dvh] w-full bg-[var(--bg)] relative overflow-hidden transition-colors duration-500">
+      <GlobalStyle themeName={activeThemeName} reducedMotion={isReducedMotion} />
 
       {/* ストレージ保存失敗バナー（オフラインバナーより上に表示） */}
       <StorageErrorBanner />
@@ -798,6 +827,7 @@ export default function App() {
         />
       )}
       <Footer />
-    </div>
+      </div>
+    </MotionConfig>
   );
 }

--- a/src/components/pages/SettingsView.jsx
+++ b/src/components/pages/SettingsView.jsx
@@ -1,11 +1,12 @@
 import React, { useState, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { ArrowLeft, Volume2, VolumeX, Palette, GraduationCap, Database, Download, Upload, Trash2, RotateCcw, Sun, Moon, Sparkles, ChevronRight, AlertTriangle, Check, X } from 'lucide-react';
+import { ArrowLeft, Volume2, VolumeX, Palette, GraduationCap, Database, Download, Upload, Trash2, RotateCcw, Sun, Moon, Sparkles, ChevronRight, AlertTriangle, Check, X, Accessibility } from 'lucide-react';
 import { MotionButton } from '../ui';
 import { StorageAPI } from '../../systems/storage';
 import { audioCtrl } from '../../systems/audio';
 import { F } from '../ui/FormatKun';
 import { DAILY_GOAL_OPTIONS, getDailyGoal } from '../../systems/learning-plan';
+import { getMotionPreference } from '../../utils/motion-preference';
 
 // 手動テーマ選択肢
 const THEME_OPTIONS = [
@@ -24,6 +25,12 @@ const VOLUME_LEVELS = [
   { id: 'low', label: '小', value: 0.3 },
   { id: 'mid', label: '中', value: 0.6 },
   { id: 'high', label: '大', value: 1.0 },
+];
+
+const MOTION_OPTIONS = [
+  { id: 'system', label: 'じどう', desc: '端末設定に合わせる' },
+  { id: 'full', label: '標準', desc: '演出を楽しむ' },
+  { id: 'reduced', label: '少なめ', desc: '動きをおさえる' },
 ];
 
 // 確認ダイアログ
@@ -70,6 +77,7 @@ const SettingsView = ({ setView, stats, setStats, isMuted, setIsMuted, levelInfo
   const showFurigana = settings.showFurigana !== false;
   const sessionSize = settings.sessionSize || 'normal';
   const dailyGoal = getDailyGoal(settings);
+  const motionPreference = getMotionPreference(settings);
 
   const updateSettings = (patch) => {
     const newSettings = { ...settings, ...patch };
@@ -87,6 +95,11 @@ const SettingsView = ({ setView, stats, setStats, isMuted, setIsMuted, levelInfo
   const handleThemeChange = (id) => {
     audioCtrl.playSE('click');
     updateSettings({ themeOverride: id });
+  };
+
+  const handleMotionChange = (id) => {
+    audioCtrl.playSE('click');
+    updateSettings({ motionPreference: id });
   };
 
   // 音量変更
@@ -203,6 +216,33 @@ const SettingsView = ({ setView, stats, setStats, isMuted, setIsMuted, levelInfo
               </button>
             );
           })}
+        </div>
+      </Section>
+
+      {/* 動き・端末負荷の設定 */}
+      <Section icon={Accessibility} title="画面のうごき">
+        <div className="grid grid-cols-3 gap-2">
+          {MOTION_OPTIONS.map((option) => {
+            const isActive = motionPreference === option.id;
+            return (
+              <button
+                key={option.id}
+                type="button"
+                aria-pressed={isActive}
+                onClick={() => handleMotionChange(option.id)}
+                className={`min-h-[72px] rounded-xl border-[3px] p-2 text-center transition-all ${isActive ? 'border-[var(--secondary)] bg-[var(--secondary)]/10 shadow-[2px_2px_0_var(--secondary)]' : 'border-[var(--text)]/20 hover:border-[var(--text)]/50'}`}
+              >
+                <div className="flex items-center justify-center gap-1 text-xs font-black text-[var(--text)]">
+                  {option.label}
+                  {isActive && <Check size={13} className="text-[var(--secondary)]" aria-hidden="true" />}
+                </div>
+                <div className="mt-1 text-[9px] font-bold leading-tight text-[var(--text)] opacity-50">{option.desc}</div>
+              </button>
+            );
+          })}
+        </div>
+        <div className="rounded-xl bg-[var(--bg)] px-3 py-2 text-[10px] font-bold leading-relaxed text-[var(--text)] opacity-60">
+          「{F("少","すく")}なめ」はアニメーション・{F("天気","てんき")}・{F("紙吹雪","かみふぶき")}をおさえ、電池も長もちしやすくします。
         </div>
       </Section>
 

--- a/src/components/town/VillagerDot.jsx
+++ b/src/components/town/VillagerDot.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion, AnimatePresence, useReducedMotionConfig } from 'framer-motion';
 import { getOccupation } from '../../data/residents';
 
 const TILE_W = 64;
@@ -31,6 +31,7 @@ const CULTIVATABLE_TERRAIN = new Set([
 const distance = (x1, y1, x2, y2) => Math.sqrt((x1 - x2) ** 2 + (y1 - y2) ** 2);
 
 const VillagerDot = React.memo(({ villager, mapData = {}, tileW, tileH }) => {
+  const shouldReduceMotion = useReducedMotionConfig();
   // === ステートマシンの状態 ===
   // 座標は初期値として村民のデータ上の座標を利用
   const [gridPos, setGridPos] = useState({ x: villager.x, y: villager.y });
@@ -61,6 +62,8 @@ const VillagerDot = React.memo(({ villager, mapData = {}, tileW, tileH }) => {
   const Avatar = getAvatarComponent(villager.occupation);
 
   useEffect(() => {
+    if (shouldReduceMotion) return undefined;
+
     let lastTime = performance.now();
 
     const loop = (time) => {
@@ -177,16 +180,16 @@ const VillagerDot = React.memo(({ villager, mapData = {}, tileW, tileH }) => {
 
     frameRef.current = requestAnimationFrame(loop);
     return () => cancelAnimationFrame(frameRef.current);
-  }, [mapData, villager.id.length]);
+  }, [mapData, shouldReduceMotion, villager.id.length]);
 
   // CSS描画用位置計算
   const baseIsoX = toIsoX(gridPos.x, gridPos.y);
   const baseIsoY = toIsoY(gridPos.x, gridPos.y);
 
   // 移動中のボビング（上下の揺れ）
-  const bobbing = aiState === 'MOVING' ? Math.sin(Date.now() / 100) * 3 : 0;
+  const bobbing = !shouldReduceMotion && aiState === 'MOVING' ? Math.sin(Date.now() / 100) * 3 : 0;
   // インタラクト中のジャンプ
-  const jumping = (aiState === 'INTERACTING' && emotion === 'heart') ? Math.abs(Math.sin(Date.now() / 200)) * -6 : 0;
+  const jumping = (!shouldReduceMotion && aiState === 'INTERACTING' && emotion === 'heart') ? Math.abs(Math.sin(Date.now() / 200)) * -6 : 0;
 
   // VillagerDotの幅・高さ（transform:translate(-50%,-100%)の代わりに手動オフセット）
   const vW = 40;

--- a/src/components/town/WeatherOverlay.jsx
+++ b/src/components/town/WeatherOverlay.jsx
@@ -1,4 +1,5 @@
 import React, { useRef, useEffect } from 'react';
+import { useReducedMotionConfig } from 'framer-motion';
 
 /**
  * HTML5 Canvasを利用した軽量・高性能パーティクルコンポーネント
@@ -6,9 +7,10 @@ import React, { useRef, useEffect } from 'react';
  */
 const WeatherOverlay = ({ weather = 'clear' }) => {
   const canvasRef = useRef(null);
+  const shouldReduceMotion = useReducedMotionConfig();
 
   useEffect(() => {
-    if (weather === 'clear') return;
+    if (weather === 'clear' || shouldReduceMotion) return;
 
     const canvas = canvasRef.current;
     const ctx = canvas.getContext('2d');
@@ -110,9 +112,9 @@ const WeatherOverlay = ({ weather = 'clear' }) => {
       window.removeEventListener('resize', resizeCanvas);
       cancelAnimationFrame(animationFrameId);
     };
-  }, [weather]);
+  }, [weather, shouldReduceMotion]);
 
-  if (weather === 'clear') return null;
+  if (weather === 'clear' || shouldReduceMotion) return null;
 
   return (
     <canvas

--- a/src/components/ui/AnimatedCounter.jsx
+++ b/src/components/ui/AnimatedCounter.jsx
@@ -1,19 +1,27 @@
 import { useState, useEffect } from 'react';
+import { useReducedMotionConfig } from 'framer-motion';
 
 // アニメーション付き数値カウンター（結果画面用）
 const AnimatedCounter = ({ target, duration = 1200, prefix = '', suffix = '' }) => {
+  const shouldReduceMotion = useReducedMotionConfig();
   const [value, setValue] = useState(0);
   useEffect(() => {
-    if (target === 0) return;
+    if (shouldReduceMotion || target === 0) {
+      setValue(target);
+      return undefined;
+    }
+
     const start = Date.now(); const startVal = 0;
+    let frameId;
     const tick = () => {
       const elapsed = Date.now() - start; const progress = Math.min(elapsed / duration, 1);
       const eased = 1 - Math.pow(1 - progress, 3); // ease-out cubic
       setValue(Math.round(startVal + (target - startVal) * eased));
-      if (progress < 1) requestAnimationFrame(tick);
+      if (progress < 1) frameId = requestAnimationFrame(tick);
     };
-    requestAnimationFrame(tick);
-  }, [target, duration]);
+    frameId = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(frameId);
+  }, [target, duration, shouldReduceMotion]);
   return <span>{prefix}{value.toLocaleString()}{suffix}</span>;
 };
 

--- a/src/components/ui/Confetti.jsx
+++ b/src/components/ui/Confetti.jsx
@@ -1,15 +1,17 @@
 import { useRef, useEffect } from 'react';
+import { useReducedMotionConfig } from 'framer-motion';
 
 const Confetti = ({ active }) => {
   const canvasRef = useRef(null);
+  const shouldReduceMotion = useReducedMotionConfig();
   useEffect(() => {
-    if (!active) return; const canvas = canvasRef.current; const ctx = canvas.getContext('2d'); canvas.width = window.innerWidth; canvas.height = window.innerHeight;
+    if (!active || shouldReduceMotion) return; const canvas = canvasRef.current; const ctx = canvas.getContext('2d'); canvas.width = window.innerWidth; canvas.height = window.innerHeight;
     const particles = Array.from({ length: 100 }, () => ({ x: canvas.width / 2, y: canvas.height / 2, r: Math.random() * 8 + 4, dx: Math.random() * 20 - 10, dy: Math.random() * -20 - 5, color: ['#fce7f3', '#fef08a', '#bae6fd', '#a7f3d0', '#c7d2fe', '#FFD700', '#FF6B6B'][Math.floor(Math.random() * 7)], tiltAngleIncrement: (Math.random() * 0.07) + 0.05, tiltAngle: 0 }));
     let animId;
     const render = () => { ctx.clearRect(0, 0, canvas.width, canvas.height); let activeCount = 0; particles.forEach(p => { p.tiltAngle += p.tiltAngleIncrement; p.y += (Math.cos(p.tiltAngle) + 1 + p.r / 2) / 2; p.x += Math.sin(p.tiltAngle) * 2 + p.dx; p.dy += 0.2; p.y += p.dy; if (p.y <= canvas.height) activeCount++; ctx.beginPath(); ctx.lineWidth = p.r; ctx.strokeStyle = p.color; ctx.moveTo(p.x + p.r, p.y); ctx.lineTo(p.x, p.y + p.r); ctx.stroke(); }); if (activeCount > 0) animId = requestAnimationFrame(render); };
     render(); return () => cancelAnimationFrame(animId);
-  }, [active]);
-  if (!active) return null; return <canvas ref={canvasRef} className="fixed inset-0 pointer-events-none z-[100]" />;
+  }, [active, shouldReduceMotion]);
+  if (!active || shouldReduceMotion) return null; return <canvas ref={canvasRef} className="fixed inset-0 pointer-events-none z-[100]" />;
 };
 
 export default Confetti;

--- a/src/utils/motion-preference.js
+++ b/src/utils/motion-preference.js
@@ -1,0 +1,16 @@
+export const MOTION_PREFERENCES = ['system', 'full', 'reduced'];
+export const DEFAULT_MOTION_PREFERENCE = 'system';
+
+export function getMotionPreference(settings) {
+  const preference = settings?.motionPreference;
+  return MOTION_PREFERENCES.includes(preference)
+    ? preference
+    : DEFAULT_MOTION_PREFERENCE;
+}
+
+/** 端末設定とアプリ内の上書き設定から、動きを減らすか決定する。 */
+export function shouldReduceMotion(preference, systemPrefersReducedMotion = false) {
+  if (preference === 'reduced') return true;
+  if (preference === 'full') return false;
+  return Boolean(systemPrefersReducedMotion);
+}

--- a/test/motion-preference.test.js
+++ b/test/motion-preference.test.js
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  getMotionPreference,
+  shouldReduceMotion,
+} from '../src/utils/motion-preference.js';
+
+test('未設定・不正な値は端末設定に合わせる', () => {
+  assert.equal(getMotionPreference(), 'system');
+  assert.equal(getMotionPreference({ motionPreference: 'unknown' }), 'system');
+  assert.equal(shouldReduceMotion('system', true), true);
+  assert.equal(shouldReduceMotion('system', false), false);
+});
+
+test('手動設定は端末設定より優先される', () => {
+  assert.equal(shouldReduceMotion('reduced', false), true);
+  assert.equal(shouldReduceMotion('full', true), false);
+});


### PR DESCRIPTION
## 概要

端末のアクセシビリティ設定に連動する「画面のうごき」設定を追加し、動きに敏感な児童や低性能端末でも漢字タウンを快適に使えるようにしました。

## 変更内容

- 初期設定では `prefers-reduced-motion` に追従
- 「じどう」「標準」「少なめ」の3段階を設定画面から選択可能
- 手動設定を既存の学習設定と同じ保存経路で永続化
- Framer Motion のアニメーションをアプリ全体で一括制御
- CSSアニメーション、画面遷移、スムーズスクロールを動き軽減時に抑制
- 天候、住民移動、紙吹雪の常時Canvas/RAF処理を停止
- 結果画面の数値カウンターを即時表示
- 旧ブラウザ向け `matchMedia.addListener` フォールバックを維持

## 利用者への効果

- 端末側の「視差効果を減らす」設定が自動的に反映される
- 動きによる不快感や集中の妨げを減らせる
- 低性能なスマートフォン・タブレットでのCPU/GPU負荷と電池消費を抑えられる
- 従来の演出を好む利用者は「標準」で維持できる

## 検証

- `npm test`: 17件すべて成功
- `npm run build`: 成功
- バンドル予算: 169.1 KiB / 220 KiB
- `git diff --check`: 成功
- ローカルとGitHub上のツリーSHA一致: `49455023713dc2e4ad84fa45b0d40922e067e207`
