### PR TITLE
PWAの横向き対応とPR品質ゲートを追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,21 +1,22 @@
-name: Deploy to GitHub Pages
+name: Quality and Deploy
 
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
-  group: pages
+  group: kanji-town-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  build:
+  quality:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -23,14 +24,21 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
+      - run: npm test
       - run: npm run build
       - uses: actions/upload-pages-artifact@v3
+        if: github.event_name == 'push'
         with:
           path: dist
 
   deploy:
-    needs: build
+    if: github.event_name == 'push'
+    needs: quality
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -5,7 +5,7 @@
   "start_url": "/KANJI_Town/",
   "scope": "/KANJI_Town/",
   "display": "standalone",
-  "orientation": "portrait",
+  "orientation": "any",
   "background_color": "#fdfbf7",
   "theme_color": "#ef4444",
   "lang": "ja",

--- a/test/platform-config.test.js
+++ b/test/platform-config.test.js
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const readProjectFile = (path) => readFile(new URL(`../${path}`, import.meta.url), 'utf8');
+
+test('インストール版PWAは縦向きと横向きの両方を許可する', async () => {
+  const manifest = JSON.parse(await readProjectFile('public/manifest.json'));
+
+  assert.equal(manifest.display, 'standalone');
+  assert.equal(manifest.orientation, 'any');
+  assert.equal(manifest.lang, 'ja');
+});
+
+test('PRの品質ゲートはテスト後に本番ビルドを検証する', async () => {
+  const workflow = await readProjectFile('.github/workflows/deploy.yml');
+  const testStep = workflow.indexOf('- run: npm test');
+  const buildStep = workflow.indexOf('- run: npm run build');
+
+  assert.match(workflow, /pull_request:\s*\n\s+branches: \[main\]/);
+  assert.ok(testStep >= 0, 'npm test が品質ゲートに含まれている');
+  assert.ok(buildStep > testStep, '本番ビルドはテスト成功後に実行される');
+  assert.match(workflow, /if: github\.event_name == 'push'/);
+});


### PR DESCRIPTION
## 概要

開発順序の第1段階「端末互換性と品質ゲート」として、インストール版PWAでも縦向き・横向きの両方を利用できるようにし、PRごとに自動テストと本番ビルドを検証します。

## 変更内容

- Web App Manifestの縦向き固定を解除し、端末回転に追従
- GitHub Actionsを `main` 向けPRでも実行
- `npm test` 成功後に `npm run build` とバンドル予算を確認
- GitHub Pages用成果物の作成とデプロイは `main` へのpush時だけ実行
- PRごとのconcurrency groupで、別PRの検証を相互にキャンセルしない構成へ変更
- CIとPWA設定の回帰テストを追加

## 利用者・開発者への効果

- インストールしたスマートフォン・タブレットでも、画面方向に応じて広い学習領域を利用できる
- テスト失敗やバンドル肥大化をマージ前に検知できる
- 検証されていないPRビルドがGitHub Pagesへ配信されない
- 以降の学習機能を安全に追加できる品質基盤になる

## 検証

- `npm test`: 19件すべて成功
- `npm run build`: 成功
- バンドル予算: 169.1 KiB / 220 KiB
- Workflow YAML構文検証: 成功
- `git diff --check`: 成功
- ローカルとGitHub上のツリーSHA一致: `7b7cfbb11c0b1b94caff29534954fff1c8cb1bd1`
