### PR TITLE
住民アニメーションを共有化してタウン描画を軽量化

### DIFF
--- a/src/components/town/DraggableTownMap.jsx
+++ b/src/components/town/DraggableTownMap.jsx
@@ -5,6 +5,7 @@ import { TOWN_ITEMS } from '../../data/town-items';
 import VillagerDot from './VillagerDot';
 import WeatherOverlay from './WeatherOverlay';
 import { audioCtrl } from '../../systems/audio';
+import { isVillagerInViewRange } from '../../systems/town-animation';
 
 // ── アイソメトリック定数 ──
 const TILE_W = 64;
@@ -279,6 +280,11 @@ const DraggableTownMap = ({ mapData, isDanger, isEditing, onCellTap, reviewCount
       endY: Math.min(GRID_SIZE - 1, Math.max(...ys) + margin),
     };
   }, [offset.x, offset.y, containerSize.w, containerSize.h, zoom]);
+
+  const renderedVillagers = useMemo(
+    () => visibleVillagers.filter((villager) => isVillagerInViewRange(villager, viewRange)),
+    [visibleVillagers, viewRange],
+  );
 
   // ── メガ建築アンカー ──
   const megaAnchors = useMemo(() => {
@@ -630,13 +636,11 @@ const DraggableTownMap = ({ mapData, isDanger, isEditing, onCellTap, reviewCount
       }}>
         {cells}
         {/* 住民（セルと同じtransformコンテナ内でz-indexによる深度制御） */}
-        {visibleVillagers.map(v => (
+        {renderedVillagers.map(v => (
           <VillagerDot
             key={v.id}
             villager={v}
             mapData={safeMapData}
-            tileW={TILE_W}
-            tileH={TILE_H}
           />
         ))}
         {/* ホバーハイライト */}

--- a/src/components/town/VillagerDot.jsx
+++ b/src/components/town/VillagerDot.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { motion, AnimatePresence, useReducedMotionConfig } from 'framer-motion';
-import { getOccupation } from '../../data/residents';
+import { subscribeTownAnimation } from '../../systems/town-animation';
 
 const TILE_W = 64;
 const TILE_H = 32;
@@ -30,7 +30,7 @@ const CULTIVATABLE_TERRAIN = new Set([
 // 距離計算ヘルパー
 const distance = (x1, y1, x2, y2) => Math.sqrt((x1 - x2) ** 2 + (y1 - y2) ** 2);
 
-const VillagerDot = React.memo(({ villager, mapData = {}, tileW, tileH }) => {
+const VillagerDot = React.memo(({ villager, mapData = {} }) => {
   const shouldReduceMotion = useReducedMotionConfig();
   // === ステートマシンの状態 ===
   // 座標は初期値として村民のデータ上の座標を利用
@@ -45,7 +45,7 @@ const VillagerDot = React.memo(({ villager, mapData = {}, tileW, tileH }) => {
     y: (Math.random() - 0.5) * 8
   }).current;
   
-  // 状態管理やアニメーションフレーム用のRef
+  // 状態管理用のRef
   const stateRef = useRef({
     currentState: 'IDLE',
     gridX: villager.x,
@@ -57,18 +57,13 @@ const VillagerDot = React.memo(({ villager, mapData = {}, tileW, tileH }) => {
     baseSpeed: 0.02 + (villager.id.length % 3) * 0.005, // 個体別の歩行速度
   });
 
-  const frameRef = useRef(null);
-  const occ = getOccupation(villager.occupation);
   const Avatar = getAvatarComponent(villager.occupation);
 
   useEffect(() => {
     if (shouldReduceMotion) return undefined;
+    let emotionTimerId = null;
 
-    let lastTime = performance.now();
-
-    const loop = (time) => {
-      const dt = Math.min((time - lastTime) / 1000, 0.1); // デルタタイム（最大0.1秒）
-      lastTime = time;
+    const unsubscribe = subscribeTownAnimation((_time, dt) => {
       const s = stateRef.current;
 
       s.timer -= dt;
@@ -105,7 +100,8 @@ const VillagerDot = React.memo(({ villager, mapData = {}, tileW, tileH }) => {
             // 行動決定のリアクション
             if(Math.random() > 0.7) {
               setEmotion('exclamation');
-              setTimeout(() => setEmotion(null), 1500);
+              if (emotionTimerId) clearTimeout(emotionTimerId);
+              emotionTimerId = setTimeout(() => setEmotion(null), 1500);
             }
           } else {
             // ランダムに少しだけ散歩
@@ -175,11 +171,12 @@ const VillagerDot = React.memo(({ villager, mapData = {}, tileW, tileH }) => {
         }
       }
 
-      frameRef.current = requestAnimationFrame(loop);
-    };
+    });
 
-    frameRef.current = requestAnimationFrame(loop);
-    return () => cancelAnimationFrame(frameRef.current);
+    return () => {
+      unsubscribe();
+      if (emotionTimerId) clearTimeout(emotionTimerId);
+    };
   }, [mapData, shouldReduceMotion, villager.id.length]);
 
   // CSS描画用位置計算

--- a/src/systems/town-animation.js
+++ b/src/systems/town-animation.js
@@ -1,0 +1,100 @@
+export const TOWN_ANIMATION_INTERVAL_MS = 50;
+export const TOWN_ANIMATION_MAX_DELTA_SECONDS = 0.1;
+
+/**
+ * 複数の住民が1本のrequestAnimationFrameを共有するスケジューラー。
+ * 20fpsへ間引き、非表示タブや購読者がいない間は完全に停止する。
+ */
+export function createTownAnimationScheduler({
+  requestFrame = (callback) => globalThis.requestAnimationFrame(callback),
+  cancelFrame = (frameId) => globalThis.cancelAnimationFrame(frameId),
+  intervalMs = TOWN_ANIMATION_INTERVAL_MS,
+  maxDeltaSeconds = TOWN_ANIMATION_MAX_DELTA_SECONDS,
+} = {}) {
+  const subscribers = new Set();
+  let frameId = null;
+  let lastTickAt = null;
+  let paused = false;
+
+  const schedule = () => {
+    if (paused || frameId !== null || subscribers.size === 0) return;
+    frameId = requestFrame(tick);
+  };
+
+  const tick = (now) => {
+    frameId = null;
+    if (paused || subscribers.size === 0) return;
+
+    if (lastTickAt === null) lastTickAt = now;
+    const elapsed = now - lastTickAt;
+    if (elapsed >= intervalMs) {
+      const deltaSeconds = Math.min(elapsed / 1000, maxDeltaSeconds);
+      lastTickAt = now;
+      [...subscribers].forEach((subscriber) => {
+        try {
+          subscriber(now, deltaSeconds);
+        } catch (error) {
+          if (import.meta.env?.DEV) console.warn('[TownAnimation] subscriber failed:', error);
+        }
+      });
+    }
+
+    schedule();
+  };
+
+  const subscribe = (subscriber) => {
+    subscribers.add(subscriber);
+    schedule();
+
+    return () => {
+      subscribers.delete(subscriber);
+      if (subscribers.size === 0) {
+        if (frameId !== null) cancelFrame(frameId);
+        frameId = null;
+        lastTickAt = null;
+      }
+    };
+  };
+
+  const pause = () => {
+    paused = true;
+    if (frameId !== null) cancelFrame(frameId);
+    frameId = null;
+    lastTickAt = null;
+  };
+
+  const resume = () => {
+    if (!paused) return;
+    paused = false;
+    schedule();
+  };
+
+  return {
+    subscribe,
+    pause,
+    resume,
+    getSubscriberCount: () => subscribers.size,
+  };
+}
+
+/** 画面外の住民を、移動余白を含めて描画対象から外す。 */
+export function isVillagerInViewRange(villager, viewRange, margin = 6) {
+  if (!villager || !viewRange) return false;
+  return villager.x >= viewRange.startX - margin
+    && villager.x <= viewRange.endX + margin
+    && villager.y >= viewRange.startY - margin
+    && villager.y <= viewRange.endY + margin;
+}
+
+export const townAnimationScheduler = createTownAnimationScheduler();
+
+if (typeof document !== 'undefined') {
+  const syncVisibility = () => {
+    if (document.hidden) townAnimationScheduler.pause();
+    else townAnimationScheduler.resume();
+  };
+  document.addEventListener('visibilitychange', syncVisibility);
+  syncVisibility();
+}
+
+export const subscribeTownAnimation = (subscriber) => townAnimationScheduler.subscribe(subscriber);

--- a/test/town-animation.test.js
+++ b/test/town-animation.test.js
@@ -1,0 +1,64 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createTownAnimationScheduler,
+  isVillagerInViewRange,
+  TOWN_ANIMATION_INTERVAL_MS,
+} from '../src/systems/town-animation.js';
+
+test('複数の住民は1本のフレーム予約を共有し20fpsで更新される', () => {
+  const frames = [];
+  const cancelled = [];
+  const scheduler = createTownAnimationScheduler({
+    requestFrame: (callback) => {
+      frames.push(callback);
+      return frames.length;
+    },
+    cancelFrame: (frameId) => cancelled.push(frameId),
+  });
+  const ticks = [];
+  const unsubscribeFirst = scheduler.subscribe((_now, delta) => ticks.push(['first', delta]));
+  const unsubscribeSecond = scheduler.subscribe((_now, delta) => ticks.push(['second', delta]));
+
+  assert.equal(frames.length, 1);
+  assert.equal(scheduler.getSubscriberCount(), 2);
+
+  frames.shift()(0);
+  frames.shift()(TOWN_ANIMATION_INTERVAL_MS - 1);
+  assert.equal(ticks.length, 0);
+  frames.shift()(TOWN_ANIMATION_INTERVAL_MS);
+
+  assert.deepEqual(ticks, [['first', 0.05], ['second', 0.05]]);
+  unsubscribeFirst();
+  unsubscribeSecond();
+  assert.equal(scheduler.getSubscriberCount(), 0);
+  assert.equal(cancelled.length, 1);
+});
+
+test('一時停止中はフレームを予約せず、再開時に1本だけ予約する', () => {
+  const frames = [];
+  const scheduler = createTownAnimationScheduler({
+    requestFrame: (callback) => {
+      frames.push(callback);
+      return frames.length;
+    },
+    cancelFrame: () => {},
+  });
+
+  scheduler.pause();
+  const unsubscribe = scheduler.subscribe(() => {});
+  assert.equal(frames.length, 0);
+
+  scheduler.resume();
+  assert.equal(frames.length, 1);
+  unsubscribe();
+});
+
+test('画面外の住民を移動余白込みでカリングする', () => {
+  const viewRange = { startX: 10, startY: 10, endX: 20, endY: 20 };
+
+  assert.equal(isVillagerInViewRange({ x: 15, y: 15 }, viewRange), true);
+  assert.equal(isVillagerInViewRange({ x: 5, y: 15 }, viewRange), true);
+  assert.equal(isVillagerInViewRange({ x: 3, y: 15 }, viewRange), false);
+  assert.equal(isVillagerInViewRange({ x: 15, y: 27 }, viewRange), false);
+});


### PR DESCRIPTION
## 概要

開発順序の第2段階「タウン描画の追加最適化」として、住民ごとに生成していた常時アニメーションループを1本の共有スケジューラーへ統合します。見た目と住民AIの挙動を維持しながら、人数が増えた町でのCPU負荷と再描画回数を抑えます。

## 変更内容

- 住民ごとの `requestAnimationFrame` をタウン全体で1本に共有
- AI・移動更新を最大20fpsに制限
- 画面外の住民を移動余白付きで描画・AI更新対象から除外
- ブラウザタブが非表示の間は共有スケジューラーを完全停止
- 住民非表示・画面外・コンポーネント破棄時は購読を解除
- 動き軽減モードでは従来どおり住民AIを開始しない
- 感情表示タイマーをアンマウント時に確実に破棄
- 共有フレーム、停止・再開、カリングの自動テストを追加

## 利用者への効果

- 住民が増えたタウンでも操作やスクロールが重くなりにくい
- スマートフォン・タブレットのCPU使用量と電池消費を抑えられる
- バックグラウンドタブで不要な処理を継続しない
- 従来の住民移動・施設への反応・感情表示は維持される

## 検証

- `npm test`: 20件すべて成功
- `npm run build`: 成功
- バンドル予算: 169.1 KiB / 220 KiB
- `git diff --check`: 成功
- ローカルとGitHub上のツリーSHA一致: `dc35028afb3411e72b70115bfe47e4bd936e7d99`

## 依存関係

PR #103とは独立しており、現在の `main` へ直接マージできます。
