### PR TITLE
4技能の習熟度記録と弱点別学習を追加

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,6 +25,7 @@ import { getDailyMissions, updateMissionProgress } from './data/daily-missions';
 import { getLoginBonusDay, getLoginBonusReward, applyLoginBonus } from './data/login-bonus';
 import { getTodayString } from './utils/date-utils';
 import { getMotionPreference, shouldReduceMotion } from './utils/motion-preference';
+import { recordSkillEvidence } from './systems/mastery';
 
 // UI
 import { PageWrapper, FullScreenWrapper, ErrorBoundary, Footer } from './components/ui';
@@ -487,19 +488,42 @@ export default function App() {
     beginSession('boss', { queue, oldExp: stats.totalExp, expMultiplier });
   };
 
-  const handleUpdateStat = (kanjiObj, evalType) => {
+  const handleRecordSkillEvidence = useCallback((kanjiObj, updates) => {
+    if (!kanjiObj?.id || !Array.isArray(updates) || updates.length === 0) return;
+    setStats(s => {
+      const latest = migrateCard(s.kanjiStats?.[kanjiObj.id]);
+      return {
+        ...s,
+        kanjiStats: {
+          ...s.kanjiStats,
+          [kanjiObj.id]: {
+            ...latest,
+            skillMastery: recordSkillEvidence(latest, updates),
+          },
+        },
+      };
+    });
+  }, []);
+
+  const handleUpdateStat = (kanjiObj, evalType, { skills = [] } = {}) => {
     const id = kanjiObj.id;
     const cur = migrateCard(stats.kanjiStats?.[id]);
+    const curWithMastery = skills.length > 0
+      ? { ...cur, skillMastery: recordSkillEvidence(cur, skills.map(skill => ({ skill, evidence: evalType }))) }
+      : cur;
     if (sessionData.isDrill) {
       setStats(s => {
         const latest = migrateCard(s.kanjiStats?.[id]);
+        const latestWithMastery = skills.length > 0
+          ? { ...latest, skillMastery: recordSkillEvidence(latest, skills.map(skill => ({ skill, evidence: evalType }))) }
+          : latest;
         return {
           ...s,
           kanjiStats: {
             ...s.kanjiStats,
             [id]: {
-              ...latest,
-              ...recordPracticeAttempt(latest, evalType),
+              ...latestWithMastery,
+              ...recordPracticeAttempt(latestWithMastery, evalType),
             },
           },
         };
@@ -514,8 +538,8 @@ export default function App() {
       return evalType !== 'again';
     }
 
-    const next = calculateNextReview(cur, evalType);
-    const wasNew = cur.status === 'new';
+    const next = calculateNextReview(curWithMastery, evalType);
+    const wasNew = curWithMastery.status === 'new';
     const isMastering = next.graduated && next.interval >= 7 * 24 * 60 * 60 * 1000;
     const newStatus = isMastering ? 'mastered' : next.graduated ? 'review' : 'learning';
     let exp = 0; let unlockedItem = null; let newVillager = null;
@@ -563,11 +587,11 @@ export default function App() {
       kanjiStats: {
         ...s.kanjiStats,
         [id]: {
-          ...cur,
+          ...curWithMastery,
           ...next,
           status: newStatus,
-          mistakes: evalType === 'again' ? (cur.mistakes || 0) + 1 : (cur.mistakes || 0),
-          ...recordPracticeAttempt(cur, evalType),
+          mistakes: evalType === 'again' ? (curWithMastery.mistakes || 0) + 1 : (curWithMastery.mistakes || 0),
+          ...recordPracticeAttempt(curWithMastery, evalType),
         },
       },
       ...(newVillager ? { population: (s.population || 0) + 1, villagers: [...(s.villagers || []), newVillager] } : {}),
@@ -808,7 +832,7 @@ export default function App() {
           {view === 'peerHost' && <PageWrapper key="peerHost"><ErrorBoundary onReset={() => setView('home')}><TeacherHostView setView={setView} drill={hostDrill} /></ErrorBoundary></PageWrapper>}
           {view === 'peerClient' && <PageWrapper key="peerClient"><ErrorBoundary onReset={() => setView('home')}><StudentClientView setView={setView} stats={stats} setStats={setStats} initialConnectId={connectParam} /></ErrorBoundary></PageWrapper>}
           {view === 'gacha' && <PageWrapper key="gacha"><ErrorBoundary onReset={() => setView('home')}><GachaView stats={stats} setStats={setStats} onBack={() => setView('home')} /></ErrorBoundary></PageWrapper>}
-          {view === 'session' && <FullScreenWrapper key="session"><ErrorBoundary onReset={abandonLearningSession}><SessionView queue={sessionData.remainingQueue || sessionData.queue} totalCount={sessionData.queue.length} stats={stats.kanjiStats || {}} onUpdateStat={handleUpdateStat} onProgress={handleSessionProgress} onFinish={handleFinishSession} onRecordPerfect={handleRecordPerfect} onRecordEasy={handleRecordEasy} isResumed={isResumedSession} /></ErrorBoundary></FullScreenWrapper>}
+          {view === 'session' && <FullScreenWrapper key="session"><ErrorBoundary onReset={abandonLearningSession}><SessionView queue={sessionData.remainingQueue || sessionData.queue} totalCount={sessionData.queue.length} stats={stats.kanjiStats || {}} onUpdateStat={handleUpdateStat} onRecordSkillEvidence={handleRecordSkillEvidence} onProgress={handleSessionProgress} onFinish={handleFinishSession} onRecordPerfect={handleRecordPerfect} onRecordEasy={handleRecordEasy} isResumed={isResumedSession} /></ErrorBoundary></FullScreenWrapper>}
           {view === 'flashcard' && <FullScreenWrapper key="flashcard"><ErrorBoundary onReset={() => setView('home')}><FlashcardView queue={sessionData.queue} stats={stats} setStats={setStats} onFinish={handleFinishSession} /></ErrorBoundary></FullScreenWrapper>}
           {view === 'survival' && <FullScreenWrapper key="survival"><ErrorBoundary onReset={() => setView('home')}><SurvivalView queue={sessionData.queue} onUpdateStat={handleUpdateStat} onFinish={handleFinishSession} /></ErrorBoundary></FullScreenWrapper>}
           {view === 'boss' && <FullScreenWrapper key="boss"><ErrorBoundary onReset={() => setView('home')}><BossBattleView queue={sessionData.queue} onUpdateStat={handleUpdateStat} onFinish={handleFinishSession} onBossDefeat={handleBossDefeat} /></ErrorBoundary></FullScreenWrapper>}

--- a/src/components/pages/StatsView.jsx
+++ b/src/components/pages/StatsView.jsx
@@ -3,6 +3,14 @@ import { BarChart3, TrendingUp, AlertCircle, ArrowLeft, Target, CalendarClock } 
 import { F } from '../ui/FormatKun';
 import { KANJI_DATA } from '../../data/kanji-data';
 import { buildWeakKanjiPlan, getReviewForecast, getWeeklyLearningSummary, WEAK_PRACTICE_SUCCESS_TARGET } from '../../systems/learning-plan';
+import { getSkillMasterySummary, MASTERY_SKILLS, MASTERY_SKILL_DEFINITIONS } from '../../systems/mastery';
+
+const SKILL_COLORS = {
+  reading: { bar: 'bg-sky-400', text: 'text-sky-700', panel: 'bg-sky-50 border-sky-200' },
+  meaning: { bar: 'bg-amber-400', text: 'text-amber-700', panel: 'bg-amber-50 border-amber-200' },
+  writing: { bar: 'bg-rose-400', text: 'text-rose-700', panel: 'bg-rose-50 border-rose-200' },
+  stroke: { bar: 'bg-violet-400', text: 'text-violet-700', panel: 'bg-violet-50 border-violet-200' },
+};
 
 const StatsView = ({ setView, stats, startWeakSession }) => {
   const kanjiList = KANJI_DATA.map(k => ({ ...k, stat: stats.kanjiStats?.[k.id] }));
@@ -10,6 +18,10 @@ const StatsView = ({ setView, stats, startWeakSession }) => {
   const learning = kanjiList.filter(k => k.stat?.status === 'learning' || k.stat?.status === 'review').length;
   const notYet = kanjiList.filter(k => !k.stat || k.stat?.status === 'new').length;
   const totalKanji = KANJI_DATA.length;
+  const masterySummary = useMemo(
+    () => getSkillMasterySummary(stats.kanjiStats),
+    [stats.kanjiStats],
+  );
 
   const weeklySummary = useMemo(
     () => getWeeklyLearningSummary(stats),
@@ -68,6 +80,34 @@ const StatsView = ({ setView, stats, startWeakSession }) => {
               <div className="text-xs font-bold text-[var(--text)] opacity-60">{s.label}</div>
             </div>
           ))}
+        </div>
+      </div>
+
+      {/* 4技能の習熟度 */}
+      <div className="bg-[var(--panel)] border-[4px] border-[var(--text)] rounded-2xl p-4 shadow-sm">
+        <div className="mb-1 text-center text-sm font-black text-[var(--text)]">漢字を身につける「4つの力」</div>
+        <div className="mb-3 text-center text-[10px] font-bold text-[var(--text)] opacity-50">
+          {masterySummary.learnedCount > 0
+            ? `${masterySummary.learnedCount}字の回答と練習記録から自動計算`
+            : '漢字を学習すると、力の伸びがここに表示されます'}
+        </div>
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-4" role="list" aria-label="読み、意味、書字、筆順の習熟度">
+          {MASTERY_SKILLS.map((skill) => {
+            const definition = MASTERY_SKILL_DEFINITIONS[skill];
+            const colors = SKILL_COLORS[skill];
+            const score = masterySummary.scores[skill];
+            return (
+              <div key={skill} role="listitem" aria-label={`${definition.label} ${score}点`} className={`${colors.panel} rounded-xl border-2 p-2.5`}>
+                <div className="mb-2 flex items-center justify-between gap-1">
+                  <span className="text-xs font-black text-[var(--text)]"><span aria-hidden="true">{definition.icon}</span> {definition.label}</span>
+                  <span className={`text-lg font-black ${colors.text}`}>{score}<span className="text-[9px] opacity-60"> / 100</span></span>
+                </div>
+                <div className="h-2.5 overflow-hidden rounded-full border border-[var(--text)] bg-white/80" aria-hidden="true">
+                  <div className={`h-full rounded-full transition-all ${colors.bar}`} style={{ width: `${score}%` }} />
+                </div>
+              </div>
+            );
+          })}
         </div>
       </div>
 

--- a/src/components/session/SessionView.jsx
+++ b/src/components/session/SessionView.jsx
@@ -11,11 +11,16 @@ import { Analyzer } from '../../systems/analyzer';
 import { fetchKanjiVg } from '../../systems/kanjiVg';
 import { F } from '../ui/FormatKun';
 import { useLearningViewport } from '../../hooks/useLearningViewport';
+import { getRecommendedPracticeMode } from '../../systems/mastery';
 
-const SessionView = ({ queue: initialQueue, totalCount, stats, onUpdateStat, onProgress, onFinish, onRecordPerfect, onRecordEasy, isResumed = false }) => {
+const MODE_LABELS = { read: '音読', watch: '書き順', write: 'なぞる', test: 'テスト' };
+const WRITING_SKILLS = { skills: ['writing', 'stroke'] };
+
+const SessionView = ({ queue: initialQueue, totalCount, stats, onUpdateStat, onRecordSkillEvidence, onProgress, onFinish, onRecordPerfect, onRecordEasy, isResumed = false }) => {
   const [queue, setQueue] = useState(initialQueue); const [mode, setMode] = useState('read'); const [paths, setPaths] = useState([]); const [strokeData, setStrokeData] = useState([]); const [crossMatrix, setCrossMatrix] = useState([]); const [isLoading, setIsLoading] = useState(false);
   const { canvasSize, isStacked } = useLearningViewport();
   const [activeStamp, setActiveStamp] = useState(null); const [combo, setCombo] = useState(0); const [reachedStep, setReachedStep] = useState(0);
+  const [focusMode, setFocusMode] = useState('read');
   const currentKanji = queue[0]; const isNew = !stats[currentKanji?.id] || stats[currentKanji?.id].status === 'new'; const MODES = useMemo(() => ['read', 'watch', 'write', 'test'], []);
   const [fetchError, setFetchError] = useState(null);
   const [showResumeNotice, setShowResumeNotice] = useState(isResumed);
@@ -29,7 +34,11 @@ const SessionView = ({ queue: initialQueue, totalCount, stats, onUpdateStat, onP
   }, [showResumeNotice]);
 
   useEffect(() => {
-    if (!currentKanji) return; setMode(isNew ? 'read' : 'test'); setReachedStep(isNew ? 0 : 3);
+    if (!currentKanji) return;
+    const recommendedMode = getRecommendedPracticeMode(stats[currentKanji.id], { isNew });
+    setMode(recommendedMode);
+    setFocusMode(recommendedMode);
+    setReachedStep(isNew ? 0 : MODES.indexOf(recommendedMode));
     const abortCtrl = new AbortController();
     const load = async () => {
       setIsLoading(true); setFetchError(null);
@@ -48,7 +57,7 @@ const SessionView = ({ queue: initialQueue, totalCount, stats, onUpdateStat, onP
       }
     }; load();
     return () => { abortCtrl.abort(); };
-  }, [currentKanji, isNew]);
+  }, [currentKanji, isNew, MODES]);
 
   useEffect(() => { const stepIdx = MODES.indexOf(mode); if (stepIdx > reachedStep) setReachedStep(stepIdx); }, [mode, reachedStep, MODES]);
 
@@ -79,7 +88,7 @@ const SessionView = ({ queue: initialQueue, totalCount, stats, onUpdateStat, onP
     setActiveStamp(evalType === 'hard' ? 'good' : evalType); // hard は good スタンプで表示
     setTimeout(() => {
       setActiveStamp(null);
-      const success = onUpdateStat(currentKanji, evalType);
+      const success = onUpdateStat(currentKanji, evalType, WRITING_SKILLS);
       if (success) {
         const nextQueue = queue.slice(1);
         onProgress?.(nextQueue);
@@ -93,6 +102,7 @@ const SessionView = ({ queue: initialQueue, totalCount, stats, onUpdateStat, onP
       }
     }, evalType === 'again' ? 1500 : 900); // again以外は短めに
   };
+  const recordSkills = (updates) => onRecordSkillEvidence?.(currentKanji, updates);
   if (!currentKanji) return null;
 
   const commonSidebarTop = (
@@ -138,6 +148,7 @@ const SessionView = ({ queue: initialQueue, totalCount, stats, onUpdateStat, onP
         <div className="text-[var(--text)] font-bold text-xs md:text-sm bg-[var(--bg)] px-2.5 md:px-4 py-1.5 md:py-2 rounded-full border-[3px] border-[var(--text)] shadow-sm flex items-center gap-1.5" aria-live="polite">のこり <span className="text-base md:text-lg font-black">{queue.length}</span> {F("文字","もじ")}</div>
         <div className="flex gap-2">
           {combo > 1 && <motion.div initial={{ scale: 0 }} animate={{ scale: 1 }} className="text-[var(--text)] font-black text-xs md:text-sm bg-[var(--accent)] px-2.5 md:px-4 py-1.5 md:py-2 rounded-full border-[3px] border-[var(--text)] shadow-sm flex items-center gap-1">{combo} COMBO 🔥</motion.div>}
+          {!isNew && focusMode !== 'test' && <div className="text-[var(--text)] font-black text-[10px] md:text-xs bg-sky-100 px-2.5 md:px-3 py-1.5 md:py-2 rounded-full border-[3px] border-sky-400 shadow-sm">おすすめ：{MODE_LABELS[focusMode]}から</div>}
           {isNew && <div className="text-[var(--panel)] font-bold text-xs md:text-sm bg-[var(--primary)] px-2.5 md:px-4 py-1.5 md:py-2 rounded-full flex items-center gap-1 border-[3px] border-[var(--text)] shadow-sm"><Star size={15} /> {F("新出","しんしゅつ")}</div>}
         </div>
       </div>
@@ -171,9 +182,9 @@ const SessionView = ({ queue: initialQueue, totalCount, stats, onUpdateStat, onP
           </div>
         ) : (
           <>
-            {mode === 'read' && <ReadMode kanji={currentKanji} onNext={() => setMode('watch')} commonSidebar={commonSidebarTop} isStacked={isStacked} />}
-            {mode === 'watch' && <WatchMode paths={paths} strokeData={strokeData} isLoading={isLoading} onNext={() => setMode('write')} canvasSize={canvasSize} commonSidebar={commonSidebarTop} isStacked={isStacked} />}
-            {mode === 'write' && <WriteMode paths={paths} strokeData={strokeData} crossMatrix={crossMatrix} onNext={() => setMode('test')} canvasSize={canvasSize} commonSidebar={commonSidebarTop} onRecordPerfect={onRecordPerfect} isStacked={isStacked} />}
+            {mode === 'read' && <ReadMode kanji={currentKanji} onNext={() => { recordSkills([{ skill: 'reading', evidence: 'exposed' }, { skill: 'meaning', evidence: 'exposed' }]); setMode('watch'); }} commonSidebar={commonSidebarTop} isStacked={isStacked} />}
+            {mode === 'watch' && <WatchMode paths={paths} strokeData={strokeData} isLoading={isLoading} onNext={() => { recordSkills([{ skill: 'stroke', evidence: 'exposed' }]); setMode('write'); }} canvasSize={canvasSize} commonSidebar={commonSidebarTop} isStacked={isStacked} />}
+            {mode === 'write' && <WriteMode paths={paths} strokeData={strokeData} crossMatrix={crossMatrix} onNext={() => setMode('test')} onPracticeComplete={(evidence) => recordSkills([{ skill: 'writing', evidence }, { skill: 'stroke', evidence }])} canvasSize={canvasSize} commonSidebar={commonSidebarTop} onRecordPerfect={onRecordPerfect} isStacked={isStacked} />}
             {mode === 'test' && <TestMode kanji={currentKanji} strokeData={strokeData} onEvaluate={handleEvaluation} canvasSize={canvasSize} commonSidebar={commonSidebarTop} isStacked={isStacked} />}
           </>
         )}

--- a/src/components/session/WriteMode.jsx
+++ b/src/components/session/WriteMode.jsx
@@ -9,7 +9,7 @@ import { audioCtrl } from '../../systems/audio';
 import { F } from '../ui/FormatKun';
 import { STROKE_THRESHOLDS } from '../../constants/strokeConfig';
 
-const WriteMode = ({ paths, strokeData, crossMatrix, onNext, canvasSize, commonSidebar, onRecordPerfect, isStacked }) => {
+const WriteMode = ({ paths, strokeData, crossMatrix, onNext, onPracticeComplete, canvasSize, commonSidebar, onRecordPerfect, isStacked }) => {
   const guideRef = useRef(null); const inkRef = useRef(null); const writeRef = useRef(null);
   const [currentStroke, setCurrentStroke] = useState(0); const [isDrawing, setIsDrawing] = useState(false);
   const [count, setCount] = useState(0); const [statusMsg, setStatusMsg] = useState("１かくめ をかこう！");
@@ -85,7 +85,9 @@ const WriteMode = ({ paths, strokeData, crossMatrix, onNext, canvasSize, commonS
       const nextStroke = currentStrokeRef.current + 1; setUserStrokes(prev => [...prev, [...currentPathRef.current]]); setCurrentStroke(nextStroke); clearCanvas(writeRef); distSum.current += currentDist; strokeDists.current.push(currentDist);
       if (nextStroke >= paths.length) {
         const avgDist = distSum.current / paths.length; let evalText = "Good!"; let color = "var(--secondary)";
-        if (avgDist < 0.08) { evalText = "Perfect!!"; color = "var(--primary)"; onRecordPerfect(inkRef.current?.toDataURL('image/png')); } else if (avgDist < 0.15) { evalText = "Great!"; color = "var(--accent)"; }
+        let skillEvidence = 'guided';
+        if (avgDist < 0.08) { evalText = "Perfect!!"; color = "var(--primary)"; skillEvidence = 'easy'; onRecordPerfect(inkRef.current?.toDataURL('image/png')); } else if (avgDist < 0.15) { evalText = "Great!"; color = "var(--accent)"; skillEvidence = 'good'; }
+        onPracticeComplete?.(skillEvidence);
         addFloatingText(canvasSize / 2, canvasSize / 2, `${evalText}`, color, 1.5); distSum.current = 0; setStatusMsg("✨ よくできました！"); audioCtrl.playSE('success'); setShowConfetti(true); setTimeout(() => setShowConfetti(false), 2500);
       } else { addFloatingText(lastPos.current.x, lastPos.current.y, "✨", "var(--accent)", 1); setStatusMsg(`${nextStroke + 1}かくめ をかこう！`); audioCtrl.playSE('click'); }
     } else { clearCanvas(writeRef); setStatusMsg("さいごまで なぞってね💦"); audioCtrl.playSE('stamp_bad'); }

--- a/src/components/training/BossBattleView.jsx
+++ b/src/components/training/BossBattleView.jsx
@@ -10,6 +10,7 @@ import { RefreshCw, Swords, Shield } from 'lucide-react';
 
 const PLAYER_MAX_HP = 3;
 const BOSS_MAX_HP = 10;
+const WRITING_SKILLS = { skills: ['writing', 'stroke'] };
 
 // --- ボスバトル専用キャンバス ---
 const BossBattleCanvas = ({ strokeData, paths, canvasSize, onSubmit, disabled }) => {
@@ -261,7 +262,7 @@ const BossBattleView = ({ queue, onUpdateStat, onFinish, onBossDefeat }) => {
       doBossAttack(2, 'タイムアウト！ボスの強攻撃！');
       // 復習リスト入り
       addToFailedKanji(kanji);
-      onUpdateStat(kanji, 'again');
+      onUpdateStat(kanji, 'again', WRITING_SKILLS);
     }, 800);
   };
 
@@ -281,14 +282,14 @@ const BossBattleView = ({ queue, onUpdateStat, onFinish, onBossDefeat }) => {
         audioCtrl.playSE('stamp_bad');
         doBossAttack(2, '画数ミス！ボスの猛攻撃！');
         addToFailedKanji(kanji);
-        onUpdateStat(kanji, 'again');
+        onUpdateStat(kanji, 'again', WRITING_SKILLS);
       } else if (!result.crossMatch) {
         // 交差ミス → 一撃アウト（0点）、ボス強攻撃2ダメージ
         setBattleMessage('せんの交わりがちがう！一撃アウト！');
         audioCtrl.playSE('stamp_bad');
         doBossAttack(2, '交差ミス！ボスの猛攻撃！');
         addToFailedKanji(kanji);
-        onUpdateStat(kanji, 'again');
+        onUpdateStat(kanji, 'again', WRITING_SKILLS);
       } else if (result.total >= 80) {
         // 会心の一撃
         setBattleMessage('会心の一撃！');
@@ -300,7 +301,7 @@ const BossBattleView = ({ queue, onUpdateStat, onFinish, onBossDefeat }) => {
           coins: earnedRef.current.coins + 8,
           perfectCount: earnedRef.current.perfectCount + 1,
         };
-        onUpdateStat(kanji, 'easy');
+        onUpdateStat(kanji, 'easy', WRITING_SKILLS);
       } else if (result.total >= 60) {
         // ダメージ！
         setBattleMessage('ダメージを与えた！');
@@ -311,20 +312,20 @@ const BossBattleView = ({ queue, onUpdateStat, onFinish, onBossDefeat }) => {
           exp: earnedRef.current.exp + 15,
           coins: earnedRef.current.coins + 5,
         };
-        onUpdateStat(kanji, 'good');
+        onUpdateStat(kanji, 'good', WRITING_SKILLS);
       } else if (result.total >= 50) {
         // ダメージ通らない + ボス反撃1ダメージ
         setBattleMessage('おしい…ダメージが通らない！');
         audioCtrl.playSE('stamp_bad');
         doBossAttack(1, 'ボスの反撃！');
-        onUpdateStat(kanji, 'hard');
+        onUpdateStat(kanji, 'hard', WRITING_SKILLS);
       } else {
         // 50点未満 → ボス強攻撃2ダメージ + 復習リスト入り
         setBattleMessage('うまく書けなかった…');
         audioCtrl.playSE('stamp_bad');
         doBossAttack(2, 'ボスの強攻撃！');
         addToFailedKanji(kanji);
-        onUpdateStat(kanji, 'again');
+        onUpdateStat(kanji, 'again', WRITING_SKILLS);
       }
     }, 600);
   };

--- a/src/components/training/DrillTestView.jsx
+++ b/src/components/training/DrillTestView.jsx
@@ -9,6 +9,8 @@ import { fetchKanjiVg } from '../../systems/kanjiVg';
 import { TEST } from '../../constants/gameConfig';
 import { getSatisfactionMultiplier, calculateSatisfaction } from '../../systems/residents';
 
+const WRITING_SKILLS = { skills: ['writing', 'stroke'] };
+
 // --- テスト専用キャンバス ---
 const TestCanvas = ({ strokeData, canvasSize, onSubmit, disabled }) => {
   const inkRef = useRef(null);
@@ -250,7 +252,7 @@ const DrillTestView = ({ queue, stats, onUpdateStat, onFinish, startDrillSession
     const passed = result.total >= TEST.PASS_THRESHOLD && result.strokeCountMatch && result.crossMatch !== false;
 
     // EXP累積のためonUpdateStatを呼ぶ
-    onUpdateStat(kanji, passed ? 'good' : 'again');
+    onUpdateStat(kanji, passed ? 'good' : 'again', WRITING_SKILLS);
 
     const answer = {
       kanji,

--- a/src/components/training/FlashcardView.jsx
+++ b/src/components/training/FlashcardView.jsx
@@ -6,6 +6,7 @@ import { audioCtrl } from '../../systems/audio';
 import { F, FormatKun } from '../ui/FormatKun';
 import { migrateCard, calculateNextReview, recordPracticeAttempt } from '../../systems/srs';
 import { StorageAPI } from '../../systems/storage';
+import { recordSkillEvidence } from '../../systems/mastery';
 
 const FlashcardView = ({ queue, stats, setStats, onFinish }) => {
   const [idx, setIdx] = useState(0);
@@ -54,10 +55,15 @@ const FlashcardView = ({ queue, stats, setStats, onFinish }) => {
 
     setStats(currentStats => {
       const cur = migrateCard(currentStats.kanjiStats?.[kanji.id]);
+      const skillMastery = recordSkillEvidence(cur, [
+        { skill: 'reading', evidence: evaluation },
+        { skill: 'meaning', evidence: 'exposed' },
+      ]);
       const card = isKnown
-        ? { ...cur, ...recordPracticeAttempt(cur, evaluation) }
+        ? { ...cur, skillMastery, ...recordPracticeAttempt(cur, evaluation) }
         : {
           ...cur,
+          skillMastery,
           ...calculateNextReview(cur, evaluation),
           status: 'learning',
           mistakes: (cur.mistakes || 0) + 1,

--- a/src/components/training/SurvivalView.jsx
+++ b/src/components/training/SurvivalView.jsx
@@ -10,6 +10,7 @@ import { fetchKanjiVg } from '../../systems/kanjiVg';
 const WAVE_SIZE = 10;
 const INITIAL_TIME = 45;
 const MAX_TIME = 60;
+const WRITING_SKILLS = { skills: ['writing', 'stroke'] };
 
 // gradeStrokes の 0-100 スコアをサバイバルのランクに変換
 function scoreToRank(result) {
@@ -442,7 +443,7 @@ const SurvivalView = ({ queue, onUpdateStat, onFinish }) => {
         perfectCount: earnedRef.current.perfectCount + 1,
       };
       audioCtrl.playSE('stamp_perfect');
-      onUpdateStat(kanji, 'easy');
+      onUpdateStat(kanji, 'easy', WRITING_SKILLS);
     } else if (rank === 'ok') {
       setOkCount(c => c + 1);
       earnedRef.current = {
@@ -451,11 +452,11 @@ const SurvivalView = ({ queue, onUpdateStat, onFinish }) => {
         coins: earnedRef.current.coins + 2,
       };
       audioCtrl.playSE('stamp_good');
-      onUpdateStat(kanji, 'good');
+      onUpdateStat(kanji, 'good', WRITING_SKILLS);
     } else {
       setMissCount(c => c + 1);
       audioCtrl.playSE('stamp_bad');
-      onUpdateStat(kanji, 'again');
+      onUpdateStat(kanji, 'again', WRITING_SKILLS);
       // ミスフラッシュ
       setMissFlash(true);
       setTimeout(() => setMissFlash(false), 400);

--- a/src/systems/mastery.js
+++ b/src/systems/mastery.js
@@ -1,0 +1,105 @@
+export const MASTERY_SKILLS = ['reading', 'meaning', 'writing', 'stroke'];
+
+export const MASTERY_SKILL_DEFINITIONS = {
+  reading: { label: '読み', shortLabel: '音読', icon: '📖', mode: 'read' },
+  meaning: { label: '意味', shortLabel: '意味', icon: '💡', mode: 'read' },
+  writing: { label: '書字', shortLabel: 'なぞり', icon: '✍️', mode: 'write' },
+  stroke: { label: '筆順', shortLabel: '書き順', icon: '🖌️', mode: 'watch' },
+};
+
+const EVIDENCE_RULES = {
+  exposed: { delta: 8, cap: 60, success: false },
+  guided: { delta: 6, cap: 75, success: true },
+  again: { delta: -18, success: false },
+  hard: { delta: 2, success: true },
+  good: { delta: 10, success: true },
+  easy: { delta: 15, success: true },
+};
+
+const clampScore = (score) => Math.max(0, Math.min(100, Math.round(Number(score) || 0)));
+
+function getLegacyBaseScore(card = {}) {
+  if (card.status === 'mastered') return 85;
+  if (card.status === 'review' || card.graduated) return 55;
+  if (card.status === 'learning') return 30;
+  return 0;
+}
+
+function normalizeEntry(entry, fallbackScore) {
+  return {
+    score: clampScore(entry?.score ?? fallbackScore),
+    attempts: Math.max(0, Number(entry?.attempts) || 0),
+    successes: Math.max(0, Number(entry?.successes) || 0),
+    lastPracticedAt: Math.max(0, Number(entry?.lastPracticedAt) || 0),
+    lastEvidence: typeof entry?.lastEvidence === 'string' ? entry.lastEvidence : null,
+  };
+}
+
+/** 旧カードや部分的な保存データを4技能の共通形式へ補完する。 */
+export function normalizeSkillMastery(skillMastery, card = {}) {
+  const fallbackScore = getLegacyBaseScore(card);
+  return Object.fromEntries(
+    MASTERY_SKILLS.map((skill) => [skill, normalizeEntry(skillMastery?.[skill], fallbackScore)]),
+  );
+}
+
+/** 複数技能の練習証拠を1回の状態更新で記録する。 */
+export function recordSkillEvidence(card, updates, now = Date.now()) {
+  const mastery = normalizeSkillMastery(card?.skillMastery, card);
+
+  (Array.isArray(updates) ? updates : []).forEach(({ skill, evidence }) => {
+    if (!MASTERY_SKILLS.includes(skill) || !EVIDENCE_RULES[evidence]) return;
+    const current = mastery[skill];
+    const rule = EVIDENCE_RULES[evidence];
+    const proposedScore = clampScore(current.score + rule.delta);
+    const nextScore = rule.cap === undefined
+      ? proposedScore
+      : Math.max(current.score, Math.min(proposedScore, rule.cap));
+
+    mastery[skill] = {
+      score: nextScore,
+      attempts: current.attempts + 1,
+      successes: current.successes + (rule.success ? 1 : 0),
+      lastPracticedAt: now,
+      lastEvidence: evidence,
+    };
+  });
+
+  return mastery;
+}
+
+export function getWeakestSkill(card) {
+  const mastery = normalizeSkillMastery(card?.skillMastery, card);
+  return MASTERY_SKILLS
+    .map((skill) => ({ skill, ...MASTERY_SKILL_DEFINITIONS[skill], ...mastery[skill] }))
+    .reduce((weakest, current) => (current.score < weakest.score ? current : weakest));
+}
+
+/** 新出は基礎から、復習は50点未満の最弱技能から始める。 */
+export function getRecommendedPracticeMode(card, { isNew = false, threshold = 50 } = {}) {
+  if (isNew) return 'read';
+  const weakest = getWeakestSkill(card);
+  return weakest.score < threshold ? weakest.mode : 'test';
+}
+
+/** 学習済み漢字全体の4技能平均を学習記録画面向けに集計する。 */
+export function getSkillMasterySummary(kanjiStats = {}) {
+  const learnedCards = Object.values(kanjiStats || {}).filter((card) => card && card.status !== 'new');
+  const totals = Object.fromEntries(MASTERY_SKILLS.map((skill) => [skill, 0]));
+  let evidenceCount = 0;
+
+  learnedCards.forEach((card) => {
+    const mastery = normalizeSkillMastery(card.skillMastery, card);
+    MASTERY_SKILLS.forEach((skill) => {
+      totals[skill] += mastery[skill].score;
+      evidenceCount += mastery[skill].attempts;
+    });
+  });
+
+  const scores = Object.fromEntries(MASTERY_SKILLS.map((skill) => [
+    skill,
+    learnedCards.length > 0 ? Math.round(totals[skill] / learnedCards.length) : 0,
+  ]));
+
+  return { scores, learnedCount: learnedCards.length, evidenceCount };
+}

--- a/src/systems/srs.js
+++ b/src/systems/srs.js
@@ -2,6 +2,7 @@
 // SM-2+ 間隔反復アルゴリズム
 // 学習フェーズ → 卒業 → レビューフェーズの3段階
 // ==========================================
+import { normalizeSkillMastery } from './mastery.js';
 
 /** 学習ステップ間隔(ms): 1分 → 10分 */
 export const LEARNING_STEPS = [1 * 60 * 1000, 10 * 60 * 1000];
@@ -231,7 +232,7 @@ export function recordPracticeAttempt(card, evaluation, now = Date.now()) {
  */
 export const migrateCard = (card) => {
   if (!card) {
-    return {
+    const migrated = {
       graduated: false,
       stepIdx: 0,
       interval: LEARNING_STEPS[0],
@@ -244,17 +245,19 @@ export const migrateCard = (card) => {
       practiceAttempts: 0,
       lastPracticedAt: 0,
     };
+    return { ...migrated, skillMastery: normalizeSkillMastery(null, migrated) };
   }
   // easeフィールドがあれば移行済み
   if (card.ease !== undefined) {
-    return sanitizeNextReview({
+    const migrated = sanitizeNextReview({
       practiceStreak: 0,
       practiceAttempts: 0,
       lastPracticedAt: 0,
       ...card,
     });
+    return { ...migrated, skillMastery: normalizeSkillMastery(card.skillMastery, migrated) };
   }
-  return sanitizeNextReview({
+  const migrated = sanitizeNextReview({
     ...card,
     ease: DEFAULT_EASE,
     graduated: (card.interval || 0) >= GRADUATING_INTERVAL,
@@ -264,4 +267,5 @@ export const migrateCard = (card) => {
     practiceAttempts: 0,
     lastPracticedAt: 0,
   });
+  return { ...migrated, skillMastery: normalizeSkillMastery(card.skillMastery, migrated) };
 };

--- a/test/mastery.test.js
+++ b/test/mastery.test.js
@@ -1,0 +1,79 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  getRecommendedPracticeMode,
+  getSkillMasterySummary,
+  getWeakestSkill,
+  normalizeSkillMastery,
+  recordSkillEvidence,
+} from '../src/systems/mastery.js';
+import { migrateCard } from '../src/systems/srs.js';
+
+test('既存カードは現在の習得状態から4技能を安全に補完する', () => {
+  const migrated = migrateCard({
+    status: 'review',
+    graduated: true,
+    interval: 86_400_000,
+    nextReview: Date.now() + 60_000,
+    ease: 2.3,
+  });
+
+  assert.deepEqual(
+    Object.fromEntries(Object.entries(migrated.skillMastery).map(([skill, value]) => [skill, value.score])),
+    { reading: 55, meaning: 55, writing: 55, stroke: 55 },
+  );
+});
+
+test('練習証拠は対象技能だけを更新し、苦手技能を判定する', () => {
+  const card = { status: 'review', graduated: true };
+  const skillMastery = recordSkillEvidence(card, [
+    { skill: 'reading', evidence: 'good' },
+    { skill: 'writing', evidence: 'again' },
+  ], 1234);
+  const updated = { ...card, skillMastery };
+
+  assert.equal(skillMastery.reading.score, 65);
+  assert.equal(skillMastery.writing.score, 37);
+  assert.equal(skillMastery.meaning.score, 55);
+  assert.equal(skillMastery.reading.lastPracticedAt, 1234);
+  assert.equal(getWeakestSkill(updated).skill, 'writing');
+  assert.equal(getRecommendedPracticeMode(updated), 'write');
+});
+
+test('見るだけ・ガイド付き練習では技能点を上限以上に押し上げない', () => {
+  let card = { status: 'new', skillMastery: normalizeSkillMastery(null, { status: 'new' }) };
+  for (let i = 0; i < 20; i++) {
+    card = {
+      ...card,
+      skillMastery: recordSkillEvidence(card, [
+        { skill: 'reading', evidence: 'exposed' },
+        { skill: 'stroke', evidence: 'guided' },
+      ], i + 1),
+    };
+  }
+
+  assert.equal(card.skillMastery.reading.score, 60);
+  assert.equal(card.skillMastery.stroke.score, 75);
+});
+
+test('新出漢字と技能別の弱点に合わせて開始モードを選ぶ', () => {
+  const strong = normalizeSkillMastery(null, { status: 'mastered' });
+  assert.equal(getRecommendedPracticeMode({ status: 'new' }, { isNew: true }), 'read');
+  assert.equal(getRecommendedPracticeMode({ status: 'mastered', skillMastery: strong }), 'test');
+  assert.equal(getRecommendedPracticeMode({
+    status: 'learning',
+    skillMastery: { ...strong, stroke: { ...strong.stroke, score: 20 } },
+  }), 'watch');
+});
+
+test('学習済み漢字の4技能平均と証拠数を集計する', () => {
+  const summary = getSkillMasterySummary({
+    a: { status: 'review', skillMastery: recordSkillEvidence({ status: 'review' }, [{ skill: 'reading', evidence: 'good' }], 1) },
+    b: { status: 'mastered' },
+    c: { status: 'new' },
+  });
+
+  assert.deepEqual(summary.scores, { reading: 75, meaning: 70, writing: 70, stroke: 70 });
+  assert.equal(summary.learnedCount, 2);
+  assert.equal(summary.evidenceCount, 1);
+});


### PR DESCRIPTION
## 概要

漢字ごとの習熟度を「読み・意味・書字・筆順」の4技能に分けて記録し、苦手な技能から学習を始められるようにします。既存のSRS（復習タイミング）は維持し、技能別データは現在のカード状態から後方互換で補完します。

## 主な変更

- 4技能のスコア・試行回数・成功回数・最終練習を記録する習熟度モデルを追加
- 閲覧・ガイド練習・自己評価を異なる強さの学習証拠として扱い、閲覧だけでは習熟上限に達しない設計を追加
- 通常学習で50点未満の最弱技能から開始する適応型フローを追加
- 音読、書き順、なぞり、書字テスト、フラッシュカード、サバイバル、ボス戦、ドリルの結果を技能別に反映
- 学習記録に「4つの力」メーターを追加（スマートフォン2列・広い画面4列）
- 旧保存データと部分的な技能データを安全に補完する移行処理を追加

## 設計上のポイント

- 復習予定を決める既存SRSは変更せず、技能モデルは学習内容の選択と可視化を担当
- 旧ユーザーの学習履歴や復習予定をリセットしない
- 新出漢字は従来どおり基礎学習から開始
- 十分に習熟した復習漢字は従来どおりテストから開始

## 確認

- `npm test` — 27件成功
- `npm run build` — 成功
- バンドル容量制限 — 成功

## 影響範囲

保存データへ後方互換な `skillMastery` フィールドを追加します。既存フィールドの削除やスキーマ破壊はありません。