### PR TITLE
おやすみパスで無理なく続く学習習慣を追加

### DIFF
--- a/src/components/pages/HomeView.jsx
+++ b/src/components/pages/HomeView.jsx
@@ -13,6 +13,7 @@ import { calculateSatisfaction, getSatisfactionLabel } from '../../systems/resid
 import { buildLearningPlan, getDailyLearningProgress, getGoalAwareSessionLimits, getReviewForecast } from '../../systems/learning-plan';
 import { getTodayString } from '../../utils/date-utils';
 import { SESSION } from '../../constants/gameConfig';
+import { getHabitStatus } from '../../systems/habit';
 
 const DraggableTownMap = lazy(() => import('../town/DraggableTownMap'));
 
@@ -34,7 +35,9 @@ const HomeView = ({ setView, stats, setStats, startSession, startFlashcard, star
   const { level, title, badge, progress, remainingExp, targetReward, isMaxLevel } = currentLevelInfo;
   const [selectedGrade, setSelectedGrade] = useState(stats.targetGrade || 1);
   const handleGradeChange = (g) => { setSelectedGrade(g); let newStats = { ...stats, targetGrade: g }; setStats(newStats); StorageAPI.saveStats(newStats); };
-  const dailyProgress = getDailyLearningProgress(stats, getTodayString());
+  const today = getTodayString();
+  const dailyProgress = getDailyLearningProgress(stats, today);
+  const habitStatus = getHabitStatus(stats, today);
   const sessionSize = stats.settings?.sessionSize || 'normal';
   const baseSessionLimits = SESSION.SIZE_LIMITS[sessionSize] || SESSION.SIZE_LIMITS.normal;
   const sessionLimits = getGoalAwareSessionLimits(baseSessionLimits, dailyProgress);
@@ -131,7 +134,13 @@ const HomeView = ({ setView, stats, setStats, startSession, startFlashcard, star
           </div>
           <div className="min-w-0">
             <div className="text-xs md:text-sm font-black text-[var(--text)] truncate">{dailyProgress.isComplete ? 'きょうの目標クリア！' : 'きょうの学習目標'}</div>
-            <div className="text-[10px] font-bold text-[var(--text)] opacity-55">🔥 {stats.streak || 0}日れんぞく</div>
+            <div className="text-[10px] font-bold text-[var(--text)] opacity-55">
+              🔥 {stats.streak || 0}日 ・ 🛡️ {habitStatus.canProtectToday
+                ? 'きょう自動で守ります'
+                : habitStatus.restPassAvailable
+                  ? 'おやすみパスあり'
+                  : `あと${habitStatus.rechargeRemaining}日でパス`}
+            </div>
           </div>
         </div>
         <div className="font-black text-[var(--text)] shrink-0"><span className="text-lg text-[var(--primary)]">{dailyProgress.reviewed}</span><span className="text-xs opacity-50"> / {dailyProgress.goal}字</span></div>
@@ -140,7 +149,11 @@ const HomeView = ({ setView, stats, setStats, startSession, startFlashcard, star
         <motion.div initial={{ width: 0 }} animate={{ width: `${dailyProgress.percent}%` }} className={`h-full ${dailyProgress.isComplete ? 'bg-emerald-400' : 'bg-[var(--primary)]'}`} />
       </div>
       <div className="flex justify-between mt-1.5 text-[10px] font-bold text-[var(--text)] opacity-60">
-        <span>{dailyProgress.isComplete ? 'よくがんばりました！' : `あと ${dailyProgress.remaining}字でクリア`}</span>
+        <span>{habitStatus.canProtectToday
+          ? 'きょう学ぶと連続記録を守れます'
+          : dailyProgress.isComplete
+            ? 'よくがんばりました！'
+            : `あと ${dailyProgress.remaining}字でクリア`}</span>
         <span>{nextReviewHint}</span>
       </div>
     </div>

--- a/src/components/pages/ResultView.jsx
+++ b/src/components/pages/ResultView.jsx
@@ -14,6 +14,7 @@ import { getOccupation } from '../../data/residents';
 import { getLevelInfoFromExp } from '../../utils/level-system';
 import { getDailyLearningProgress } from '../../systems/learning-plan';
 import { getTodayString } from '../../utils/date-utils';
+import { getHabitStatus } from '../../systems/habit';
 
 import { gachaRoll, isRareItem } from '../../systems/gacha';
 
@@ -24,7 +25,9 @@ const ResultView = ({ sessionMetrics, oldExp, setView, stats, setStats, onContin
   const [gachaResult, setGachaResult] = useState(null);
   const [gachaPhase, setGachaPhase] = useState('idle');
   const coinBonus = Math.floor(earnedExp / 4);
-  const dailyProgress = getDailyLearningProgress(stats, getTodayString());
+  const today = getTodayString();
+  const dailyProgress = getDailyLearningProgress(stats, today);
+  const habitStatus = getHabitStatus(stats, today);
 
   const oldLevelInfo = getLevelInfoFromExp(oldExp);
   const newLevelInfo = getLevelInfoFromExp(oldExp + earnedExp);
@@ -148,6 +151,13 @@ const ResultView = ({ sessionMetrics, oldExp, setView, stats, setStats, onContin
         <div className="h-3 bg-gray-200 rounded-full overflow-hidden border-2 border-[var(--text)]" role="progressbar" aria-label="今日の学習目標" aria-valuemin="0" aria-valuemax={dailyProgress.goal} aria-valuenow={Math.min(dailyProgress.reviewed, dailyProgress.goal)}>
           <motion.div initial={{ width: 0 }} animate={{ width: `${dailyProgress.percent}%` }} className={`h-full ${dailyProgress.isComplete ? 'bg-emerald-400' : 'bg-[var(--primary)]'}`} />
         </div>
+        {habitStatus.event && (
+          <div className="mt-3 rounded-xl border-2 border-sky-300 bg-sky-50 px-3 py-2 text-center text-xs font-black text-sky-700" role="status">
+            {habitStatus.event.type === 'rest_protected'
+              ? '🛡️ おやすみパスで、休んだ日も連続記録を守りました！'
+              : '🛡️ 5日間の学習で、おやすみパスがもどりました！'}
+          </div>
+        )}
       </motion.div>
 
       {/* ストーリーナレーション */}

--- a/src/components/pages/StatsView.jsx
+++ b/src/components/pages/StatsView.jsx
@@ -4,6 +4,8 @@ import { F } from '../ui/FormatKun';
 import { KANJI_DATA } from '../../data/kanji-data';
 import { buildWeakKanjiPlan, getReviewForecast, getWeeklyLearningSummary, WEAK_PRACTICE_SUCCESS_TARGET } from '../../systems/learning-plan';
 import { getSkillMasterySummary, MASTERY_SKILLS, MASTERY_SKILL_DEFINITIONS } from '../../systems/mastery';
+import { getHabitStatus } from '../../systems/habit';
+import { getTodayString } from '../../utils/date-utils';
 
 const SKILL_COLORS = {
   reading: { bar: 'bg-sky-400', text: 'text-sky-700', panel: 'bg-sky-50 border-sky-200' },
@@ -22,6 +24,7 @@ const StatsView = ({ setView, stats, startWeakSession }) => {
     () => getSkillMasterySummary(stats.kanjiStats),
     [stats.kanjiStats],
   );
+  const habitStatus = getHabitStatus(stats, getTodayString());
 
   const weeklySummary = useMemo(
     () => getWeeklyLearningSummary(stats),
@@ -117,6 +120,7 @@ const StatsView = ({ setView, stats, startWeakSession }) => {
           <div className="text-3xl mb-1">🔥</div>
           <div className="text-3xl font-black text-[var(--primary)]">{stats.streak || 0}</div>
           <div className="text-xs font-bold text-[var(--text)] opacity-60">{F("連続","れんぞく")}{F("学習","がくしゅう")}{F("日数","にっすう")}</div>
+          <div className="mt-2 text-[10px] font-black text-sky-700">🛡️ {habitStatus.restPassAvailable ? 'おやすみパスあり' : `あと${habitStatus.rechargeRemaining}日でパス`}</div>
         </div>
         <div className="bg-[var(--panel)] border-[4px] border-[var(--text)] rounded-2xl p-4 shadow-sm text-center">
           <div className="text-3xl mb-1">⚡</div>

--- a/src/systems/habit.js
+++ b/src/systems/habit.js
@@ -1,0 +1,116 @@
+export const REST_PASS_RECHARGE_DAYS = 5;
+
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const HABIT_EVENT_TYPES = new Set(['rest_protected', 'rest_pass_recharged']);
+
+function parseDateKey(value) {
+  if (typeof value !== 'string' || !DATE_PATTERN.test(value)) return null;
+  const [year, month, day] = value.split('-').map(Number);
+  const timestamp = Date.UTC(year, month - 1, day);
+  const parsed = new Date(timestamp);
+  if (
+    parsed.getUTCFullYear() !== year
+    || parsed.getUTCMonth() !== month - 1
+    || parsed.getUTCDate() !== day
+  ) return null;
+  return timestamp;
+}
+
+export function getDayDifference(fromDate, toDate) {
+  const from = parseDateKey(fromDate);
+  const to = parseDateKey(toDate);
+  if (from === null || to === null) return null;
+  return Math.round((to - from) / 86_400_000);
+}
+
+function getPreviousDate(dateKey) {
+  const timestamp = parseDateKey(dateKey);
+  if (timestamp === null) return '';
+  return new Date(timestamp - 86_400_000).toISOString().slice(0, 10);
+}
+
+export function normalizeHabitState(stats = {}) {
+  const available = stats.restPassAvailable !== false;
+  const rawProgress = Math.max(0, Math.floor(Number(stats.restPassRechargeProgress) || 0));
+  const rawEvent = stats.lastHabitEvent;
+  const lastHabitEvent = rawEvent
+    && typeof rawEvent === 'object'
+    && HABIT_EVENT_TYPES.has(rawEvent.type)
+    && parseDateKey(rawEvent.date) !== null
+    ? {
+      type: rawEvent.type,
+      date: rawEvent.date,
+      ...(rawEvent.type === 'rest_protected' && parseDateKey(rawEvent.restDate) !== null
+        ? { restDate: rawEvent.restDate }
+        : {}),
+    }
+    : null;
+  return {
+    restPassAvailable: available,
+    restPassRechargeProgress: available ? 0 : Math.min(rawProgress, REST_PASS_RECHARGE_DAYS - 1),
+    lastRestPassDate: typeof stats.lastRestPassDate === 'string' ? stats.lastRestPassDate : '',
+    lastHabitEvent,
+  };
+}
+
+/** 直前の学習から1日だけ空いており、パスで休息日を守れるかを返す。 */
+export function canProtectRestDay(stats, today) {
+  const habit = normalizeHabitState(stats);
+  return habit.restPassAvailable && getDayDifference(stats?.lastDate, today) === 2;
+}
+
+export function getHabitStatus(stats, today) {
+  const habit = normalizeHabitState(stats);
+  const event = habit.lastHabitEvent?.date === today ? habit.lastHabitEvent : null;
+  return {
+    ...habit,
+    rechargeRemaining: habit.restPassAvailable
+      ? 0
+      : REST_PASS_RECHARGE_DAYS - habit.restPassRechargeProgress,
+    canProtectToday: canProtectRestDay(stats, today),
+    event,
+  };
+}
+
+/**
+ * 新しい学習日をストリークへ反映する。
+ * 1日だけ休んだ場合はパスを自動使用し、学習5日で再獲得する。
+ */
+export function applyLearningDayHabit(stats, today) {
+  const habit = normalizeHabitState(stats);
+  const difference = getDayDifference(stats?.lastDate, today);
+
+  if (difference === 0) return { ...habit, streak: Math.max(0, Number(stats?.streak) || 0), lastDate: today };
+
+  const currentStreak = Math.max(0, Number(stats?.streak) || 0);
+  const isConsecutive = difference === 1;
+  const usesRestPass = difference === 2 && habit.restPassAvailable;
+  let streak = isConsecutive || usesRestPass ? Math.max(1, currentStreak + 1) : 1;
+  let restPassAvailable = habit.restPassAvailable;
+  let restPassRechargeProgress = habit.restPassRechargeProgress;
+  let lastRestPassDate = habit.lastRestPassDate;
+  let lastHabitEvent = habit.lastHabitEvent;
+
+  if (usesRestPass) {
+    restPassAvailable = false;
+    restPassRechargeProgress = 1;
+    lastRestPassDate = getPreviousDate(today);
+    lastHabitEvent = { type: 'rest_protected', date: today, restDate: lastRestPassDate };
+  } else if (!restPassAvailable) {
+    restPassRechargeProgress += 1;
+    if (restPassRechargeProgress >= REST_PASS_RECHARGE_DAYS) {
+      restPassAvailable = true;
+      restPassRechargeProgress = 0;
+      lastHabitEvent = { type: 'rest_pass_recharged', date: today };
+    }
+  }
+
+  return {
+    restPassAvailable,
+    restPassRechargeProgress,
+    lastRestPassDate,
+    lastHabitEvent,
+    streak,
+    lastDate: today,
+  };
+}

--- a/src/systems/storage.js
+++ b/src/systems/storage.js
@@ -11,6 +11,7 @@ import { migrateVillagers, collectDailyResources, calculateSatisfaction, calcula
 import { getTodayString, formatDate } from '../utils/date-utils.js';
 import { getLevelInfoFromExp, getThemeFromLevel } from '../utils/level-system.js';
 import { MAP, ECONOMY, NEGLECT, DEBOUNCE } from '../constants/gameConfig.js';
+import { applyLearningDayHabit, canProtectRestDay, normalizeHabitState } from './habit.js';
 
 // ── 内部エラーログ（直近20件を保持、デバッグ用） ──
 const _errorLog = [];
@@ -222,6 +223,7 @@ const StorageAPI = {
     tutorialCompleted: stats.tutorialCompleted,
     settings: stats.settings,
     seenHints: stats.seenHints || [],
+    ...normalizeHabitState(stats),
   }),
 
   /**
@@ -362,6 +364,10 @@ const StorageAPI = {
         streak: 0,
         lastDate: '',
         lastNeglectAppliedDate: '',
+        restPassAvailable: true,
+        restPassRechargeProgress: 0,
+        lastRestPassDate: '',
+        lastHabitEvent: null,
         coins: ECONOMY.INITIAL_COINS,
         targetGrade: 1,
         townMap: map,
@@ -398,6 +404,7 @@ const StorageAPI = {
       if (!stats[field]) stats[field] = defaultVal;
     }
     if (stats.coins === undefined) stats.coins = 0;
+    Object.assign(stats, normalizeHabitState(stats));
 
     // ── 20×20 → 50×50 マイグレーション ──
     if (!stats.mapSize || stats.mapSize < MAP.GRID_SIZE) {
@@ -500,6 +507,8 @@ const StorageAPI = {
     const todayStr = getTodayString();
     if (!stats.lastDate || stats.lastDate === todayStr) return false;
     if (stats.lastNeglectAppliedDate === todayStr) return false;
+    // 1日だけの休息はおやすみパスの対象。実際に学習した時点でパスを消費する。
+    if (canProtectRestDay(stats, todayStr)) return false;
 
     const last = new Date(`${stats.lastDate}T00:00:00`);
     const today = new Date(`${todayStr}T00:00:00`);
@@ -626,17 +635,9 @@ const StorageAPI = {
       }
     }
 
-    // ストリーク更新
+    // ストリーク更新（1日の休息はおやすみパスで自動保護）
     if (hasLearningActivity && stats.lastDate !== today) {
-      if (stats.lastDate) {
-        const yesterday = new Date();
-        yesterday.setDate(yesterday.getDate() - 1);
-        const yesterdayStr = formatDate(yesterday);
-        stats.streak = stats.lastDate === yesterdayStr ? stats.streak + 1 : 1;
-      } else {
-        stats.streak = 1;
-      }
-      stats.lastDate = today;
+      Object.assign(stats, applyLearningDayHabit(stats, today));
       stats.lastNeglectAppliedDate = today;
     }
 

--- a/test/habit.test.js
+++ b/test/habit.test.js
@@ -1,0 +1,104 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  applyLearningDayHabit,
+  canProtectRestDay,
+  getDayDifference,
+  getHabitStatus,
+  normalizeHabitState,
+  REST_PASS_RECHARGE_DAYS,
+} from '../src/systems/habit.js';
+
+test('旧保存データには使用可能なおやすみパスを安全に補完する', () => {
+  assert.deepEqual(normalizeHabitState({}), {
+    restPassAvailable: true,
+    restPassRechargeProgress: 0,
+    lastRestPassDate: '',
+    lastHabitEvent: null,
+  });
+  assert.equal(getHabitStatus({}, '2026-07-21').rechargeRemaining, 0);
+  assert.equal(normalizeHabitState({ lastHabitEvent: { type: 'unknown', date: '2026-07-21' } }).lastHabitEvent, null);
+});
+
+test('ローカル日付キーの日数差を夏時間の影響なく判定する', () => {
+  assert.equal(getDayDifference('2026-03-07', '2026-03-09'), 2);
+  assert.equal(getDayDifference('2026-02-28', '2026-03-01'), 1);
+  assert.equal(getDayDifference('invalid', '2026-03-01'), null);
+});
+
+test('1日の休息はパスを自動使用して連続記録を守る', () => {
+  const before = { lastDate: '2026-07-19', streak: 8, restPassAvailable: true };
+  assert.equal(canProtectRestDay(before, '2026-07-21'), true);
+
+  const next = applyLearningDayHabit(before, '2026-07-21');
+  assert.equal(next.streak, 9);
+  assert.equal(next.restPassAvailable, false);
+  assert.equal(next.restPassRechargeProgress, 1);
+  assert.equal(next.lastRestPassDate, '2026-07-20');
+  assert.deepEqual(next.lastHabitEvent, {
+    type: 'rest_protected',
+    date: '2026-07-21',
+    restDate: '2026-07-20',
+  });
+});
+
+test('2日以上の休みではパスを消費せず連続記録を再開する', () => {
+  const next = applyLearningDayHabit({
+    lastDate: '2026-07-18',
+    streak: 8,
+    restPassAvailable: true,
+  }, '2026-07-21');
+
+  assert.equal(next.streak, 1);
+  assert.equal(next.restPassAvailable, true);
+  assert.equal(next.lastHabitEvent, null);
+});
+
+test('同じ日の追加学習ではパスと再獲得進捗を重複更新しない', () => {
+  const current = {
+    lastDate: '2026-07-21',
+    streak: 9,
+    restPassAvailable: false,
+    restPassRechargeProgress: 1,
+    lastRestPassDate: '2026-07-20',
+    lastHabitEvent: { type: 'rest_protected', date: '2026-07-21' },
+  };
+  const next = applyLearningDayHabit(current, '2026-07-21');
+
+  assert.equal(next.streak, 9);
+  assert.equal(next.restPassAvailable, false);
+  assert.equal(next.restPassRechargeProgress, 1);
+});
+
+test('パスがない状態で休むと連続記録を1日目から再開する', () => {
+  const next = applyLearningDayHabit({
+    lastDate: '2026-07-19',
+    streak: 9,
+    restPassAvailable: false,
+    restPassRechargeProgress: 2,
+  }, '2026-07-21');
+
+  assert.equal(next.streak, 1);
+  assert.equal(next.restPassAvailable, false);
+  assert.equal(next.restPassRechargeProgress, 3);
+});
+
+test('パス使用後は合計5日の学習で再獲得する', () => {
+  let stats = {
+    lastDate: '2026-07-21',
+    streak: 9,
+    restPassAvailable: false,
+    restPassRechargeProgress: 1,
+  };
+
+  for (let day = 22; day <= 25; day++) {
+    const today = `2026-07-${day}`;
+    stats = { ...stats, ...applyLearningDayHabit(stats, today) };
+  }
+
+  assert.equal(stats.restPassAvailable, true);
+  assert.equal(stats.restPassRechargeProgress, 0);
+  assert.equal(stats.streak, 13);
+  assert.equal(stats.lastHabitEvent.type, 'rest_pass_recharged');
+  assert.equal(REST_PASS_RECHARGE_DAYS, 5);
+});


### PR DESCRIPTION
## 概要

ロードマップ第4段階「学習習慣の強化」として、1日だけ休んでも学習の連続記録と街を守れる「おやすみパス」を追加します。児童が休息への不安を抱えず、無理のないリズムで学習を続けられる設計です。

## 主な変更

- 旧ユーザー・新規ユーザーへ使用可能なおやすみパスを1枚付与
- 直前の学習から1日だけ空いた次回学習時にパスを自動使用
- パス使用時はストリークを維持し、休息日に街の放置ペナルティを適用しない
- パス使用日を含む5学習日で自動再獲得
- 同じ日の複数セッションではパス・再獲得進捗を重複更新しない
- ホームで使用可能状態／再獲得までの日数／当日の保護予定を表示
- 学習結果でパス使用・再獲得を通知
- 学習記録画面でも現在のパス状態を確認可能

## 設計上のポイント

- パスを使うための操作は不要で、1日の休息だけを自動保護
- 2日以上休んだ場合、またはパスがない場合は従来どおり連続記録を1日目から再開
- 休息日そのものを連続日数へ加算せず、実際に学習した日数だけを数える
- 日付計算はUTCの日付キーで行い、夏時間や月末・年末をまたぐ場合も安定
- 既存保存データへ後方互換でフィールドを補完し、スキーマ破壊なし

## 確認

- `npm test` — 34件成功
- `npm run build` — 成功
- バンドル容量制限 — 成功
- `git diff --check` — 成功