### PR TITLE
アカウントと安全なクラウド同期を追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=your-publishable-anon-key

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,9 @@ jobs:
       - run: npm ci
       - run: npm test
       - run: npm run build
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
       - uses: actions/upload-pages-artifact@v3
         if: github.event_name == 'push'
         with:

--- a/docs/cloud-sync-setup.md
+++ b/docs/cloud-sync-setup.md
@@ -1,0 +1,41 @@
+# アカウント・クラウド同期の設定
+
+漢字タウンはSupabase AuthとPostgresを使って、利用者本人の学習データだけを端末間で同期します。環境変数がないビルドではクラウド機能だけが無効になり、従来のローカル保存はそのまま利用できます。
+
+## 1. Supabaseプロジェクト
+
+1. Supabaseでプロジェクトを作成します。
+2. SQL Editorで `supabase/migrations/202607210001_cloud_sync.sql` を実行します。
+3. AuthenticationのEmail providerを有効にします。
+4. URL Configurationへ本番URLとローカル開発URLを登録します。
+   - `https://gigayama.github.io/KANJI_Town/`
+   - `http://localhost:5173/KANJI_Town/`
+
+SQLにはRLSポリシーが含まれ、未認証利用者を拒否し、認証済み利用者も自分の1行だけを読み書きできます。ブラウザへservice role keyを設定してはいけません。
+
+## 2. ローカル開発
+
+`.env.example` を参考に `.env.local` を作成し、SupabaseのProject URLとpublishable/anon keyを設定します。
+
+```env
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=your-publishable-anon-key
+```
+
+## 3. GitHub Pages
+
+リポジトリのSettings → Secrets and variables → Actionsへ次のRepository secretsを登録します。
+
+- `VITE_SUPABASE_URL`
+- `VITE_SUPABASE_ANON_KEY`
+
+どちらもフロントエンド用の公開設定です。データ保護はキーの秘匿ではなく、認証トークンとRLSで行います。
+
+## 4. 同期動作
+
+- ログイン後、クラウドが空なら現在の端末データを初回保存します。
+- 新しい端末が未学習状態ならクラウドデータを自動復元します。
+- 一方だけが更新されていれば新しい側を自動採用します。
+- 両方が更新されている場合は自動上書きせず、設定画面で「この端末」または「クラウド」を選択します。
+- 共有端末で別のアカウントへ切り替えた場合、以前の利用者のデータは自動送信せず、明示的な選択を求めます。
+- 更新はrevisionによる楽観ロックで、同時更新を検知します。

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "kanji-town",
       "version": "0.1.0",
       "dependencies": {
+        "@supabase/supabase-js": "^2.110.7",
         "framer-motion": "^12.36.0",
         "lucide-react": "^0.577.0",
         "react": "^19.2.4",
@@ -1151,6 +1152,90 @@
         "win32"
       ]
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.110.7",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.110.7.tgz",
+      "integrity": "sha512-M5Bpl4hCv6kHcOO/xM06Dyfg1mYLHljMkp1plhzG9IRZPc3czvyMsSN1XpL5+GKisOKM3lSN59zhpcm6sMVXfA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.110.7",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.110.7.tgz",
+      "integrity": "sha512-megYmexlYEoR/0qlsr4Snh9wtzAodO7MAri3NMevZrXzNvQRKlvmTcSBoKGLQEPDakgDZMqbMdf9DwoZz6qfoA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.5.tgz",
+      "integrity": "sha512-aAn9H9ovVyeApKy11OWOrrOGq8DV68yWeH4ud2lN9fzn4aO8Zb5GLL9m1pUg9nLqIcT+ZDfAcsZe0E/nqdv2lw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.110.7",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.110.7.tgz",
+      "integrity": "sha512-ban6YV0djhVaqVYezlOARKLIuOBSvLLhyQVZjA2nxPrtswhxHCl1+gI4giFgI9ATQAaMNbUZb4JXiuL5lEA/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.110.7",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.110.7.tgz",
+      "integrity": "sha512-AMtZjyFA2gsmjuxopPNS/sRznLQHG0Ht5x+ytTPTOh3vAcOTUlVRLx7gW4/CONNnbb3PKOkE+HmM35HOSbmomQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "0.4.5",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.110.7",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.110.7.tgz",
+      "integrity": "sha512-2tcDE8cjEDy1uKxKavBpKQod1JdMV1jDXQag48TCa+kycmJOltc0yVabC0BUlhOwAl6WykXU2aOsH3ELMtZrmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.110.7",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.110.7.tgz",
+      "integrity": "sha512-AnfO3A230Shy6RMO7cya3Wl1OcXnABJrzH8vP+fY7/RFjhzcchB7DjKkkTIAntlwekD+GkSFzEvt2tC+D4Fp8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.110.7",
+        "@supabase/functions-js": "2.110.7",
+        "@supabase/postgrest-js": "2.110.7",
+        "@supabase/realtime-js": "2.110.7",
+        "@supabase/storage-js": "2.110.7"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.1.tgz",
@@ -1748,6 +1833,15 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/jiti": {
       "version": "2.6.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "node --test"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.110.7",
     "framer-motion": "^12.36.0",
     "lucide-react": "^0.577.0",
     "react": "^19.2.4",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import { PenTool, Volume2, VolumeX, Settings, Users } from 'lucide-react';
 import { useOnlineStatus } from './hooks/useOnlineStatus';
 import { useIsMobile } from './hooks/useIsMobile';
 import { usePrefetchKanji } from './hooks/usePrefetchKanji';
+import { useCloudSync } from './hooks/useCloudSync';
 import OfflineBanner from './components/ui/OfflineBanner';
 import StorageErrorBanner from './components/ui/StorageErrorBanner';
 import MobileBottomNav from './components/ui/MobileBottomNav';
@@ -152,6 +153,10 @@ export default function App() {
   const [view, setView] = useState(connectParam ? 'peerClient' : initialAppState.restoredSession ? 'session' : 'home');
   const [isMuted, setIsMuted] = useState(audioCtrl.muted);
   const [stats, setStats] = useState(initialAppState.loadedStats);
+  const cloudSync = useCloudSync({ stats, setStats });
+  useEffect(() => {
+    if (cloudSync.needsPasswordReset) setView('settings');
+  }, [cloudSync.needsPasswordReset]);
   const [sessionData, setSessionDataState] = useState(() => createInitialSessionData(initialAppState.restoredSession || {}));
   const sessionDataRef = useRef(sessionData);
   const setSessionData = useCallback((update) => {
@@ -826,7 +831,7 @@ export default function App() {
               }} /></ErrorBoundary></PageWrapper>}
           {view === 'achievements' && <PageWrapper key="achievements"><ErrorBoundary onReset={() => setView('home')}><FeatureHint featureKey="achievements" seenHints={seenHints} onDismiss={handleDismissHint} /><AchievementView setView={setView} stats={stats} setStats={setStats} /></ErrorBoundary></PageWrapper>}
           {view === 'stats' && <PageWrapper key="stats"><ErrorBoundary onReset={() => setView('home')}><FeatureHint featureKey="stats" seenHints={seenHints} onDismiss={handleDismissHint} /><StatsView setView={setView} stats={stats} startWeakSession={startWeakSession} /></ErrorBoundary></PageWrapper>}
-          {view === 'settings' && <PageWrapper key="settings"><ErrorBoundary onReset={() => setView('home')}><SettingsView setView={setView} stats={stats} setStats={setStats} isMuted={isMuted} setIsMuted={setIsMuted} levelInfo={levelInfo} /></ErrorBoundary></PageWrapper>}
+          {view === 'settings' && <PageWrapper key="settings"><ErrorBoundary onReset={() => setView('home')}><SettingsView setView={setView} stats={stats} setStats={setStats} isMuted={isMuted} setIsMuted={setIsMuted} levelInfo={levelInfo} cloudSync={cloudSync} /></ErrorBoundary></PageWrapper>}
           {view === 'myDrills' && <PageWrapper key="myDrills"><ErrorBoundary onReset={() => setView('home')}><MyDrillsView setView={setView} stats={stats} setStats={setStats} startDrillSession={startDrillSession} startDrillTest={startDrillTest} setHostDrill={setHostDrill} /></ErrorBoundary></PageWrapper>}
           {view === 'drillEditor' && <PageWrapper key="drillEditor" wide><ErrorBoundary onReset={() => setView('home')}><DrillEditorView setView={setView} stats={stats} setStats={setStats} /></ErrorBoundary></PageWrapper>}
           {view === 'peerHost' && <PageWrapper key="peerHost"><ErrorBoundary onReset={() => setView('home')}><TeacherHostView setView={setView} drill={hostDrill} /></ErrorBoundary></PageWrapper>}

--- a/src/components/pages/SettingsView.jsx
+++ b/src/components/pages/SettingsView.jsx
@@ -1,12 +1,13 @@
 import React, { useState, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { ArrowLeft, Volume2, VolumeX, Palette, GraduationCap, Database, Download, Upload, Trash2, RotateCcw, Sun, Moon, Sparkles, ChevronRight, AlertTriangle, Check, X, Accessibility } from 'lucide-react';
+import { ArrowLeft, Volume2, VolumeX, Palette, GraduationCap, Database, Download, Upload, Trash2, RotateCcw, Sun, Moon, Sparkles, ChevronRight, AlertTriangle, Check, X, Accessibility, Cloud } from 'lucide-react';
 import { MotionButton } from '../ui';
 import { StorageAPI } from '../../systems/storage';
 import { audioCtrl } from '../../systems/audio';
 import { F } from '../ui/FormatKun';
 import { DAILY_GOAL_OPTIONS, getDailyGoal } from '../../systems/learning-plan';
 import { getMotionPreference } from '../../utils/motion-preference';
+import AccountSyncPanel from '../settings/AccountSyncPanel';
 
 // 手動テーマ選択肢
 const THEME_OPTIONS = [
@@ -65,7 +66,7 @@ const Section = ({ icon: Icon, title, children }) => (
   </div>
 );
 
-const SettingsView = ({ setView, stats, setStats, isMuted, setIsMuted, levelInfo }) => {
+const SettingsView = ({ setView, stats, setStats, isMuted, setIsMuted, levelInfo, cloudSync }) => {
   const [confirm, setConfirm] = useState(null);
   const [toast, setToast] = useState(null);
   const fileInputRef = useRef(null);
@@ -169,6 +170,7 @@ const SettingsView = ({ setView, stats, setStats, isMuted, setIsMuted, levelInfo
         window.localStorage.removeItem('kanji_town_v7');
         window.localStorage.removeItem('kanji_mega_builder_final_v6');
         window.localStorage.removeItem('kanji_mega_builder_final_v5');
+        window.localStorage.removeItem('kanji_town_cloud_owner_v1');
         setStats(StorageAPI.getStats());
         setConfirm(null);
         showToast('データをリセットしました');
@@ -318,6 +320,11 @@ const SettingsView = ({ setView, stats, setStats, isMuted, setIsMuted, levelInfo
             </div>
           </div>
         </div>
+      </Section>
+
+      {/* アカウント・クラウド同期 */}
+      <Section icon={Cloud} title="アカウント・クラウド同期">
+        <AccountSyncPanel cloudSync={cloudSync} />
       </Section>
 
       {/* データ管理 */}

--- a/src/components/settings/AccountSyncPanel.jsx
+++ b/src/components/settings/AccountSyncPanel.jsx
@@ -1,0 +1,218 @@
+import React, { useMemo, useState } from 'react';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Cloud,
+  CloudOff,
+  LoaderCircle,
+  LogIn,
+  LogOut,
+  RefreshCw,
+  ShieldCheck,
+} from 'lucide-react';
+import MotionButton from '../ui/MotionButton';
+
+const STATUS_LABELS = {
+  initializing: '接続を確認中',
+  authenticating: '認証中',
+  pending: '保存待ち',
+  syncing: '同期中',
+  synced: '同期済み',
+  conflict: '確認が必要',
+  error: '再試行します',
+};
+
+const formatSyncTime = (value) => {
+  if (!value) return 'まだ同期していません';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '同期時刻を確認できません';
+  return new Intl.DateTimeFormat('ja-JP', {
+    month: 'numeric', day: 'numeric', hour: '2-digit', minute: '2-digit',
+  }).format(date);
+};
+
+const DataSummary = ({ label, value, tone }) => (
+  <div className={`rounded-xl border-2 p-3 ${tone}`}>
+    <div className="mb-2 text-center text-xs font-black text-[var(--text)]">{label}</div>
+    <div className="grid grid-cols-2 gap-1 text-[10px] font-bold text-[var(--text)]">
+      <span>学習漢字</span><strong className="text-right">{value?.learned || 0}字</strong>
+      <span>EXP</span><strong className="text-right">{(value?.totalExp || 0).toLocaleString()}</strong>
+      <span>連続</span><strong className="text-right">{value?.streak || 0}日</strong>
+      <span>学習回数</span><strong className="text-right">{value?.sessions || 0}回</strong>
+    </div>
+  </div>
+);
+
+const AccountSyncPanel = ({ cloudSync }) => {
+  const [mode, setMode] = useState('signin');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [passwordConfirm, setPasswordConfirm] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [validationError, setValidationError] = useState(null);
+  const [confirmChoice, setConfirmChoice] = useState(null);
+
+  const busy = cloudSync.status === 'authenticating' || cloudSync.status === 'syncing';
+  const statusLabel = STATUS_LABELS[cloudSync.status] || '端末に保存中';
+  const isSignedIn = Boolean(cloudSync.user);
+  const isAccountSwitch = cloudSync.conflict?.reason === 'account_switch';
+  const emailValid = useMemo(() => /^\S+@\S+\.\S+$/.test(email.trim()), [email]);
+
+  const handleAuth = async (event) => {
+    event.preventDefault();
+    setValidationError(null);
+    cloudSync.clearMessage();
+    if (!emailValid) {
+      setValidationError('メールアドレスを確認してください。');
+      return;
+    }
+    if (password.length < 8) {
+      setValidationError('パスワードは8文字以上で入力してください。');
+      return;
+    }
+    if (mode === 'signup' && password !== passwordConfirm) {
+      setValidationError('確認用パスワードが一致しません。');
+      return;
+    }
+    try {
+      if (mode === 'signup') await cloudSync.signUp({ email, password });
+      else await cloudSync.signIn({ email, password });
+    } catch {}
+  };
+
+  const handleReset = async () => {
+    setValidationError(null);
+    if (!emailValid) {
+      setValidationError('再設定メールを送るメールアドレスを入力してください。');
+      return;
+    }
+    try { await cloudSync.requestPasswordReset(email); } catch {}
+  };
+
+  const handleNewPassword = async (event) => {
+    event.preventDefault();
+    if (newPassword.length < 8) {
+      setValidationError('新しいパスワードは8文字以上で入力してください。');
+      return;
+    }
+    try {
+      await cloudSync.updatePassword(newPassword);
+      setNewPassword('');
+    } catch {}
+  };
+
+  const chooseConflict = (choice) => {
+    if (confirmChoice !== choice) {
+      setConfirmChoice(choice);
+      return;
+    }
+    setConfirmChoice(null);
+    cloudSync.resolveConflict(choice);
+  };
+
+  if (!cloudSync.isConfigured) {
+    return (
+      <div className="rounded-xl border-2 border-slate-200 bg-slate-50 p-3">
+        <div className="flex items-center gap-2 text-sm font-black text-slate-600"><CloudOff size={18} /> クラウド同期は準備中です</div>
+        <p className="mt-1 text-[11px] font-bold leading-relaxed text-slate-500">学習データはこれまでどおり、この端末へ安全に保存されます。</p>
+      </div>
+    );
+  }
+
+  if (cloudSync.status === 'initializing') {
+    return <div className="flex min-h-24 items-center justify-center gap-2 text-sm font-bold text-[var(--text)] opacity-60"><LoaderCircle className="animate-spin" size={20} /> アカウントを確認しています…</div>;
+  }
+
+  if (!isSignedIn) {
+    return (
+      <form onSubmit={handleAuth} className="flex flex-col gap-3">
+        <div className="grid grid-cols-2 gap-2 rounded-xl bg-[var(--bg)] p-1" role="tablist" aria-label="アカウント操作">
+          <button type="button" role="tab" aria-selected={mode === 'signin'} onClick={() => setMode('signin')} className={`min-h-11 rounded-lg text-xs font-black ${mode === 'signin' ? 'bg-[var(--panel)] shadow-sm border-2 border-[var(--secondary)]' : 'opacity-55'}`}>ログイン</button>
+          <button type="button" role="tab" aria-selected={mode === 'signup'} onClick={() => setMode('signup')} className={`min-h-11 rounded-lg text-xs font-black ${mode === 'signup' ? 'bg-[var(--panel)] shadow-sm border-2 border-[var(--secondary)]' : 'opacity-55'}`}>新しく作る</button>
+        </div>
+        <label className="text-xs font-black text-[var(--text)]">
+          メールアドレス
+          <input type="email" value={email} onChange={(event) => setEmail(event.target.value)} autoComplete="email" inputMode="email" className="mt-1 min-h-11 w-full rounded-xl border-[3px] border-[var(--text)] bg-[var(--bg)] px-3 text-sm outline-none focus:ring-2 focus:ring-[var(--secondary)]" placeholder="name@example.com" />
+        </label>
+        <label className="text-xs font-black text-[var(--text)]">
+          パスワード
+          <input type="password" value={password} onChange={(event) => setPassword(event.target.value)} autoComplete={mode === 'signup' ? 'new-password' : 'current-password'} minLength={8} className="mt-1 min-h-11 w-full rounded-xl border-[3px] border-[var(--text)] bg-[var(--bg)] px-3 text-sm outline-none focus:ring-2 focus:ring-[var(--secondary)]" placeholder="8文字以上" />
+        </label>
+        {mode === 'signup' && (
+          <label className="text-xs font-black text-[var(--text)]">
+            パスワード（確認）
+            <input type="password" value={passwordConfirm} onChange={(event) => setPasswordConfirm(event.target.value)} autoComplete="new-password" minLength={8} className="mt-1 min-h-11 w-full rounded-xl border-[3px] border-[var(--text)] bg-[var(--bg)] px-3 text-sm outline-none focus:ring-2 focus:ring-[var(--secondary)]" placeholder="もう一度入力" />
+          </label>
+        )}
+        {(validationError || cloudSync.error) && <div role="alert" className="rounded-lg bg-rose-50 px-3 py-2 text-xs font-bold text-rose-700">{validationError || cloudSync.error}</div>}
+        {cloudSync.notice && <div role="status" className="rounded-lg bg-sky-50 px-3 py-2 text-xs font-bold text-sky-700">{cloudSync.notice}</div>}
+        <MotionButton type="submit" variant="primary" disabled={busy} className="min-h-12 border-[3px] border-[var(--text)] text-sm shadow-sm">
+          {busy ? <LoaderCircle className="animate-spin" size={18} /> : <LogIn size={18} />}
+          {mode === 'signup' ? 'アカウントを作る' : 'ログインして同期'}
+        </MotionButton>
+        {mode === 'signin' && <button type="button" onClick={handleReset} className="min-h-11 text-xs font-bold text-sky-700 underline underline-offset-2">パスワードを忘れたとき</button>}
+        <div className="flex items-start gap-2 rounded-xl border-2 border-sky-100 bg-sky-50 p-2.5 text-[10px] font-bold leading-relaxed text-sky-800">
+          <ShieldCheck size={16} className="mt-0.5 shrink-0" />
+          児童が使う場合は、保護者または学校が管理できるメールアドレスを使用してください。学習データは本人のアカウントだけがアクセスできます。
+        </div>
+      </form>
+    );
+  }
+
+  if (cloudSync.needsPasswordReset) {
+    return (
+      <form onSubmit={handleNewPassword} className="flex flex-col gap-3">
+        <div className="text-sm font-black text-[var(--text)]">新しいパスワードを設定</div>
+        <input type="password" value={newPassword} onChange={(event) => setNewPassword(event.target.value)} autoComplete="new-password" minLength={8} className="min-h-11 w-full rounded-xl border-[3px] border-[var(--text)] bg-[var(--bg)] px-3 text-sm" placeholder="8文字以上" />
+        {(validationError || cloudSync.error) && <div role="alert" className="text-xs font-bold text-rose-700">{validationError || cloudSync.error}</div>}
+        <MotionButton type="submit" variant="primary" className="min-h-12 border-[3px] border-[var(--text)]">パスワードを更新</MotionButton>
+      </form>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between gap-3 rounded-xl border-2 border-emerald-200 bg-emerald-50 p-3">
+        <div className="min-w-0">
+          <div className="truncate text-sm font-black text-emerald-800">{cloudSync.user.email}</div>
+          <div className="mt-0.5 text-[10px] font-bold text-emerald-700">{formatSyncTime(cloudSync.lastSyncedAt)}</div>
+        </div>
+        <div className={`flex shrink-0 items-center gap-1 rounded-full px-2.5 py-1 text-[10px] font-black ${cloudSync.status === 'conflict' || cloudSync.status === 'error' ? 'bg-amber-100 text-amber-800' : 'bg-white text-emerald-700'}`}>
+          {cloudSync.status === 'syncing' ? <LoaderCircle className="animate-spin" size={13} /> : cloudSync.status === 'synced' ? <CheckCircle2 size={13} /> : <Cloud size={13} />}
+          {statusLabel}
+        </div>
+      </div>
+
+      {cloudSync.conflict && (
+        <div className="rounded-xl border-[3px] border-amber-400 bg-amber-50 p-3" role="alert">
+          <div className="mb-1 flex items-center gap-2 text-sm font-black text-amber-900"><AlertTriangle size={18} /> {isAccountSwitch ? '別のアカウントの端末データです' : '2つの学習データがあります'}</div>
+          <p className="mb-3 text-[10px] font-bold leading-relaxed text-amber-800">
+            {isAccountSwitch
+              ? '共有端末で以前使われたデータを自動送信しないため停止しました。今のアカウントで残したい方を選んでください。'
+              : '両方の端末で変更されました。残したい方を選んでください。選ばなかった方の変更は置き換わります。'}
+          </p>
+          <div className="mb-3 grid grid-cols-2 gap-2">
+            <DataSummary label={isAccountSwitch ? '以前の端末データ' : 'この端末'} value={cloudSync.conflict.local} tone="border-sky-200 bg-sky-50" />
+            <DataSummary label="クラウド" value={cloudSync.conflict.cloud} tone="border-violet-200 bg-violet-50" />
+          </div>
+          <div className="grid grid-cols-2 gap-2">
+            <button type="button" disabled={busy} onClick={() => chooseConflict('local')} className="min-h-12 rounded-xl border-[3px] border-sky-500 bg-white px-2 text-xs font-black text-sky-800">{confirmChoice === 'local' ? 'もう一度押して確定' : isAccountSwitch ? '端末データを引き継ぐ' : 'この端末を残す'}</button>
+            <button type="button" disabled={busy || !cloudSync.conflict.cloudExists} onClick={() => chooseConflict('cloud')} className="min-h-12 rounded-xl border-[3px] border-violet-500 bg-white px-2 text-xs font-black text-violet-800 disabled:cursor-not-allowed disabled:opacity-45">{!cloudSync.conflict.cloudExists ? 'クラウドデータなし' : confirmChoice === 'cloud' ? 'もう一度押して確定' : 'クラウドを使う'}</button>
+          </div>
+          {isAccountSwitch && !cloudSync.conflict.cloudExists && <p className="mt-2 text-[10px] font-bold leading-relaxed text-amber-800">新しく始める場合は、下の「データを全て消す」で端末を初期化してから「端末データを引き継ぐ」を選びます。</p>}
+        </div>
+      )}
+
+      {cloudSync.error && <div role="alert" className="rounded-lg bg-rose-50 px-3 py-2 text-xs font-bold text-rose-700">{cloudSync.error}</div>}
+      {cloudSync.notice && <div role="status" className="rounded-lg bg-sky-50 px-3 py-2 text-xs font-bold text-sky-700">{cloudSync.notice}</div>}
+
+      <div className="grid grid-cols-2 gap-2">
+        <MotionButton variant="secondary" disabled={busy || cloudSync.status === 'conflict'} onClick={() => cloudSync.syncNow()} className="min-h-12 border-[3px] border-[var(--text)] text-xs shadow-sm"><RefreshCw size={16} className={busy ? 'animate-spin' : ''} /> 今すぐ同期</MotionButton>
+        <MotionButton variant="secondary" disabled={busy} onClick={cloudSync.signOut} className="min-h-12 border-[3px] border-[var(--text)] text-xs shadow-sm"><LogOut size={16} /> ログアウト</MotionButton>
+      </div>
+      <p className="text-[10px] font-bold leading-relaxed text-[var(--text)] opacity-50">変更は端末へ先に保存され、通信できるときにクラウドへ同期されます。オフラインでも学習できます。</p>
+    </div>
+  );
+};
+
+export default AccountSyncPanel;

--- a/src/hooks/useCloudSync.js
+++ b/src/hooks/useCloudSync.js
@@ -1,0 +1,430 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  createCloudSave,
+  fetchCloudSave,
+  getAuthRedirectUrl,
+  getCloudClient,
+  getCloudConfiguration,
+  updateCloudSave,
+} from '../systems/cloud-client';
+import {
+  CLOUD_SAVE_VERSION,
+  createSyncMeta,
+  decideSyncAction,
+  hashCloudPayload,
+  isEmptyLearningData,
+  prepareCloudPayload,
+  summarizeCloudData,
+} from '../systems/cloud-sync';
+import { StorageAPI } from '../systems/storage';
+
+const META_KEY_PREFIX = 'kanji_town_cloud_meta_v1:';
+const LOCAL_OWNER_KEY = 'kanji_town_cloud_owner_v1';
+const AUTO_SYNC_DELAY_MS = 1800;
+
+function readMeta(userId) {
+  try {
+    const value = window.localStorage.getItem(`${META_KEY_PREFIX}${userId}`);
+    return value ? JSON.parse(value) : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeMeta(userId, meta) {
+  try {
+    window.localStorage.setItem(`${META_KEY_PREFIX}${userId}`, JSON.stringify(meta));
+  } catch {}
+}
+
+function readLocalOwner() {
+  try {
+    return window.localStorage.getItem(LOCAL_OWNER_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function writeLocalOwner(userId) {
+  try {
+    window.localStorage.setItem(LOCAL_OWNER_KEY, userId);
+  } catch {}
+}
+
+function friendlyError(error) {
+  const code = String(error?.code || '').toLowerCase();
+  const message = String(error?.message || '').toLowerCase();
+  if (code === 'newer_cloud_schema') return 'クラウドデータが新しい形式です。アプリを最新版に更新してください。';
+  if (code === 'local_save_failed') return 'この端末の保存容量が不足しています。クラウドのデータは変更していません。';
+  if (code === 'invalid_credentials' || message.includes('invalid login credentials')) {
+    return 'メールアドレスまたはパスワードを確認してください。';
+  }
+  if (message.includes('email not confirmed')) return '確認メールのリンクを開いてからログインしてください。';
+  if (message.includes('user already registered')) return 'このメールアドレスは登録済みです。';
+  if (message.includes('rate limit')) return '短時間に操作が集中しました。少し待ってからお試しください。';
+  if (message.includes('password')) return 'パスワードは8文字以上で設定してください。';
+  if (message.includes('fetch') || message.includes('network')) return '通信できませんでした。接続後に自動で再試行します。';
+  if (code === '23505') return '別の端末で同期が始まりました。もう一度お試しください。';
+  return 'クラウド同期を完了できませんでした。端末のデータは安全に残っています。';
+}
+
+const initialState = (configured) => ({
+  status: configured ? 'initializing' : 'unavailable',
+  user: null,
+  error: null,
+  notice: null,
+  conflict: null,
+  lastSyncedAt: null,
+  needsPasswordReset: false,
+});
+
+export function useCloudSync({ stats, setStats }) {
+  const configuration = getCloudConfiguration();
+  const [state, setState] = useState(() => initialState(configuration.isConfigured));
+  const mountedRef = useRef(true);
+  const statsRef = useRef(stats);
+  const userRef = useRef(null);
+  const metaRef = useRef(null);
+  const conflictRemoteRef = useRef(null);
+  const syncPromiseRef = useRef(null);
+  const autoSyncTimerRef = useRef(null);
+
+  statsRef.current = stats;
+
+  const patchState = useCallback((patch) => {
+    if (!mountedRef.current) return;
+    setState((current) => ({ ...current, ...patch }));
+  }, []);
+
+  const rememberRemote = useCallback((userId, remote) => {
+    const meta = createSyncMeta(remote);
+    metaRef.current = meta;
+    conflictRemoteRef.current = null;
+    writeMeta(userId, meta);
+    writeLocalOwner(userId);
+    patchState({
+      status: 'synced',
+      error: null,
+      conflict: null,
+      lastSyncedAt: meta.lastSyncedAt,
+    });
+  }, [patchState]);
+
+  const applyRemote = useCallback((userId, remote) => {
+    if (!remote?.payload || typeof remote.payload !== 'object' || Array.isArray(remote.payload)) {
+      throw new Error('invalid_cloud_payload');
+    }
+    if ((Number(remote.schema_version) || 0) > CLOUD_SAVE_VERSION) {
+      const error = new Error('newer_cloud_schema');
+      error.code = 'newer_cloud_schema';
+      throw error;
+    }
+
+    // 既存の保存移行・ID検証を必ず通してからReact stateへ反映する。
+    if (!StorageAPI.saveStatsImmediate(remote.payload)) {
+      const error = new Error('local_save_failed');
+      error.code = 'local_save_failed';
+      throw error;
+    }
+    const normalized = StorageAPI.getStats();
+    const meta = createSyncMeta(remote);
+    metaRef.current = meta;
+    conflictRemoteRef.current = null;
+    writeMeta(userId, meta);
+    writeLocalOwner(userId);
+    setStats(normalized);
+    patchState({
+      status: 'synced',
+      error: null,
+      conflict: null,
+      lastSyncedAt: meta.lastSyncedAt,
+      notice: 'クラウドの学習データをこの端末へ復元しました。',
+    });
+  }, [patchState, setStats]);
+
+  const showConflict = useCallback((remote, localStats, reason = 'both_changed') => {
+    conflictRemoteRef.current = remote || { missing: true };
+    patchState({
+      status: 'conflict',
+      error: null,
+      conflict: {
+        local: summarizeCloudData(localStats),
+        cloud: summarizeCloudData(remote?.payload),
+        cloudUpdatedAt: remote?.updated_at || null,
+        cloudExists: Boolean(remote),
+        reason,
+      },
+    });
+  }, [patchState]);
+
+  const performSync = useCallback(async (explicitUser = null) => {
+    const activeUser = explicitUser || userRef.current;
+    if (!configuration.isConfigured || !activeUser) return null;
+    if (syncPromiseRef.current) return syncPromiseRef.current;
+
+    const task = (async () => {
+      patchState({ status: 'syncing', error: null, notice: null });
+      try {
+        const client = await getCloudClient();
+        if (!client) return null;
+        const localStats = statsRef.current;
+        const payload = prepareCloudPayload(localStats);
+        const localHash = await hashCloudPayload(payload);
+        const remote = await fetchCloudSave(client, activeUser.id);
+        // ログアウトや別アカウントへの切替後に、古いリクエスト結果を反映しない。
+        if (userRef.current?.id !== activeUser.id) return null;
+        const localOwner = readLocalOwner();
+        const meta = metaRef.current || readMeta(activeUser.id);
+        metaRef.current = meta;
+        const decision = decideSyncAction({
+          localHash,
+          localIsEmpty: isEmptyLearningData(localStats),
+          remote,
+          meta,
+          localOwnerId: localOwner,
+          userId: activeUser.id,
+        });
+
+        if (decision.action === 'create_remote') {
+          try {
+            const created = await createCloudSave(client, activeUser.id, payload, localHash);
+            if (userRef.current?.id !== activeUser.id) return null;
+            rememberRemote(activeUser.id, created);
+          } catch (error) {
+            if (String(error?.code) !== '23505') throw error;
+            const latest = await fetchCloudSave(client, activeUser.id);
+            if (userRef.current?.id !== activeUser.id) return null;
+            showConflict(latest, localStats);
+          }
+        } else if (decision.action === 'push_local') {
+          const updated = await updateCloudSave(client, activeUser.id, remote.revision, payload, localHash);
+          if (userRef.current?.id !== activeUser.id) return null;
+          if (!updated) {
+            const latest = await fetchCloudSave(client, activeUser.id);
+            if (userRef.current?.id !== activeUser.id) return null;
+            showConflict(latest, localStats);
+          } else {
+            rememberRemote(activeUser.id, updated);
+          }
+        } else if (decision.action === 'pull_remote') {
+          applyRemote(activeUser.id, remote);
+        } else if (decision.action === 'conflict') {
+          showConflict(remote, localStats, decision.reason);
+        } else {
+          rememberRemote(activeUser.id, remote);
+        }
+        return decision.action;
+      } catch (error) {
+        patchState({ status: 'error', error: friendlyError(error) });
+        return null;
+      }
+    })();
+
+    syncPromiseRef.current = task;
+    try {
+      return await task;
+    } finally {
+      syncPromiseRef.current = null;
+    }
+  }, [applyRemote, configuration.isConfigured, patchState, rememberRemote, showConflict]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    if (!configuration.isConfigured) return () => { mountedRef.current = false; };
+
+    let active = true;
+    let unsubscribe = null;
+    getCloudClient().then(async (client) => {
+      if (!client || !active || !mountedRef.current) return;
+      // URL内のPASSWORD_RECOVERYイベントを取りこぼさないよう、session読込より先に監視する。
+      const { data: listener } = client.auth.onAuthStateChange((event, nextSession) => {
+        if (!active || !mountedRef.current) return;
+        const nextUser = nextSession?.user || null;
+        userRef.current = nextUser;
+        metaRef.current = nextUser ? readMeta(nextUser.id) : null;
+        conflictRemoteRef.current = null;
+        patchState({
+          user: nextUser,
+          status: nextUser ? 'pending' : 'signed_out',
+          conflict: null,
+          error: null,
+          lastSyncedAt: metaRef.current?.lastSyncedAt || null,
+          needsPasswordReset: event === 'PASSWORD_RECOVERY',
+        });
+        if (nextUser) setTimeout(() => performSync(nextUser), 0);
+      });
+      unsubscribe = () => listener?.subscription?.unsubscribe();
+
+      const { data } = await client.auth.getSession();
+      if (!active || !mountedRef.current) return;
+      const session = data?.session || null;
+      userRef.current = session?.user || null;
+      metaRef.current = session?.user ? readMeta(session.user.id) : null;
+      patchState({
+        status: session?.user ? 'pending' : 'signed_out',
+        user: session?.user || null,
+        lastSyncedAt: metaRef.current?.lastSyncedAt || null,
+      });
+      if (session?.user) setTimeout(() => performSync(session.user), 0);
+    }).catch((error) => {
+      if (active) patchState({ status: 'error', error: friendlyError(error) });
+    });
+
+    return () => {
+      active = false;
+      mountedRef.current = false;
+      unsubscribe?.();
+      if (autoSyncTimerRef.current) clearTimeout(autoSyncTimerRef.current);
+    };
+  }, [configuration.isConfigured, patchState, performSync]);
+
+  useEffect(() => {
+    if (!configuration.isConfigured || !userRef.current || conflictRemoteRef.current) return undefined;
+    if (autoSyncTimerRef.current) clearTimeout(autoSyncTimerRef.current);
+    patchState({ status: 'pending' });
+    autoSyncTimerRef.current = setTimeout(() => performSync(), AUTO_SYNC_DELAY_MS);
+    return () => clearTimeout(autoSyncTimerRef.current);
+  }, [configuration.isConfigured, performSync, patchState, stats]);
+
+  useEffect(() => {
+    if (!configuration.isConfigured) return undefined;
+    const handleOnline = () => performSync();
+    const handleVisible = () => {
+      if (document.visibilityState === 'visible') performSync();
+    };
+    window.addEventListener('online', handleOnline);
+    document.addEventListener('visibilitychange', handleVisible);
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      document.removeEventListener('visibilitychange', handleVisible);
+    };
+  }, [configuration.isConfigured, performSync]);
+
+  const signIn = useCallback(async ({ email, password }) => {
+    patchState({ status: 'authenticating', error: null, notice: null });
+    try {
+      const client = await getCloudClient();
+      const { error } = await client.auth.signInWithPassword({ email: email.trim(), password });
+      if (error) throw error;
+    } catch (error) {
+      patchState({ status: 'signed_out', error: friendlyError(error) });
+      throw error;
+    }
+  }, [patchState]);
+
+  const signUp = useCallback(async ({ email, password }) => {
+    patchState({ status: 'authenticating', error: null, notice: null });
+    try {
+      const client = await getCloudClient();
+      const { data, error } = await client.auth.signUp({
+        email: email.trim(),
+        password,
+        options: { emailRedirectTo: getAuthRedirectUrl() },
+      });
+      if (error) throw error;
+      if (!data?.session) {
+        patchState({ status: 'signed_out', notice: '確認メールを送りました。リンクを開いて登録を完了してください。' });
+      }
+    } catch (error) {
+      patchState({ status: 'signed_out', error: friendlyError(error) });
+      throw error;
+    }
+  }, [patchState]);
+
+  const signOut = useCallback(async () => {
+    try {
+      const client = await getCloudClient();
+      const { error } = await client.auth.signOut();
+      if (error) throw error;
+      userRef.current = null;
+      metaRef.current = null;
+      conflictRemoteRef.current = null;
+      patchState({ ...initialState(true), status: 'signed_out' });
+    } catch (error) {
+      patchState({ error: friendlyError(error) });
+    }
+  }, [patchState]);
+
+  const requestPasswordReset = useCallback(async (email) => {
+    try {
+      const client = await getCloudClient();
+      const { error } = await client.auth.resetPasswordForEmail(email.trim(), { redirectTo: getAuthRedirectUrl() });
+      if (error) throw error;
+      patchState({ notice: 'パスワード再設定メールを送りました。', error: null });
+    } catch (error) {
+      patchState({ error: friendlyError(error) });
+      throw error;
+    }
+  }, [patchState]);
+
+  const updatePassword = useCallback(async (password) => {
+    try {
+      const client = await getCloudClient();
+      const { error } = await client.auth.updateUser({ password });
+      if (error) throw error;
+      patchState({ needsPasswordReset: false, notice: 'パスワードを更新しました。', error: null });
+    } catch (error) {
+      patchState({ error: friendlyError(error) });
+      throw error;
+    }
+  }, [patchState]);
+
+  const resolveConflict = useCallback(async (choice) => {
+    const activeUser = userRef.current;
+    if (!activeUser) return;
+    patchState({ status: 'syncing', error: null });
+    try {
+      const client = await getCloudClient();
+      const latest = await fetchCloudSave(client, activeUser.id);
+      if (userRef.current?.id !== activeUser.id) return;
+      if (!latest) {
+        if (choice !== 'local') {
+          patchState({ status: 'conflict', error: 'このアカウントにはクラウドデータがありません。' });
+          return;
+        }
+        const localStats = statsRef.current;
+        const payload = prepareCloudPayload(localStats);
+        const hash = await hashCloudPayload(payload);
+        const created = await createCloudSave(client, activeUser.id, payload, hash);
+        if (userRef.current?.id !== activeUser.id) return;
+        rememberRemote(activeUser.id, created);
+        patchState({ notice: 'この端末の学習データを新しいアカウントへ保存しました。' });
+        return;
+      }
+
+      if (choice === 'cloud') {
+        applyRemote(activeUser.id, latest);
+        return;
+      }
+
+      const localStats = statsRef.current;
+      const payload = prepareCloudPayload(localStats);
+      const hash = await hashCloudPayload(payload);
+      const updated = await updateCloudSave(client, activeUser.id, latest.revision, payload, hash);
+      if (userRef.current?.id !== activeUser.id) return;
+      if (!updated) {
+        const newest = await fetchCloudSave(client, activeUser.id);
+        if (userRef.current?.id !== activeUser.id) return;
+        showConflict(newest, localStats);
+        return;
+      }
+      rememberRemote(activeUser.id, updated);
+      patchState({ notice: 'この端末の学習データをクラウドへ保存しました。' });
+    } catch (error) {
+      patchState({ status: 'error', error: friendlyError(error) });
+    }
+  }, [applyRemote, patchState, performSync, rememberRemote, showConflict]);
+
+  return {
+    ...state,
+    isConfigured: configuration.isConfigured,
+    signIn,
+    signUp,
+    signOut,
+    requestPasswordReset,
+    updatePassword,
+    syncNow: performSync,
+    resolveConflict,
+    clearMessage: () => patchState({ error: null, notice: null }),
+  };
+}

--- a/src/systems/cloud-client.js
+++ b/src/systems/cloud-client.js
@@ -1,0 +1,101 @@
+import { CLOUD_SAVE_VERSION } from './cloud-sync.js';
+
+const CLOUD_TABLE = 'kanji_town_saves';
+let clientPromise = null;
+
+const readEnvironment = () => {
+  const environment = import.meta.env || {};
+  return {
+    url: String(environment.VITE_SUPABASE_URL || '').trim(),
+    anonKey: String(environment.VITE_SUPABASE_ANON_KEY || '').trim(),
+  };
+};
+
+export function getCloudConfiguration() {
+  const config = readEnvironment();
+  let validUrl = false;
+  try {
+    validUrl = new URL(config.url).protocol === 'https:';
+  } catch {}
+  return {
+    ...config,
+    isConfigured: validUrl && config.anonKey.length >= 20,
+  };
+}
+
+export async function getCloudClient() {
+  const config = getCloudConfiguration();
+  if (!config.isConfigured) return null;
+  if (!clientPromise) {
+    clientPromise = import('@supabase/supabase-js').then(({ createClient }) => createClient(
+      config.url,
+      config.anonKey,
+      {
+        auth: {
+          persistSession: true,
+          autoRefreshToken: true,
+          detectSessionInUrl: true,
+          flowType: 'pkce',
+        },
+      },
+    ));
+  }
+  return clientPromise;
+}
+
+function throwIfError(error, fallbackMessage) {
+  if (!error) return;
+  const cloudError = new Error(error.message || fallbackMessage);
+  cloudError.code = error.code || error.status || 'cloud_error';
+  throw cloudError;
+}
+
+const SAVE_COLUMNS = 'payload,payload_hash,revision,schema_version,updated_at';
+
+export async function fetchCloudSave(client, userId) {
+  const { data, error } = await client
+    .from(CLOUD_TABLE)
+    .select(SAVE_COLUMNS)
+    .eq('user_id', userId)
+    .maybeSingle();
+  throwIfError(error, 'クラウドデータを読み込めませんでした');
+  return data || null;
+}
+
+export async function createCloudSave(client, userId, payload, payloadHash) {
+  const { data, error } = await client
+    .from(CLOUD_TABLE)
+    .insert({
+      user_id: userId,
+      payload,
+      payload_hash: payloadHash,
+      revision: 1,
+      schema_version: CLOUD_SAVE_VERSION,
+    })
+    .select(SAVE_COLUMNS)
+    .single();
+  throwIfError(error, 'クラウドデータを作成できませんでした');
+  return data;
+}
+
+/** revision一致時だけ更新する楽観ロック。data=nullは他端末との競合を表す。 */
+export async function updateCloudSave(client, userId, expectedRevision, payload, payloadHash) {
+  const { data, error } = await client
+    .from(CLOUD_TABLE)
+    .update({
+      payload,
+      payload_hash: payloadHash,
+      revision: expectedRevision + 1,
+      schema_version: CLOUD_SAVE_VERSION,
+    })
+    .eq('user_id', userId)
+    .eq('revision', expectedRevision)
+    .select(SAVE_COLUMNS)
+    .maybeSingle();
+  throwIfError(error, 'クラウドデータを更新できませんでした');
+  return data || null;
+}
+
+export function getAuthRedirectUrl() {
+  return new URL(import.meta.env?.BASE_URL || '/', window.location.origin).toString();
+}

--- a/src/systems/cloud-sync.js
+++ b/src/systems/cloud-sync.js
@@ -1,0 +1,101 @@
+export const CLOUD_SAVE_VERSION = 1;
+
+const cloneJson = (value) => JSON.parse(JSON.stringify(value ?? {}));
+
+function sortForStableJson(value) {
+  if (Array.isArray(value)) return value.map(sortForStableJson);
+  if (!value || typeof value !== 'object') return value;
+  return Object.fromEntries(
+    Object.keys(value)
+      .sort()
+      .map((key) => [key, sortForStableJson(value[key])]),
+  );
+}
+
+export function prepareCloudPayload(stats) {
+  const payload = cloneJson(stats);
+  // 同期制御情報や直前の一時表示は端末ごとの状態なのでクラウドへ含めない。
+  delete payload.cloudSync;
+  delete payload.lastCollectionResult;
+  return payload;
+}
+
+export function stableSerialize(value) {
+  return JSON.stringify(sortForStableJson(value));
+}
+
+export async function hashCloudPayload(payload) {
+  const serialized = stableSerialize(payload);
+  const bytes = new TextEncoder().encode(serialized);
+  if (globalThis.crypto?.subtle) {
+    const digest = await globalThis.crypto.subtle.digest('SHA-256', bytes);
+    return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('');
+  }
+
+  // 古いWebView向けフォールバック。衝突を抑えるため異なる初期値を2本組み合わせる。
+  const fnv = (seed) => {
+    let hash = seed;
+    for (let i = 0; i < serialized.length; i++) {
+      hash ^= serialized.charCodeAt(i);
+      hash = Math.imul(hash, 0x01000193);
+    }
+    return (hash >>> 0).toString(16).padStart(8, '0');
+  };
+  return `${fnv(0x811c9dc5)}${fnv(0x9e3779b9)}`;
+}
+
+export function isEmptyLearningData(stats = {}) {
+  return (Number(stats.totalExp) || 0) === 0
+    && Object.keys(stats.kanjiStats || {}).length === 0
+    && (Number(stats.sessionCount) || 0) === 0
+    && (Number(stats.population) || 0) === 0
+    && (Number(stats.craftCount) || 0) === 0
+    && Object.keys(stats.daily || {}).length === 0
+    && (stats.myDrills || []).length === 0;
+}
+
+export function summarizeCloudData(stats = {}) {
+  const learned = Object.values(stats.kanjiStats || {}).filter((card) => card?.status !== 'new').length;
+  return {
+    totalExp: Math.max(0, Number(stats.totalExp) || 0),
+    learned,
+    streak: Math.max(0, Number(stats.streak) || 0),
+    sessions: Math.max(0, Number(stats.sessionCount) || 0),
+  };
+}
+
+/**
+ * ローカル・クラウド・最後に同期した版から、データを失わない次の操作を決定する。
+ * 双方が変わった場合は自動上書きせず、必ず利用者へ選択を求める。
+ */
+export function decideSyncAction({ localHash, localIsEmpty, remote, meta, localOwnerId, userId }) {
+  if (localOwnerId && userId && localOwnerId !== userId) {
+    return { action: 'conflict', reason: 'account_switch' };
+  }
+  if (!remote) return { action: 'create_remote', reason: 'cloud_empty' };
+
+  const remoteHash = remote.payload_hash;
+  if (localHash === remoteHash) return { action: 'up_to_date', reason: 'same_content' };
+
+  const lastSyncedHash = meta?.lastSyncedHash || null;
+  if (!lastSyncedHash) {
+    return localIsEmpty
+      ? { action: 'pull_remote', reason: 'new_device' }
+      : { action: 'conflict', reason: 'first_sync_has_both' };
+  }
+
+  const localChanged = localHash !== lastSyncedHash;
+  const remoteChanged = remoteHash !== lastSyncedHash;
+  if (localChanged && remoteChanged) return { action: 'conflict', reason: 'both_changed' };
+  if (remoteChanged) return { action: 'pull_remote', reason: 'cloud_changed' };
+  if (localChanged) return { action: 'push_local', reason: 'local_changed' };
+  return { action: 'up_to_date', reason: 'revision_only' };
+}
+
+export function createSyncMeta(remote, syncedAt = new Date().toISOString()) {
+  return {
+    remoteRevision: Math.max(0, Number(remote?.revision) || 0),
+    lastSyncedHash: typeof remote?.payload_hash === 'string' ? remote.payload_hash : '',
+    lastSyncedAt: syncedAt,
+  };
+}

--- a/src/systems/storage.js
+++ b/src/systems/storage.js
@@ -252,13 +252,14 @@ const StorageAPI = {
   /**
    * 即時保存（セッション終了時など、データロスを防ぐ場面で使用）
    * @param {object} stats
+   * @returns {boolean} 保存成功
    */
   saveStatsImmediate: (stats) => {
     if (_saveDebounceTimer) {
       clearTimeout(_saveDebounceTimer);
       _saveDebounceTimer = null;
     }
-    StorageAPI.safeSet(STORAGE_KEY, stats);
+    return StorageAPI.safeSet(STORAGE_KEY, stats);
   },
 
   /** 学習途中の小さなチェックポイントを即時保存する。 */

--- a/supabase/migrations/202607210001_cloud_sync.sql
+++ b/supabase/migrations/202607210001_cloud_sync.sql
@@ -1,0 +1,68 @@
+-- 漢字タウン: 利用者本人だけが読み書きできるクラウド保存領域
+create table if not exists public.kanji_town_saves (
+  user_id uuid primary key references auth.users(id) on delete cascade,
+  payload jsonb not null default '{}'::jsonb,
+  payload_hash text not null check (payload_hash ~ '^[0-9a-f]{16,64}$'),
+  revision bigint not null default 1 check (revision >= 1),
+  schema_version integer not null default 1 check (schema_version >= 1),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint kanji_town_payload_size check (octet_length(payload::text) <= 5242880)
+);
+
+alter table public.kanji_town_saves enable row level security;
+
+revoke all on table public.kanji_town_saves from anon;
+grant select, insert, update, delete on table public.kanji_town_saves to authenticated;
+
+drop policy if exists "read own kanji town save" on public.kanji_town_saves;
+create policy "read own kanji town save"
+on public.kanji_town_saves
+for select
+to authenticated
+using ((select auth.uid()) = user_id);
+
+drop policy if exists "insert own kanji town save" on public.kanji_town_saves;
+create policy "insert own kanji town save"
+on public.kanji_town_saves
+for insert
+to authenticated
+with check ((select auth.uid()) = user_id and revision = 1);
+
+drop policy if exists "update own kanji town save" on public.kanji_town_saves;
+create policy "update own kanji town save"
+on public.kanji_town_saves
+for update
+to authenticated
+using ((select auth.uid()) = user_id)
+with check ((select auth.uid()) = user_id);
+
+drop policy if exists "delete own kanji town save" on public.kanji_town_saves;
+create policy "delete own kanji town save"
+on public.kanji_town_saves
+for delete
+to authenticated
+using ((select auth.uid()) = user_id);
+
+create or replace function public.set_kanji_town_save_updated_at()
+returns trigger
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+begin
+  if new.user_id <> old.user_id then
+    raise exception 'user_id cannot be changed';
+  end if;
+  if new.revision <> old.revision + 1 then
+    raise exception 'revision must increase by exactly one' using errcode = '40001';
+  end if;
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists set_kanji_town_save_updated_at on public.kanji_town_saves;
+create trigger set_kanji_town_save_updated_at
+before update on public.kanji_town_saves
+for each row execute function public.set_kanji_town_save_updated_at();

--- a/test/cloud-client.test.js
+++ b/test/cloud-client.test.js
@@ -1,0 +1,67 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  fetchCloudSave,
+  getCloudConfiguration,
+  updateCloudSave,
+} from '../src/systems/cloud-client.js';
+
+function createQueryClient(result) {
+  const calls = [];
+  const query = {
+    select(columns) {
+      calls.push(['select', columns]);
+      return this;
+    },
+    update(value) {
+      calls.push(['update', value]);
+      return this;
+    },
+    eq(column, value) {
+      calls.push(['eq', column, value]);
+      return this;
+    },
+    maybeSingle() {
+      calls.push(['maybeSingle']);
+      return Promise.resolve(result);
+    },
+  };
+  return {
+    calls,
+    client: {
+      from(table) {
+        calls.push(['from', table]);
+        return query;
+      },
+    },
+  };
+}
+
+test('環境変数がない場合はクラウド機能だけを無効にする', () => {
+  assert.deepEqual(getCloudConfiguration(), { url: '', anonKey: '', isConfigured: false });
+});
+
+test('クラウド読込は利用者IDで絞り込み、0件を正常に扱う', async () => {
+  const { client, calls } = createQueryClient({ data: null, error: null });
+  assert.equal(await fetchCloudSave(client, 'user-a'), null);
+  assert.ok(calls.some((call) => call[0] === 'eq' && call[1] === 'user_id' && call[2] === 'user-a'));
+  assert.equal(calls.at(-1)[0], 'maybeSingle');
+});
+
+test('クラウド更新は利用者IDとrevisionの両方で楽観ロックする', async () => {
+  const remote = { revision: 8, payload_hash: 'next' };
+  const { client, calls } = createQueryClient({ data: remote, error: null });
+  const result = await updateCloudSave(client, 'user-b', 7, { totalExp: 30 }, 'next');
+
+  assert.equal(result, remote);
+  assert.ok(calls.some((call) => call[0] === 'eq' && call[1] === 'user_id' && call[2] === 'user-b'));
+  assert.ok(calls.some((call) => call[0] === 'eq' && call[1] === 'revision' && call[2] === 7));
+  const update = calls.find((call) => call[0] === 'update')[1];
+  assert.equal(update.revision, 8);
+  assert.equal(update.schema_version, 1);
+});
+
+test('revision不一致で更新対象が消えた場合は競合としてnullを返す', async () => {
+  const { client } = createQueryClient({ data: null, error: null });
+  assert.equal(await updateCloudSave(client, 'user-c', 2, {}, 'hash'), null);
+});

--- a/test/cloud-sync.test.js
+++ b/test/cloud-sync.test.js
@@ -1,0 +1,110 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createSyncMeta,
+  decideSyncAction,
+  hashCloudPayload,
+  isEmptyLearningData,
+  prepareCloudPayload,
+  stableSerialize,
+  summarizeCloudData,
+} from '../src/systems/cloud-sync.js';
+
+test('クラウド用データは端末固有の一時情報を除外し、元データを変更しない', () => {
+  const stats = {
+    totalExp: 20,
+    cloudSync: { status: 'syncing' },
+    lastCollectionResult: { coins: 3 },
+    kanjiStats: { one: { status: 'review' } },
+  };
+  const payload = prepareCloudPayload(stats);
+
+  assert.equal(payload.cloudSync, undefined);
+  assert.equal(payload.lastCollectionResult, undefined);
+  assert.equal(stats.cloudSync.status, 'syncing');
+  assert.equal(payload.kanjiStats.one.status, 'review');
+});
+
+test('キー順が違っても同じクラウドハッシュになる', async () => {
+  const left = { b: 2, a: { d: 4, c: 3 } };
+  const right = { a: { c: 3, d: 4 }, b: 2 };
+  assert.equal(stableSerialize(left), stableSerialize(right));
+  assert.equal(await hashCloudPayload(left), await hashCloudPayload(right));
+});
+
+test('クラウドが空ならローカルを新規保存する', () => {
+  assert.deepEqual(decideSyncAction({ localHash: 'local', localIsEmpty: false, remote: null, meta: null }), {
+    action: 'create_remote',
+    reason: 'cloud_empty',
+  });
+});
+
+test('新しい端末の初期データにはクラウドを安全に復元する', () => {
+  assert.equal(decideSyncAction({
+    localHash: 'empty',
+    localIsEmpty: true,
+    remote: { revision: 3, payload_hash: 'cloud' },
+    meta: null,
+  }).action, 'pull_remote');
+});
+
+test('初回同期で双方に学習記録がある場合は自動上書きしない', () => {
+  assert.equal(decideSyncAction({
+    localHash: 'local',
+    localIsEmpty: false,
+    remote: { revision: 3, payload_hash: 'cloud' },
+    meta: null,
+  }).action, 'conflict');
+});
+
+test('最後の同期後に片側だけ変わった場合はその側を採用する', () => {
+  const meta = { lastSyncedHash: 'base', remoteRevision: 2 };
+  assert.equal(decideSyncAction({
+    localHash: 'local',
+    localIsEmpty: false,
+    remote: { revision: 2, payload_hash: 'base' },
+    meta,
+  }).action, 'push_local');
+  assert.equal(decideSyncAction({
+    localHash: 'base',
+    localIsEmpty: false,
+    remote: { revision: 3, payload_hash: 'cloud' },
+    meta,
+  }).action, 'pull_remote');
+});
+
+test('双方が変更された場合は競合として停止する', () => {
+  assert.equal(decideSyncAction({
+    localHash: 'local',
+    localIsEmpty: false,
+    remote: { revision: 4, payload_hash: 'cloud' },
+    meta: { lastSyncedHash: 'base', remoteRevision: 2 },
+  }).action, 'conflict');
+});
+
+test('共有端末で別アカウントへ切り替えた場合は自動送信しない', () => {
+  assert.deepEqual(decideSyncAction({
+    localHash: 'local',
+    localIsEmpty: false,
+    remote: null,
+    meta: null,
+    localOwnerId: 'previous-user',
+    userId: 'next-user',
+  }), { action: 'conflict', reason: 'account_switch' });
+});
+
+test('競合表示向けサマリーと同期メタデータを正規化する', () => {
+  assert.deepEqual(summarizeCloudData({
+    totalExp: 120,
+    streak: 4,
+    sessionCount: 7,
+    kanjiStats: { a: { status: 'review' }, b: { status: 'new' } },
+  }), { totalExp: 120, learned: 1, streak: 4, sessions: 7 });
+  assert.deepEqual(createSyncMeta({ revision: 5, payload_hash: 'hash' }, 'now'), {
+    remoteRevision: 5,
+    lastSyncedHash: 'hash',
+    lastSyncedAt: 'now',
+  });
+  assert.equal(isEmptyLearningData({ totalExp: 0, kanjiStats: {} }), true);
+  assert.equal(isEmptyLearningData({ totalExp: 0, kanjiStats: {}, myDrills: [{ id: 'local' }] }), false);
+});


### PR DESCRIPTION
## 概要

漢字タウンに、メールアカウントと安全なクラウド同期を追加します。静的な GitHub Pages 構成を維持したまま、Supabase Auth / Postgres を利用して複数端末から学習を継続できます。

## 変更内容

- メールアドレスによる新規登録、ログイン、ログアウト、パスワード再設定
- ローカル優先の自動保存と、オンライン復帰・画面復帰時の自動同期
- SHA-256 と revision 楽観ロックによる変更検出
- 片側だけ更新された場合の自動反映、双方更新時の比較・二段階確認
- 共有端末で別アカウントへ以前のデータを自動送信しない所有者チェック
- Supabase RLS、利用者ごとに1行だけアクセスできる保存テーブル
- 環境変数未設定時はクラウド機能だけを無効化し、従来の端末保存を維持
- GitHub Pages 用 Secrets 連携とセットアップドキュメント

## 利用者への影響

設定画面からアカウントを作成すると、学習進捗・まち・設定を端末間で同期できます。通信できない間も学習を続けられ、復帰後に自動同期します。競合やアカウント切替では自動上書きせず、データ概要を比較して残す側を選べます。

## 導入時の設定

マージ後に `docs/cloud-sync-setup.md` に従って以下を設定します。

1. Supabase migration の適用
2. Email provider と redirect URL の設定
3. GitHub Actions secrets `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` の登録

設定が完了するまでは、既存のローカル保存のみで安全に動作します。

## 検証

- `npm test` — 47件成功
- `npm run build` — 成功
- Supabase 環境変数あり／なしの両構成で本番ビルド成功
- メイン bundle 186.1 KiB / 220 KiB
- `npm audit --omit=dev` — 既知の脆弱性0件
- `git diff --check` — 問題なし
