### PR TITLE
教師・保護者の学習見守り共有を追加

### DIFF
--- a/docs/cloud-sync-setup.md
+++ b/docs/cloud-sync-setup.md
@@ -5,7 +5,9 @@
 ## 1. Supabaseプロジェクト
 
 1. Supabaseでプロジェクトを作成します。
-2. SQL Editorで `supabase/migrations/202607210001_cloud_sync.sql` を実行します。
+2. SQL Editorで次のmigrationを番号順に実行します。
+   - `supabase/migrations/202607210001_cloud_sync.sql`
+   - `supabase/migrations/202607210002_learning_sharing.sql`
 3. AuthenticationのEmail providerを有効にします。
 4. URL Configurationへ本番URLとローカル開発URLを登録します。
    - `https://gigayama.github.io/KANJI_Town/`
@@ -39,3 +41,12 @@ VITE_SUPABASE_ANON_KEY=your-publishable-anon-key
 - 両方が更新されている場合は自動上書きせず、設定画面で「この端末」または「クラウド」を選択します。
 - 共有端末で別のアカウントへ切り替えた場合、以前の利用者のデータは自動送信せず、明示的な選択を求めます。
 - 更新はrevisionによる楽観ロックで、同時更新を検知します。
+
+## 5. 教師・保護者との見守り共有
+
+- 児童側が「児童の表示名」と共有先（保護者・先生）を選び、15分間・1回限りの招待コードを発行します。
+- 招待コードは80bitの乱数で生成し、サーバーにはSHA-256ハッシュだけを保存します。
+- 見守り側には、進捗、学習習慣、4技能、復習支援に必要な漢字だけを表示します。
+- メールアドレス、まち、設定、ドリル、個々の回答履歴、クラウド保存本体は共有しません。
+- 共有関係は児童側・見守り側のどちらからでも解除できます。1児童あたりの共有先は最大10人です。
+- レポート取得は `security definer` のDB関数へ限定し、`authenticated` だけに実行権限を与えています。関数はログイン中の利用者が結ばれた児童の要約だけを返します。

--- a/src/components/pages/SettingsView.jsx
+++ b/src/components/pages/SettingsView.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { ArrowLeft, Volume2, VolumeX, Palette, GraduationCap, Database, Download, Upload, Trash2, RotateCcw, Sun, Moon, Sparkles, ChevronRight, AlertTriangle, Check, X, Accessibility, Cloud } from 'lucide-react';
+import { ArrowLeft, Volume2, VolumeX, Palette, GraduationCap, Database, Download, Upload, Trash2, RotateCcw, Sun, Moon, Sparkles, ChevronRight, AlertTriangle, Check, X, Accessibility, Cloud, HeartHandshake } from 'lucide-react';
 import { MotionButton } from '../ui';
 import { StorageAPI } from '../../systems/storage';
 import { audioCtrl } from '../../systems/audio';
@@ -8,6 +8,7 @@ import { F } from '../ui/FormatKun';
 import { DAILY_GOAL_OPTIONS, getDailyGoal } from '../../systems/learning-plan';
 import { getMotionPreference } from '../../utils/motion-preference';
 import AccountSyncPanel from '../settings/AccountSyncPanel';
+import LearningSharePanel from '../settings/LearningSharePanel';
 
 // 手動テーマ選択肢
 const THEME_OPTIONS = [
@@ -325,6 +326,11 @@ const SettingsView = ({ setView, stats, setStats, isMuted, setIsMuted, levelInfo
       {/* アカウント・クラウド同期 */}
       <Section icon={Cloud} title="アカウント・クラウド同期">
         <AccountSyncPanel cloudSync={cloudSync} />
+      </Section>
+
+      {/* 教師・保護者向け見守り共有 */}
+      <Section icon={HeartHandshake} title="学習の見守り共有">
+        <LearningSharePanel cloudSync={cloudSync} />
       </Section>
 
       {/* データ管理 */}

--- a/src/components/settings/LearningSharePanel.jsx
+++ b/src/components/settings/LearningSharePanel.jsx
@@ -1,0 +1,213 @@
+import React, { useMemo, useState } from 'react';
+import {
+  Check,
+  Clipboard,
+  GraduationCap,
+  HeartHandshake,
+  Link2,
+  LoaderCircle,
+  RefreshCw,
+  ShieldCheck,
+  Trash2,
+  Users,
+} from 'lucide-react';
+import MotionButton from '../ui/MotionButton';
+import { KANJI_DATA } from '../../data/kanji-data';
+import { MASTERY_SKILL_DEFINITIONS, MASTERY_SKILLS } from '../../systems/mastery';
+import { useLearningSharing } from '../../hooks/useLearningSharing';
+
+const ROLE_LABEL = { guardian: '保護者', teacher: '先生' };
+const SKILL_COLOR = {
+  reading: 'bg-sky-400',
+  meaning: 'bg-amber-400',
+  writing: 'bg-rose-400',
+  stroke: 'bg-violet-400',
+};
+
+const formatDateTime = (value) => {
+  const date = new Date(value);
+  if (!value || Number.isNaN(date.getTime())) return '同期待ち';
+  return new Intl.DateTimeFormat('ja-JP', {
+    month: 'numeric', day: 'numeric', hour: '2-digit', minute: '2-digit',
+  }).format(date);
+};
+
+const getSupportMessage = (report) => {
+  if (!report) return '児童が次に同期するとレポートが表示されます。';
+  if ((report.support?.overdueReviews || 0) > 0) return `復習を待つ漢字が${report.support.overdueReviews}字あります。短い復習を応援してあげましょう。`;
+  if ((report.habit?.goalDays || 0) >= 5) return '今週はよい学習リズムです。取り組めたことを具体的に認めてあげましょう。';
+  if ((report.habit?.studiedDays || 0) === 0) return '今週はまだ学習記録がありません。無理のない短い学習から声をかけてみましょう。';
+  return '学習を続けられています。結果だけでなく、取り組んだ過程もほめてあげましょう。';
+};
+
+const ReportCard = ({ item, onRemove, confirmRemove, setConfirmRemove, busy }) => {
+  const report = item.report_payload?.version === 1 ? item.report_payload : null;
+  const weakChars = (report?.support?.weakKanjiIds || [])
+    .map((id) => KANJI_DATA.find((kanji) => kanji.id === id)?.char)
+    .filter(Boolean);
+
+  return (
+    <div className="rounded-2xl border-[3px] border-violet-200 bg-violet-50 p-3">
+      <div className="mb-3 flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="truncate text-base font-black text-violet-900">{item.learner_label}</div>
+          <div className="text-[10px] font-bold text-violet-700">{ROLE_LABEL[item.viewer_role]}として見守り中 ・ 更新 {formatDateTime(item.updated_at)}</div>
+        </div>
+        <button type="button" disabled={busy} onClick={() => {
+          if (confirmRemove === item.link_id) onRemove(item.link_id);
+          else setConfirmRemove(item.link_id);
+        }} className="min-h-11 shrink-0 rounded-xl border-2 border-rose-300 bg-white px-2 text-[10px] font-black text-rose-700 disabled:opacity-40" aria-label={`${item.learner_label}との共有を解除`}>
+          <span className="flex items-center gap-1"><Trash2 size={14} /> {confirmRemove === item.link_id ? 'もう一度押す' : '解除'}</span>
+        </button>
+      </div>
+
+      {report ? (
+        <>
+          <div className="mb-3 grid grid-cols-2 gap-2 sm:grid-cols-4">
+            {[
+              ['学習漢字', `${report.progress?.learned || 0}字`],
+              ['連続学習', `${report.habit?.streak || 0}日`],
+              ['今週の目標', `${report.habit?.goalDays || 0}/7日`],
+              ['正答率', report.habit?.accuracy === null ? '—' : `${report.habit?.accuracy || 0}%`],
+            ].map(([label, value]) => (
+              <div key={label} className="rounded-xl border-2 border-white bg-white/80 p-2 text-center">
+                <div className="text-lg font-black text-[var(--text)]">{value}</div>
+                <div className="text-[9px] font-bold text-[var(--text)] opacity-55">{label}</div>
+              </div>
+            ))}
+          </div>
+          <div className="mb-3 grid grid-cols-2 gap-2 sm:grid-cols-4" aria-label="4技能の習熟度">
+            {MASTERY_SKILLS.map((skill) => {
+              const score = Math.max(0, Math.min(100, Number(report.mastery?.[skill]) || 0));
+              const definition = MASTERY_SKILL_DEFINITIONS[skill];
+              return (
+                <div key={skill} className="rounded-xl bg-white/75 p-2">
+                  <div className="mb-1 flex justify-between text-[10px] font-black"><span>{definition.icon} {definition.label}</span><span>{score}</span></div>
+                  <div className="h-2 overflow-hidden rounded-full bg-slate-200"><div className={`h-full ${SKILL_COLOR[skill]}`} style={{ width: `${score}%` }} /></div>
+                </div>
+              );
+            })}
+          </div>
+          {weakChars.length > 0 && <div className="mb-2 rounded-xl border-2 border-amber-200 bg-amber-50 px-3 py-2 text-xs font-bold text-amber-900">復習を支えたい漢字：<span className="ml-1 text-lg font-black tracking-widest">{weakChars.join(' ')}</span></div>}
+        </>
+      ) : null}
+
+      <div className="rounded-xl border-2 border-emerald-200 bg-emerald-50 px-3 py-2 text-[11px] font-bold leading-relaxed text-emerald-900">{getSupportMessage(report)}</div>
+    </div>
+  );
+};
+
+const LearningSharePanel = ({ cloudSync }) => {
+  const sharing = useLearningSharing({ cloudSync });
+  const [mode, setMode] = useState('share');
+  const [learnerLabel, setLearnerLabel] = useState('');
+  const [viewerRole, setViewerRole] = useState('guardian');
+  const [viewerLabel, setViewerLabel] = useState('');
+  const [token, setToken] = useState('');
+  const [validationError, setValidationError] = useState(null);
+  const [copied, setCopied] = useState(false);
+  const [confirmRemove, setConfirmRemove] = useState(null);
+
+  const busy = sharing.status === 'loading' || sharing.status === 'saving';
+  const userId = cloudSync.user?.id;
+  const outgoingLinks = useMemo(() => sharing.links.filter((link) => link.learner_id === userId), [sharing.links, userId]);
+  const incomingReports = sharing.reports || [];
+
+  if (!cloudSync.isConfigured) return <p className="text-[11px] font-bold text-[var(--text)] opacity-55">クラウド同期の設定後に利用できます。</p>;
+  if (!cloudSync.user) return <p className="text-[11px] font-bold leading-relaxed text-[var(--text)] opacity-55">先に上の「アカウント・クラウド同期」からログインしてください。</p>;
+
+  const handleCreate = async () => {
+    const label = learnerLabel.trim();
+    setValidationError(null);
+    sharing.clearMessage();
+    if (label.length < 1 || label.length > 30) {
+      setValidationError('児童の表示名を1〜30文字で入力してください。');
+      return;
+    }
+    await sharing.createInvite({ learnerLabel: label, viewerRole });
+  };
+
+  const handleClaim = async () => {
+    const label = viewerLabel.trim();
+    setValidationError(null);
+    sharing.clearMessage();
+    if (label.length < 1 || label.length > 30) {
+      setValidationError('あなたの表示名を1〜30文字で入力してください。');
+      return;
+    }
+    if (await sharing.claimInvite({ token, viewerLabel: label })) setToken('');
+  };
+
+  const copyInvite = async () => {
+    if (!sharing.invite) return;
+    try {
+      await navigator.clipboard.writeText(sharing.invite.formattedToken);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setValidationError('コードを選択してコピーしてください。');
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="grid grid-cols-2 gap-2 rounded-xl bg-[var(--bg)] p-1" role="tablist" aria-label="見守り共有の操作">
+        <button type="button" role="tab" aria-selected={mode === 'share'} onClick={() => { setMode('share'); setValidationError(null); sharing.clearMessage(); }} className={`min-h-11 rounded-lg text-xs font-black ${mode === 'share' ? 'border-2 border-emerald-400 bg-[var(--panel)] shadow-sm' : 'opacity-55'}`}><span className="flex items-center justify-center gap-1"><HeartHandshake size={16} /> 見守ってもらう</span></button>
+        <button type="button" role="tab" aria-selected={mode === 'watch'} onClick={() => { setMode('watch'); setValidationError(null); sharing.clearMessage(); }} className={`min-h-11 rounded-lg text-xs font-black ${mode === 'watch' ? 'border-2 border-violet-400 bg-[var(--panel)] shadow-sm' : 'opacity-55'}`}><span className="flex items-center justify-center gap-1"><GraduationCap size={16} /> 学習を見守る</span></button>
+      </div>
+
+      {mode === 'share' ? (
+        <div className="flex flex-col gap-3">
+          <label className="text-xs font-black text-[var(--text)]">児童の表示名
+            <input value={learnerLabel} maxLength={30} onChange={(event) => setLearnerLabel(event.target.value)} className="mt-1 min-h-11 w-full rounded-xl border-[3px] border-[var(--text)] bg-[var(--bg)] px-3 text-sm" placeholder="例：たろう" />
+          </label>
+          <div>
+            <div className="mb-1 text-xs font-black text-[var(--text)]">招待する人</div>
+            <div className="grid grid-cols-2 gap-2">
+              {Object.entries(ROLE_LABEL).map(([value, label]) => <button key={value} type="button" aria-pressed={viewerRole === value} onClick={() => setViewerRole(value)} className={`min-h-11 rounded-xl border-[3px] text-xs font-black ${viewerRole === value ? 'border-emerald-400 bg-emerald-50 text-emerald-900' : 'border-[var(--text)]/20'}`}>{label}</button>)}
+            </div>
+          </div>
+          <MotionButton variant="secondary" disabled={busy} onClick={handleCreate} className="min-h-12 border-[3px] border-[var(--text)] text-xs"><Link2 size={17} /> 15分招待コードを作る</MotionButton>
+
+          {sharing.invite && (
+            <div className="rounded-2xl border-[3px] border-emerald-300 bg-emerald-50 p-3 text-center" role="status">
+              <div className="mb-1 text-[10px] font-black text-emerald-800">{ROLE_LABEL[sharing.invite.viewerRole]}へ、このコードだけを伝えます</div>
+              <div className="select-all break-all rounded-xl bg-white px-2 py-3 font-mono text-xl font-black tracking-wider text-emerald-900">{sharing.invite.formattedToken}</div>
+              <button type="button" onClick={copyInvite} className="mt-2 min-h-11 rounded-xl border-2 border-emerald-400 bg-white px-4 text-xs font-black text-emerald-800"><span className="flex items-center gap-1">{copied ? <Check size={16} /> : <Clipboard size={16} />}{copied ? 'コピーしました' : 'コードをコピー'}</span></button>
+              <button type="button" disabled={busy} onClick={sharing.cancelInvite} className="ml-2 mt-2 min-h-11 rounded-xl px-3 text-[10px] font-black text-rose-700 underline underline-offset-2">招待を取り消す</button>
+              <p className="mt-2 text-[10px] font-bold leading-relaxed text-emerald-800">1回だけ使用でき、15分で無効になります。信頼できる保護者・先生にだけ伝えてください。</p>
+            </div>
+          )}
+
+          {outgoingLinks.length > 0 && <div className="flex flex-col gap-2">
+            <div className="text-xs font-black text-[var(--text)]">見守っている人</div>
+            {outgoingLinks.map((link) => <div key={link.id} className="flex items-center justify-between gap-2 rounded-xl border-2 border-emerald-200 bg-emerald-50 p-2.5">
+              <div className="min-w-0"><div className="truncate text-sm font-black text-emerald-900">{link.viewer_label}</div><div className="text-[10px] font-bold text-emerald-700">{ROLE_LABEL[link.viewer_role]}</div></div>
+              <button type="button" disabled={busy} onClick={() => { if (confirmRemove === link.id) sharing.removeLink(link.id); else setConfirmRemove(link.id); }} className="min-h-11 rounded-xl border-2 border-rose-300 bg-white px-2 text-[10px] font-black text-rose-700"><span className="flex items-center gap-1"><Trash2 size={14} />{confirmRemove === link.id ? 'もう一度押す' : '解除'}</span></button>
+            </div>)}
+          </div>}
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3">
+          <label className="text-xs font-black text-[var(--text)]">あなたの表示名
+            <input value={viewerLabel} maxLength={30} onChange={(event) => setViewerLabel(event.target.value)} className="mt-1 min-h-11 w-full rounded-xl border-[3px] border-[var(--text)] bg-[var(--bg)] px-3 text-sm" placeholder="例：お母さん、山田先生" />
+          </label>
+          <label className="text-xs font-black text-[var(--text)]">16文字の招待コード
+            <input value={token} autoCapitalize="characters" autoCorrect="off" spellCheck="false" onChange={(event) => setToken(event.target.value.toUpperCase())} className="mt-1 min-h-11 w-full rounded-xl border-[3px] border-[var(--text)] bg-[var(--bg)] px-3 font-mono text-sm uppercase tracking-wider" placeholder="ABCD-EFGH-JKMN-PQRS" />
+          </label>
+          <MotionButton variant="secondary" disabled={busy} onClick={handleClaim} className="min-h-12 border-[3px] border-[var(--text)] text-xs"><Users size={17} /> 見守りを開始する</MotionButton>
+
+          {incomingReports.length > 0 ? incomingReports.map((item) => <ReportCard key={item.link_id} item={item} busy={busy} confirmRemove={confirmRemove} setConfirmRemove={setConfirmRemove} onRemove={sharing.removeLink} />) : <div className="rounded-xl border-2 border-slate-200 bg-slate-50 p-3 text-center text-[11px] font-bold text-slate-500">招待コードを入力すると、児童の学習要約がここに表示されます。</div>}
+        </div>
+      )}
+
+      {(validationError || sharing.error) && <div role="alert" className="rounded-lg bg-rose-50 px-3 py-2 text-xs font-bold text-rose-700">{validationError || sharing.error}</div>}
+      {sharing.notice && <div role="status" className="rounded-lg bg-sky-50 px-3 py-2 text-xs font-bold text-sky-700">{sharing.notice}</div>}
+      {busy && <div role="status" className="flex items-center justify-center gap-2 text-xs font-bold text-[var(--text)] opacity-55"><LoaderCircle className="animate-spin" size={16} /> 更新しています…</div>}
+      <div className="flex items-start gap-2 rounded-xl border-2 border-sky-100 bg-sky-50 p-2.5 text-[10px] font-bold leading-relaxed text-sky-800"><ShieldCheck size={16} className="mt-0.5 shrink-0" />共有されるのは学習の要約だけです。メール、まち、設定、ドリル、個々の回答履歴は共有されません。</div>
+      <button type="button" disabled={busy} onClick={sharing.refresh} className="min-h-11 text-xs font-bold text-sky-700"><span className="flex items-center justify-center gap-1"><RefreshCw size={14} /> 最新のレポートを確認</span></button>
+    </div>
+  );
+};
+
+export default LearningSharePanel;

--- a/src/hooks/useCloudSync.js
+++ b/src/hooks/useCloudSync.js
@@ -17,6 +17,11 @@ import {
   summarizeCloudData,
 } from '../systems/cloud-sync';
 import { StorageAPI } from '../systems/storage';
+import {
+  attachReportSource,
+  buildLearningReport,
+  isLearningReportCurrent,
+} from '../systems/learning-report';
 
 const META_KEY_PREFIX = 'kanji_town_cloud_meta_v1:';
 const LOCAL_OWNER_KEY = 'kanji_town_cloud_owner_v1';
@@ -170,6 +175,7 @@ export function useCloudSync({ stats, setStats }) {
         const localStats = statsRef.current;
         const payload = prepareCloudPayload(localStats);
         const localHash = await hashCloudPayload(payload);
+        const reportPayload = attachReportSource(buildLearningReport(localStats), localHash);
         const remote = await fetchCloudSave(client, activeUser.id);
         // ログアウトや別アカウントへの切替後に、古いリクエスト結果を反映しない。
         if (userRef.current?.id !== activeUser.id) return null;
@@ -187,7 +193,7 @@ export function useCloudSync({ stats, setStats }) {
 
         if (decision.action === 'create_remote') {
           try {
-            const created = await createCloudSave(client, activeUser.id, payload, localHash);
+            const created = await createCloudSave(client, activeUser.id, payload, localHash, reportPayload);
             if (userRef.current?.id !== activeUser.id) return null;
             rememberRemote(activeUser.id, created);
           } catch (error) {
@@ -197,7 +203,7 @@ export function useCloudSync({ stats, setStats }) {
             showConflict(latest, localStats);
           }
         } else if (decision.action === 'push_local') {
-          const updated = await updateCloudSave(client, activeUser.id, remote.revision, payload, localHash);
+          const updated = await updateCloudSave(client, activeUser.id, remote.revision, payload, localHash, reportPayload);
           if (userRef.current?.id !== activeUser.id) return null;
           if (!updated) {
             const latest = await fetchCloudSave(client, activeUser.id);
@@ -210,6 +216,22 @@ export function useCloudSync({ stats, setStats }) {
           applyRemote(activeUser.id, remote);
         } else if (decision.action === 'conflict') {
           showConflict(remote, localStats, decision.reason);
+        } else if (!isLearningReportCurrent(remote.report_payload, remote.payload_hash)) {
+          const updated = await updateCloudSave(
+            client,
+            activeUser.id,
+            remote.revision,
+            payload,
+            localHash,
+            reportPayload,
+          );
+          if (userRef.current?.id !== activeUser.id) return null;
+          if (updated) rememberRemote(activeUser.id, updated);
+          else {
+            const latest = await fetchCloudSave(client, activeUser.id);
+            if (userRef.current?.id !== activeUser.id) return null;
+            showConflict(latest, localStats);
+          }
         } else {
           rememberRemote(activeUser.id, remote);
         }
@@ -385,7 +407,8 @@ export function useCloudSync({ stats, setStats }) {
         const localStats = statsRef.current;
         const payload = prepareCloudPayload(localStats);
         const hash = await hashCloudPayload(payload);
-        const created = await createCloudSave(client, activeUser.id, payload, hash);
+        const report = attachReportSource(buildLearningReport(localStats), hash);
+        const created = await createCloudSave(client, activeUser.id, payload, hash, report);
         if (userRef.current?.id !== activeUser.id) return;
         rememberRemote(activeUser.id, created);
         patchState({ notice: 'この端末の学習データを新しいアカウントへ保存しました。' });
@@ -400,7 +423,8 @@ export function useCloudSync({ stats, setStats }) {
       const localStats = statsRef.current;
       const payload = prepareCloudPayload(localStats);
       const hash = await hashCloudPayload(payload);
-      const updated = await updateCloudSave(client, activeUser.id, latest.revision, payload, hash);
+      const report = attachReportSource(buildLearningReport(localStats), hash);
+      const updated = await updateCloudSave(client, activeUser.id, latest.revision, payload, hash, report);
       if (userRef.current?.id !== activeUser.id) return;
       if (!updated) {
         const newest = await fetchCloudSave(client, activeUser.id);

--- a/src/hooks/useLearningSharing.js
+++ b/src/hooks/useLearningSharing.js
@@ -1,0 +1,173 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  claimLearningShareInvite,
+  createLearningShareInvite,
+  deleteLearningLink,
+  deleteLearningShareInvite,
+  fetchLinkedLearningReports,
+  getCloudClient,
+  listLearningLinks,
+} from '../systems/cloud-client';
+import {
+  createShareToken,
+  formatShareToken,
+  hashShareToken,
+  normalizeShareToken,
+} from '../systems/cloud-sharing';
+
+const initialState = {
+  status: 'idle',
+  links: [],
+  reports: [],
+  invite: null,
+  error: null,
+  notice: null,
+};
+
+function sharingError(error) {
+  const code = String(error?.code || '').toUpperCase();
+  const message = String(error?.message || '').toLowerCase();
+  if (code === 'P0002' || message.includes('invalid or expired invite')) {
+    return '招待コードが違うか、有効期限が切れています。';
+  }
+  if (code === '22023') return '表示名と共有先を確認してください。';
+  if (code === '54000') return 'この児童の見守り共有は上限の10人に達しています。';
+  if (code === '23505') return '招待コードを作り直して、もう一度お試しください。';
+  if (code === '42883' || code === '42P01' || code === 'PGRST202' || code === 'PGRST205') {
+    return '見守り共有のデータベース設定がまだ完了していません。';
+  }
+  if (message.includes('fetch') || message.includes('network')) return '通信できませんでした。接続後にもう一度お試しください。';
+  return '見守り共有を完了できませんでした。学習データは変更していません。';
+}
+
+export function useLearningSharing({ cloudSync }) {
+  const userId = cloudSync.user?.id || null;
+  const mountedRef = useRef(true);
+  const requestRef = useRef(0);
+  const [state, setState] = useState(initialState);
+
+  const patchState = useCallback((patch) => {
+    if (!mountedRef.current) return;
+    setState((current) => ({ ...current, ...patch }));
+  }, []);
+
+  const refresh = useCallback(async () => {
+    if (!userId) {
+      patchState({ ...initialState });
+      return;
+    }
+    const requestId = ++requestRef.current;
+    patchState({ status: 'loading', error: null });
+    try {
+      const client = await getCloudClient();
+      const [links, reports] = await Promise.all([
+        listLearningLinks(client),
+        fetchLinkedLearningReports(client),
+      ]);
+      if (requestId !== requestRef.current) return;
+      patchState({ status: 'ready', links, reports, error: null });
+    } catch (error) {
+      if (requestId !== requestRef.current) return;
+      patchState({ status: 'error', error: sharingError(error) });
+    }
+  }, [patchState, userId]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    refresh();
+    return () => {
+      mountedRef.current = false;
+      requestRef.current += 1;
+    };
+  }, [refresh]);
+
+  const createInvite = useCallback(async ({ learnerLabel, viewerRole }) => {
+    if (!userId) return null;
+    patchState({ status: 'saving', error: null, notice: null, invite: null });
+    try {
+      const token = createShareToken();
+      const tokenHash = await hashShareToken(token);
+      const client = await getCloudClient();
+      const created = await createLearningShareInvite(client, {
+        tokenHash,
+        learnerLabel: learnerLabel.trim(),
+        viewerRole,
+      });
+      const invite = {
+        id: created.invite_id,
+        token,
+        formattedToken: formatShareToken(token),
+        expiresAt: created.expires_at,
+        viewerRole,
+      };
+      patchState({ status: 'ready', invite, notice: '15分間使える招待コードを作りました。' });
+      return invite;
+    } catch (error) {
+      patchState({ status: 'error', error: sharingError(error) });
+      return null;
+    }
+  }, [patchState, userId]);
+
+  const claimInvite = useCallback(async ({ token, viewerLabel }) => {
+    if (!userId) return false;
+    const normalized = normalizeShareToken(token);
+    if (!normalized) {
+      patchState({ error: '招待コードは16文字です。文字を確認してください。' });
+      return false;
+    }
+    patchState({ status: 'saving', error: null, notice: null });
+    try {
+      const client = await getCloudClient();
+      await claimLearningShareInvite(client, await hashShareToken(normalized), viewerLabel.trim());
+      patchState({ notice: '見守り共有を開始しました。' });
+      await refresh();
+      return true;
+    } catch (error) {
+      patchState({ status: 'error', error: sharingError(error) });
+      return false;
+    }
+  }, [patchState, refresh, userId]);
+
+  const cancelInvite = useCallback(async () => {
+    if (!state.invite?.id) return false;
+    patchState({ status: 'saving', error: null, notice: null });
+    try {
+      const client = await getCloudClient();
+      const removed = await deleteLearningShareInvite(client, state.invite.id);
+      patchState({
+        status: 'ready',
+        invite: null,
+        notice: removed ? '招待コードを無効にしました。' : '招待コードは使用済みか、すでに無効です。',
+      });
+      return true;
+    } catch (error) {
+      patchState({ status: 'error', error: sharingError(error) });
+      return false;
+    }
+  }, [patchState, state.invite?.id]);
+
+  const removeLink = useCallback(async (linkId) => {
+    patchState({ status: 'saving', error: null, notice: null });
+    try {
+      const client = await getCloudClient();
+      const removed = await deleteLearningLink(client, linkId);
+      if (!removed) throw new Error('link_not_found');
+      patchState({ notice: '見守り共有を解除しました。' });
+      await refresh();
+      return true;
+    } catch (error) {
+      patchState({ status: 'error', error: sharingError(error) });
+      return false;
+    }
+  }, [patchState, refresh]);
+
+  return {
+    ...state,
+    refresh,
+    createInvite,
+    cancelInvite,
+    claimInvite,
+    removeLink,
+    clearMessage: () => patchState({ error: null, notice: null }),
+  };
+}

--- a/src/systems/cloud-client.js
+++ b/src/systems/cloud-client.js
@@ -50,7 +50,7 @@ function throwIfError(error, fallbackMessage) {
   throw cloudError;
 }
 
-const SAVE_COLUMNS = 'payload,payload_hash,revision,schema_version,updated_at';
+const SAVE_COLUMNS = 'payload,payload_hash,revision,schema_version,report_payload,updated_at';
 
 export async function fetchCloudSave(client, userId) {
   const { data, error } = await client
@@ -62,7 +62,7 @@ export async function fetchCloudSave(client, userId) {
   return data || null;
 }
 
-export async function createCloudSave(client, userId, payload, payloadHash) {
+export async function createCloudSave(client, userId, payload, payloadHash, reportPayload = {}) {
   const { data, error } = await client
     .from(CLOUD_TABLE)
     .insert({
@@ -71,6 +71,7 @@ export async function createCloudSave(client, userId, payload, payloadHash) {
       payload_hash: payloadHash,
       revision: 1,
       schema_version: CLOUD_SAVE_VERSION,
+      report_payload: reportPayload,
     })
     .select(SAVE_COLUMNS)
     .single();
@@ -79,7 +80,7 @@ export async function createCloudSave(client, userId, payload, payloadHash) {
 }
 
 /** revision一致時だけ更新する楽観ロック。data=nullは他端末との競合を表す。 */
-export async function updateCloudSave(client, userId, expectedRevision, payload, payloadHash) {
+export async function updateCloudSave(client, userId, expectedRevision, payload, payloadHash, reportPayload = {}) {
   const { data, error } = await client
     .from(CLOUD_TABLE)
     .update({
@@ -87,6 +88,7 @@ export async function updateCloudSave(client, userId, expectedRevision, payload,
       payload_hash: payloadHash,
       revision: expectedRevision + 1,
       schema_version: CLOUD_SAVE_VERSION,
+      report_payload: reportPayload,
     })
     .eq('user_id', userId)
     .eq('revision', expectedRevision)
@@ -94,6 +96,66 @@ export async function updateCloudSave(client, userId, expectedRevision, payload,
     .maybeSingle();
   throwIfError(error, 'クラウドデータを更新できませんでした');
   return data || null;
+}
+
+const LINK_COLUMNS = 'id,learner_id,viewer_id,learner_label,viewer_label,viewer_role,created_at';
+
+export async function listLearningLinks(client) {
+  const { data, error } = await client
+    .from('kanji_town_learning_links')
+    .select(LINK_COLUMNS)
+    .order('created_at', { ascending: false });
+  throwIfError(error, '見守り共有を読み込めませんでした');
+  return data || [];
+}
+
+export async function createLearningShareInvite(client, { tokenHash, learnerLabel, viewerRole }) {
+  const { data, error } = await client
+    .rpc('create_kanji_town_share_invite', {
+      p_token_hash: tokenHash,
+      p_learner_label: learnerLabel,
+      p_viewer_role: viewerRole,
+    })
+    .single();
+  throwIfError(error, '招待コードを作成できませんでした');
+  return data;
+}
+
+export async function claimLearningShareInvite(client, tokenHash, viewerLabel) {
+  const { data, error } = await client.rpc('claim_kanji_town_share_invite', {
+    p_token_hash: tokenHash,
+    p_viewer_label: viewerLabel,
+  });
+  throwIfError(error, '招待コードを確認できませんでした');
+  return data;
+}
+
+export async function deleteLearningShareInvite(client, inviteId) {
+  const { data, error } = await client
+    .from('kanji_town_share_invites')
+    .delete()
+    .eq('id', inviteId)
+    .select('id')
+    .maybeSingle();
+  throwIfError(error, '招待コードを取り消せませんでした');
+  return Boolean(data);
+}
+
+export async function fetchLinkedLearningReports(client) {
+  const { data, error } = await client.rpc('get_kanji_town_linked_reports');
+  throwIfError(error, '見守りレポートを読み込めませんでした');
+  return data || [];
+}
+
+export async function deleteLearningLink(client, linkId) {
+  const { data, error } = await client
+    .from('kanji_town_learning_links')
+    .delete()
+    .eq('id', linkId)
+    .select('id')
+    .maybeSingle();
+  throwIfError(error, '見守り共有を解除できませんでした');
+  return Boolean(data);
 }
 
 export function getAuthRedirectUrl() {

--- a/src/systems/cloud-sharing.js
+++ b/src/systems/cloud-sharing.js
@@ -1,0 +1,46 @@
+const SHARE_TOKEN_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+const SHARE_TOKEN_LENGTH = 16;
+const SHARE_TOKEN_PATTERN = new RegExp(`^[${SHARE_TOKEN_ALPHABET}]{${SHARE_TOKEN_LENGTH}}$`);
+
+export function encodeShareToken(bytes) {
+  if (!(bytes instanceof Uint8Array) || bytes.length !== 10) {
+    throw new Error('invalid_share_token_bytes');
+  }
+  let value = 0;
+  let bits = 0;
+  let token = '';
+  for (const byte of bytes) {
+    value = (value << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      bits -= 5;
+      token += SHARE_TOKEN_ALPHABET[(value >>> bits) & 31];
+      value &= (1 << bits) - 1;
+    }
+  }
+  return token;
+}
+
+export function createShareToken() {
+  if (!globalThis.crypto?.getRandomValues) throw new Error('secure_random_unavailable');
+  return encodeShareToken(globalThis.crypto.getRandomValues(new Uint8Array(10)));
+}
+
+export function normalizeShareToken(value) {
+  const token = String(value || '').toUpperCase().replace(/[\s-]/g, '');
+  return SHARE_TOKEN_PATTERN.test(token) ? token : null;
+}
+
+export function formatShareToken(value) {
+  const token = normalizeShareToken(value);
+  if (!token) return String(value || '');
+  return token.match(/.{1,4}/g).join('-');
+}
+
+export async function hashShareToken(value) {
+  const token = normalizeShareToken(value);
+  if (!token) throw new Error('invalid_share_token');
+  if (!globalThis.crypto?.subtle) throw new Error('secure_hash_unavailable');
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', new TextEncoder().encode(token));
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('');
+}

--- a/src/systems/learning-report.js
+++ b/src/systems/learning-report.js
@@ -1,0 +1,72 @@
+import { KANJI_DATA } from '../data/kanji-data.js';
+import {
+  buildWeakKanjiPlan,
+  getReviewForecast,
+  getWeeklyLearningSummary,
+} from './learning-plan.js';
+import { getSkillMasterySummary, MASTERY_SKILLS } from './mastery.js';
+
+export const LEARNING_REPORT_VERSION = 1;
+
+const DATE_KEY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+const asCount = (value) => Math.max(0, Math.floor(Number(value) || 0));
+
+/**
+ * 教師・保護者へ共有する、学習支援に必要な最小限の要約。
+ * まち、メール、設定、ドリル、個々の回答履歴は意図的に含めない。
+ */
+export function buildLearningReport(stats = {}, now = new Date()) {
+  const parsedNow = new Date(now);
+  const safeNow = Number.isNaN(parsedNow.getTime()) ? new Date() : parsedNow;
+  const kanjiStats = stats.kanjiStats || {};
+  const learnedCards = Object.values(kanjiStats).filter((card) => card && card.status !== 'new');
+  const weekly = getWeeklyLearningSummary(stats, safeNow);
+  const mastery = getSkillMasterySummary(kanjiStats);
+  const review = getReviewForecast(kanjiStats, safeNow);
+  const weak = buildWeakKanjiPlan({
+    kanjiData: KANJI_DATA,
+    kanjiStats,
+    limit: 5,
+    now: safeNow.getTime(),
+  });
+
+  return {
+    version: LEARNING_REPORT_VERSION,
+    generatedAt: safeNow.toISOString(),
+    grade: Math.min(6, Math.max(1, Math.floor(Number(stats.targetGrade) || 1))),
+    progress: {
+      learned: learnedCards.length,
+      mastered: learnedCards.filter((card) => card.status === 'mastered').length,
+      totalExp: asCount(stats.totalExp),
+      sessions: asCount(stats.sessionCount),
+    },
+    habit: {
+      streak: asCount(stats.streak),
+      lastLearningDate: DATE_KEY_PATTERN.test(stats.lastDate || '') ? stats.lastDate : null,
+      studiedDays: weekly.studiedDays,
+      goalDays: weekly.goalDays,
+      weeklyGoal: weekly.goal,
+      reviewed: weekly.reviewed,
+      accuracy: weekly.accuracy,
+    },
+    mastery: Object.fromEntries(MASTERY_SKILLS.map((skill) => [skill, mastery.scores[skill]])),
+    support: {
+      overdueReviews: review.overdueCount,
+      weekReviews: review.weekCount,
+      weakKanjiIds: weak.queue.map((kanji) => kanji.id),
+    },
+  };
+}
+
+export function attachReportSource(report, payloadHash) {
+  return {
+    ...report,
+    sourceHash: typeof payloadHash === 'string' ? payloadHash : '',
+  };
+}
+
+export function isLearningReportCurrent(report, payloadHash) {
+  return report?.version === LEARNING_REPORT_VERSION
+    && report?.sourceHash === payloadHash;
+}

--- a/supabase/migrations/202607210002_learning_sharing.sql
+++ b/supabase/migrations/202607210002_learning_sharing.sql
@@ -1,0 +1,207 @@
+-- 漢字タウン: 教師・保護者へ最小限の学習要約だけを共有する
+alter table public.kanji_town_saves
+add column if not exists report_payload jsonb not null default '{}'::jsonb;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'kanji_town_report_payload_size'
+      and conrelid = 'public.kanji_town_saves'::regclass
+  ) then
+    alter table public.kanji_town_saves
+    add constraint kanji_town_report_payload_size
+    check (octet_length(report_payload::text) <= 65536);
+  end if;
+end;
+$$;
+
+create table if not exists public.kanji_town_share_invites (
+  id uuid primary key default gen_random_uuid(),
+  learner_id uuid not null references auth.users(id) on delete cascade,
+  token_hash text not null unique check (token_hash ~ '^[0-9a-f]{64}$'),
+  learner_label text not null check (char_length(learner_label) between 1 and 30),
+  viewer_role text not null check (viewer_role in ('guardian', 'teacher')),
+  created_at timestamptz not null default now(),
+  expires_at timestamptz not null,
+  constraint kanji_town_share_invite_one_per_learner unique (learner_id),
+  constraint kanji_town_share_invite_expiry check (
+    expires_at > created_at and expires_at <= created_at + interval '1 hour'
+  )
+);
+
+create table if not exists public.kanji_town_learning_links (
+  id uuid primary key default gen_random_uuid(),
+  learner_id uuid not null references auth.users(id) on delete cascade,
+  viewer_id uuid not null references auth.users(id) on delete cascade,
+  learner_label text not null check (char_length(learner_label) between 1 and 30),
+  viewer_label text not null check (char_length(viewer_label) between 1 and 30),
+  viewer_role text not null check (viewer_role in ('guardian', 'teacher')),
+  created_at timestamptz not null default now(),
+  constraint kanji_town_learning_link_accounts check (learner_id <> viewer_id),
+  constraint kanji_town_learning_link_unique unique (learner_id, viewer_id)
+);
+
+alter table public.kanji_town_share_invites enable row level security;
+alter table public.kanji_town_learning_links enable row level security;
+
+revoke all on table public.kanji_town_share_invites from anon, authenticated;
+revoke all on table public.kanji_town_learning_links from anon, authenticated;
+grant select, delete on table public.kanji_town_share_invites to authenticated;
+grant select, delete on table public.kanji_town_learning_links to authenticated;
+
+drop policy if exists "manage own learning share invites" on public.kanji_town_share_invites;
+drop policy if exists "read own learning share invites" on public.kanji_town_share_invites;
+create policy "read own learning share invites"
+on public.kanji_town_share_invites
+for select
+to authenticated
+using ((select auth.uid()) = learner_id);
+
+drop policy if exists "remove own learning share invites" on public.kanji_town_share_invites;
+create policy "remove own learning share invites"
+on public.kanji_town_share_invites
+for delete
+to authenticated
+using ((select auth.uid()) = learner_id);
+
+drop policy if exists "read related learning links" on public.kanji_town_learning_links;
+create policy "read related learning links"
+on public.kanji_town_learning_links
+for select
+to authenticated
+using ((select auth.uid()) in (learner_id, viewer_id));
+
+drop policy if exists "remove related learning links" on public.kanji_town_learning_links;
+create policy "remove related learning links"
+on public.kanji_town_learning_links
+for delete
+to authenticated
+using ((select auth.uid()) in (learner_id, viewer_id));
+
+create or replace function public.create_kanji_town_share_invite(
+  p_token_hash text,
+  p_learner_label text,
+  p_viewer_role text
+)
+returns table (invite_id uuid, expires_at timestamptz)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  current_user_id uuid := (select auth.uid());
+  clean_label text := btrim(p_learner_label);
+begin
+  if current_user_id is null then
+    raise exception 'authentication required' using errcode = '28000';
+  end if;
+  if p_token_hash is null or p_token_hash !~ '^[0-9a-f]{64}$'
+    or clean_label is null or char_length(clean_label) not between 1 and 30
+    or p_viewer_role is null or p_viewer_role not in ('guardian', 'teacher') then
+    raise exception 'invalid invite input' using errcode = '22023';
+  end if;
+
+  -- 1アカウントにつき有効な招待は1件だけにして、不要な蓄積と誤共有を防ぐ。
+  delete from public.kanji_town_share_invites where learner_id = current_user_id;
+  return query
+  insert into public.kanji_town_share_invites as created (
+    learner_id, token_hash, learner_label, viewer_role, expires_at
+  ) values (
+    current_user_id, p_token_hash, clean_label, p_viewer_role, now() + interval '15 minutes'
+  )
+  returning created.id, created.expires_at;
+end;
+$$;
+
+create or replace function public.claim_kanji_town_share_invite(
+  p_token_hash text,
+  p_viewer_label text
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  current_user_id uuid := (select auth.uid());
+  clean_viewer_label text := btrim(p_viewer_label);
+  invite public.kanji_town_share_invites%rowtype;
+  link_id uuid;
+begin
+  if current_user_id is null then
+    raise exception 'authentication required' using errcode = '28000';
+  end if;
+  if p_token_hash is null or p_token_hash !~ '^[0-9a-f]{64}$'
+    or clean_viewer_label is null or char_length(clean_viewer_label) not between 1 and 30 then
+    raise exception 'invalid or expired invite' using errcode = 'P0002';
+  end if;
+
+  select * into invite
+  from public.kanji_town_share_invites
+  where token_hash = p_token_hash and expires_at > now()
+  for update;
+
+  if not found or invite.learner_id = current_user_id then
+    raise exception 'invalid or expired invite' using errcode = 'P0002';
+  end if;
+
+  if not exists (
+    select 1 from public.kanji_town_learning_links
+    where learner_id = invite.learner_id and viewer_id = current_user_id
+  ) and (
+    select count(*) from public.kanji_town_learning_links
+    where learner_id = invite.learner_id
+  ) >= 10 then
+    raise exception 'viewer limit reached' using errcode = '54000';
+  end if;
+
+  insert into public.kanji_town_learning_links (
+    learner_id, viewer_id, learner_label, viewer_label, viewer_role
+  ) values (
+    invite.learner_id, current_user_id, invite.learner_label, clean_viewer_label, invite.viewer_role
+  )
+  on conflict (learner_id, viewer_id) do update set
+    learner_label = excluded.learner_label,
+    viewer_label = excluded.viewer_label,
+    viewer_role = excluded.viewer_role
+  returning id into link_id;
+
+  delete from public.kanji_town_share_invites where id = invite.id;
+  return link_id;
+end;
+$$;
+
+create or replace function public.get_kanji_town_linked_reports()
+returns table (
+  link_id uuid,
+  learner_id uuid,
+  learner_label text,
+  viewer_role text,
+  report_payload jsonb,
+  updated_at timestamptz
+)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select
+    link.id,
+    link.learner_id,
+    link.learner_label,
+    link.viewer_role,
+    save.report_payload,
+    save.updated_at
+  from public.kanji_town_learning_links as link
+  left join public.kanji_town_saves as save on save.user_id = link.learner_id
+  where link.viewer_id = (select auth.uid())
+  order by link.created_at desc;
+$$;
+
+revoke all on function public.create_kanji_town_share_invite(text, text, text) from public, anon;
+revoke all on function public.claim_kanji_town_share_invite(text, text) from public, anon;
+revoke all on function public.get_kanji_town_linked_reports() from public, anon;
+grant execute on function public.create_kanji_town_share_invite(text, text, text) to authenticated;
+grant execute on function public.claim_kanji_town_share_invite(text, text) to authenticated;
+grant execute on function public.get_kanji_town_linked_reports() to authenticated;

--- a/test/cloud-client.test.js
+++ b/test/cloud-client.test.js
@@ -1,7 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
+  claimLearningShareInvite,
+  createLearningShareInvite,
   fetchCloudSave,
+  fetchLinkedLearningReports,
   getCloudConfiguration,
   updateCloudSave,
 } from '../src/systems/cloud-client.js';
@@ -16,6 +19,10 @@ function createQueryClient(result) {
     update(value) {
       calls.push(['update', value]);
       return this;
+    },
+    order(column, value) {
+      calls.push(['order', column, value]);
+      return Promise.resolve(result);
     },
     eq(column, value) {
       calls.push(['eq', column, value]);
@@ -51,7 +58,8 @@ test('クラウド読込は利用者IDで絞り込み、0件を正常に扱う',
 test('クラウド更新は利用者IDとrevisionの両方で楽観ロックする', async () => {
   const remote = { revision: 8, payload_hash: 'next' };
   const { client, calls } = createQueryClient({ data: remote, error: null });
-  const result = await updateCloudSave(client, 'user-b', 7, { totalExp: 30 }, 'next');
+  const report = { version: 1, sourceHash: 'next' };
+  const result = await updateCloudSave(client, 'user-b', 7, { totalExp: 30 }, 'next', report);
 
   assert.equal(result, remote);
   assert.ok(calls.some((call) => call[0] === 'eq' && call[1] === 'user_id' && call[2] === 'user-b'));
@@ -59,9 +67,52 @@ test('クラウド更新は利用者IDとrevisionの両方で楽観ロックす�
   const update = calls.find((call) => call[0] === 'update')[1];
   assert.equal(update.revision, 8);
   assert.equal(update.schema_version, 1);
+  assert.equal(update.report_payload, report);
 });
 
 test('revision不一致で更新対象が消えた場合は競合としてnullを返す', async () => {
   const { client } = createQueryClient({ data: null, error: null });
   assert.equal(await updateCloudSave(client, 'user-c', 2, {}, 'hash'), null);
+});
+
+test('招待の作成と引換は生コードを送らずハッシュと表示名だけをRPCへ渡す', async () => {
+  const calls = [];
+  const client = {
+    rpc(name, args) {
+      calls.push([name, args]);
+      if (name === 'create_kanji_town_share_invite') {
+        return { single: async () => ({ data: { invite_id: 'invite-1' }, error: null }) };
+      }
+      return Promise.resolve({ data: 'link-1', error: null });
+    },
+  };
+
+  await createLearningShareInvite(client, {
+    tokenHash: 'a'.repeat(64), learnerLabel: 'たろう', viewerRole: 'guardian',
+  });
+  await claimLearningShareInvite(client, 'a'.repeat(64), 'お母さん');
+
+  assert.deepEqual(calls[0], ['create_kanji_town_share_invite', {
+    p_token_hash: 'a'.repeat(64),
+    p_learner_label: 'たろう',
+    p_viewer_role: 'guardian',
+  }]);
+  assert.deepEqual(calls[1], ['claim_kanji_town_share_invite', {
+    p_token_hash: 'a'.repeat(64),
+    p_viewer_label: 'お母さん',
+  }]);
+  assert.equal(JSON.stringify(calls).includes('ABCD-EFGH'), false);
+});
+
+test('見守り側は専用RPCから要約レポートだけを取得する', async () => {
+  const calls = [];
+  const client = {
+    async rpc(name, args) {
+      calls.push([name, args]);
+      return { data: [{ learner_label: 'たろう', report_payload: { version: 1 } }], error: null };
+    },
+  };
+  const reports = await fetchLinkedLearningReports(client);
+  assert.equal(reports[0].report_payload.version, 1);
+  assert.deepEqual(calls, [['get_kanji_town_linked_reports', undefined]]);
 });

--- a/test/cloud-sharing.test.js
+++ b/test/cloud-sharing.test.js
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  encodeShareToken,
+  formatShareToken,
+  hashShareToken,
+  normalizeShareToken,
+} from '../src/systems/cloud-sharing.js';
+
+test('80bitの招待値を読み間違えにくい16文字へ変換する', () => {
+  const token = encodeShareToken(new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]));
+  assert.equal(token.length, 16);
+  assert.match(token, /^[A-HJ-NP-Z2-9]{16}$/);
+  assert.equal(formatShareToken(token).split('-').length, 4);
+});
+
+test('招待コードは空白とハイフンを除去して正規化する', () => {
+  assert.equal(normalizeShareToken('abcd-efgh-jkmn-pqrs'), 'ABCDEFGHJKMNPQRS');
+  assert.equal(normalizeShareToken('IIII-OOOO-1111-0000'), null);
+  assert.equal(normalizeShareToken('short'), null);
+});
+
+test('招待コードはSHA-256でサーバー保存用ハッシュにする', async () => {
+  const left = await hashShareToken('ABCD-EFGH-JKMN-PQRS');
+  const right = await hashShareToken('abcdefghjkmnpqrs');
+  assert.equal(left, right);
+  assert.match(left, /^[0-9a-f]{64}$/);
+});

--- a/test/learning-report.test.js
+++ b/test/learning-report.test.js
@@ -1,0 +1,58 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  attachReportSource,
+  buildLearningReport,
+  isLearningReportCurrent,
+} from '../src/systems/learning-report.js';
+
+test('見守りレポートは学習支援に必要な要約だけを含む', () => {
+  const report = buildLearningReport({
+    targetGrade: 2,
+    totalExp: 480,
+    streak: 6,
+    lastDate: '2026-07-21',
+    sessionCount: 9,
+    townMap: { secret: 't_house1' },
+    myDrills: [{ name: '非公開ドリル' }],
+    settings: { theme: 'private' },
+    kanjiStats: {
+      k1_1: { status: 'mastered', mistakes: 0, nextReview: Date.parse('2026-07-22T00:00:00Z') },
+      k1_2: { status: 'review', mistakes: 3, lapses: 1, nextReview: Date.parse('2026-07-20T00:00:00Z') },
+    },
+    daily: {
+      '2026-07-21': { reviewed: 10, attempts: 12, correct: 9, exp: 50 },
+    },
+  }, new Date('2026-07-21T12:00:00Z'));
+
+  assert.equal(report.grade, 2);
+  assert.deepEqual(report.progress, { learned: 2, mastered: 1, totalExp: 480, sessions: 9 });
+  assert.equal(report.habit.accuracy, 75);
+  assert.equal(report.support.overdueReviews, 1);
+  assert.deepEqual(report.support.weakKanjiIds, ['k1_2']);
+  assert.equal(report.townMap, undefined);
+  assert.equal(report.myDrills, undefined);
+  assert.equal(report.settings, undefined);
+  assert.equal(report.kanjiStats, undefined);
+});
+
+test('不正値を安全な既定値へ正規化する', () => {
+  const report = buildLearningReport({
+    targetGrade: 99,
+    totalExp: -10,
+    sessionCount: 'invalid',
+    lastDate: 'not-a-date',
+  }, new Date('2026-07-21T00:00:00Z'));
+
+  assert.equal(report.grade, 6);
+  assert.equal(report.progress.totalExp, 0);
+  assert.equal(report.progress.sessions, 0);
+  assert.equal(report.habit.lastLearningDate, null);
+});
+
+test('レポートが同じ学習データから生成されたか判定する', () => {
+  const report = attachReportSource(buildLearningReport({}, new Date('2026-07-21T00:00:00Z')), 'payload-hash');
+  assert.equal(isLearningReportCurrent(report, 'payload-hash'), true);
+  assert.equal(isLearningReportCurrent(report, 'new-hash'), false);
+  assert.equal(isLearningReportCurrent(null, 'payload-hash'), false);
+});

--- a/test/learning-sharing-security.test.js
+++ b/test/learning-sharing-security.test.js
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const migrationUrl = new URL('../supabase/migrations/202607210002_learning_sharing.sql', import.meta.url);
+
+test('見守り共有テーブルはRLSを有効化し匿名アクセスを拒否する', async () => {
+  const sql = await readFile(migrationUrl, 'utf8');
+  assert.match(sql, /alter table public\.kanji_town_share_invites enable row level security/i);
+  assert.match(sql, /alter table public\.kanji_town_learning_links enable row level security/i);
+  assert.match(sql, /revoke all on table public\.kanji_town_share_invites from anon, authenticated/i);
+  assert.match(sql, /revoke all on table public\.kanji_town_learning_links from anon, authenticated/i);
+});
+
+test('レポート関数は認証済み利用者にだけ実行を許可する', async () => {
+  const sql = await readFile(migrationUrl, 'utf8');
+  assert.match(sql, /security definer[\s\S]*set search_path = ''/i);
+  assert.match(sql, /revoke all on function public\.get_kanji_town_linked_reports\(\) from public, anon/i);
+  assert.match(sql, /grant execute on function public\.get_kanji_town_linked_reports\(\) to authenticated/i);
+  assert.doesNotMatch(sql, /select[\s\S]{0,200}save\.payload(?:\s|,)/i);
+});
+
+test('招待は短時間・一度限りで共有人数にも上限がある', async () => {
+  const sql = await readFile(migrationUrl, 'utf8');
+  assert.match(sql, /now\(\) \+ interval '15 minutes'/i);
+  assert.match(sql, /delete from public\.kanji_town_share_invites where id = invite\.id/i);
+  assert.match(sql, />= 10/);
+});


### PR DESCRIPTION
## 概要

アカウント・クラウド同期を基盤に、児童が保護者または教師へ学習状況だけを安全に共有できる「見守り共有」を追加します。

## 変更内容

- 設定画面に「見守り共有」を追加
  - 児童側: 表示名と共有先の種別を設定し、15分間有効な招待コードを発行
  - 保護者・教師側: 招待コードを使って連携し、学習レポートを確認
  - 双方からいつでも連携解除可能
- 学習レポートをクラウド保存時に生成・更新
  - 習得数、連続学習日数、週目標、正答率
  - 読み・書き・画数・部首の4技能
  - 復習状況とつまずき漢字
- SupabaseのRLSとRPCを使った共有基盤を追加
- スマートフォン／タブレットを含むレスポンシブ表示と44px以上の操作領域に対応
- セットアップ文書と自動テストを追加

## プライバシーと安全性

- 共有対象は学習レポートに限定し、メールアドレス、設定、町の状態、個別解答などは共有しません
- 招待コードは80-bitの乱数から生成し、サーバーにはSHA-256ハッシュだけを保存します
- 招待コードは1回限り・15分で失効します
- 児童1人あたりの共有先は最大10件です
- テーブルはRLSで保護し、権限付きRPCの実行権限はauthenticatedロールだけに限定しています

## 導入手順

既存の `202607210001_account_cloud_sync.sql` に続けて、Supabaseで次を適用してください。

```
supabase/migrations/202607210002_learning_sharing.sql
```

## 検証

- `npm test`: 58件成功
- `npm run build`: 成功（Supabase未設定／設定済み相当の両方）
- メインバンドル: 189.0 KiB / 220 KiB
- `npm audit --omit=dev`: 脆弱性0件
- `git diff --check`: 成功

## 前提

アカウント・クラウド同期の #107 はマージ済みです。このPRは最新の `main` を直接ベースにしています。
