### PR TITLE
タブレットで書き順・手書きの線が出ない問題とマップ画面の白飛びを修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <!-- Android WebView / Mi Browser等の強制ダークモードによる自動反転で
+         書き順・手書きの線が背景と同化して見えなくなるのを防ぐ -->
+    <meta name="color-scheme" content="light" />
     <meta name="theme-color" content="#ef4444" />
     <meta name="description" content="漢字を覚えて街をつくろう！小学生向け漢字学習アプリ" />
     <meta name="mobile-web-app-capable" content="yes" />

--- a/src/components/pages/HomeView.jsx
+++ b/src/components/pages/HomeView.jsx
@@ -171,7 +171,7 @@ const HomeView = ({ setView, stats, setStats, startSession, startFlashcard, star
         <DraggableTownMap mapData={stats.townMap} isDanger={isReviewNeeded} isEditing={false} reviewCount={reviewTargetsCount} villagers={stats.villagers || []} exploredRadius={stats.exploredRadius || 3} />
       </Suspense>
       {isTownEditorUnlocked && (
-        <div className="absolute bottom-2 right-2 bg-[var(--panel)]/90 backdrop-blur-sm border-[2px] border-[var(--text)] rounded-xl px-2.5 md:px-3 py-1 md:py-1.5 flex items-center gap-1.5 z-10 pointer-events-none shadow-sm">
+        <div className="absolute bottom-2 right-2 bg-[var(--panel)]/95 border-[2px] border-[var(--text)] rounded-xl px-2.5 md:px-3 py-1 md:py-1.5 flex items-center gap-1.5 z-10 pointer-events-none shadow-sm">
           <Map size={14} className="text-[var(--accent)]" />
           <span className="text-[10px] md:text-xs font-black text-[var(--text)]">タップでまちづくり</span>
         </div>

--- a/src/components/session/TestMode.jsx
+++ b/src/components/session/TestMode.jsx
@@ -6,6 +6,8 @@ import ModeLayout from '../ui/ModeLayout';
 import { FormatKun, F } from '../ui/FormatKun';
 import { audioCtrl } from '../../systems/audio';
 import { gradeStrokes } from '../../systems/strokeGrader';
+import { resolveThemeColor } from '../../utils/theme-colors';
+import { attachDrawListeners } from '../../utils/draw-pointer-events';
 
 function scoreToRecommendation(result) {
   if (!result.strokeCountMatch || !result.crossMatch) return 'again';
@@ -66,7 +68,7 @@ const TestMode = ({ kanji, strokeData, onEvaluate, canvasSize, commonSidebar, is
     currentPathRef.current = [{ x, y, time: Date.now() }];
     const ctx = canvasRef.current.getContext('2d');
     ctx.beginPath(); ctx.moveTo(x, y);
-    ctx.strokeStyle = "var(--text)"; ctx.lineWidth = canvasSize * 0.06;
+    ctx.strokeStyle = resolveThemeColor('--text'); ctx.lineWidth = canvasSize * 0.06;
     ctx.lineCap = "round"; ctx.lineJoin = "round";
   };
 
@@ -91,20 +93,18 @@ const TestMode = ({ kanji, strokeData, onEvaluate, canvasSize, commonSidebar, is
   startDrawRef.current = startDraw; drawRef.current = draw; stopDrawRef.current = stopDraw;
   useEffect(() => {
     const canvas = canvasRef.current; if (!canvas) return;
-    const onStart = (e) => startDrawRef.current(e);
-    const onMove = (e) => drawRef.current(e);
-    const onEnd = (e) => stopDrawRef.current(e);
-    canvas.addEventListener('touchstart', onStart, { passive: false });
-    canvas.addEventListener('touchmove', onMove, { passive: false });
-    canvas.addEventListener('touchend', onEnd, { passive: false });
-    return () => { canvas.removeEventListener('touchstart', onStart); canvas.removeEventListener('touchmove', onMove); canvas.removeEventListener('touchend', onEnd); };
+    return attachDrawListeners(canvas, {
+      onStart: (e) => startDrawRef.current(e),
+      onMove: (e) => drawRef.current(e),
+      onEnd: (e) => stopDrawRef.current(e),
+    });
   }, []);
 
   const redrawStrokes = (strokes) => {
     const ctx = canvasRef.current?.getContext('2d');
     if (!ctx) return;
     ctx.clearRect(0, 0, canvasSize, canvasSize);
-    ctx.strokeStyle = "var(--text)"; ctx.lineWidth = canvasSize * 0.06;
+    ctx.strokeStyle = resolveThemeColor('--text'); ctx.lineWidth = canvasSize * 0.06;
     ctx.lineCap = "round"; ctx.lineJoin = "round";
     strokes.forEach(stroke => {
       if (stroke.length < 2) return;
@@ -145,7 +145,7 @@ const TestMode = ({ kanji, strokeData, onEvaluate, canvasSize, commonSidebar, is
       <div className="relative border-[4px] border-[var(--text)] rounded-[20px] bg-[var(--panel)] overflow-hidden touch-none transition-all duration-200 shadow-[4px_4px_0_var(--text)] md:shadow-[8px_8px_0_var(--text)] shrink-0" style={{ width: canvasSize, maxWidth: showAnswer ? 'calc(50% - 16px)' : '100%', maxHeight: '100%', aspectRatio: '1/1' }}>
         <div className="absolute top-0 left-1/2 w-0 h-full border-l-4 border-dashed border-[var(--text)] opacity-10 -translate-x-1/2 pointer-events-none" />
         <div className="absolute top-1/2 left-0 w-full h-0 border-t-4 border-dashed border-[var(--text)] opacity-10 -translate-y-1/2 pointer-events-none" />
-        <canvas ref={canvasRef} onMouseDown={startDraw} onMouseMove={draw} onMouseUp={stopDraw} onMouseLeave={stopDraw} className="absolute inset-0 z-10 cursor-crosshair w-full h-full" />
+        <canvas ref={canvasRef} className="absolute inset-0 z-10 cursor-crosshair w-full h-full touch-none" />
         <div className="absolute top-3 left-3 bg-[var(--text)] text-[var(--panel)] text-[10px] md:text-xs font-bold px-3 py-1 rounded-full opacity-50 pointer-events-none">かくところ</div>
         {!showAnswer && userStrokes.length > 0 && (
           <div className="absolute bottom-3 right-3 z-20 flex gap-1.5">

--- a/src/components/session/WriteMode.jsx
+++ b/src/components/session/WriteMode.jsx
@@ -8,6 +8,8 @@ import { Analyzer } from '../../systems/analyzer';
 import { audioCtrl } from '../../systems/audio';
 import { F } from '../ui/FormatKun';
 import { STROKE_THRESHOLDS } from '../../constants/strokeConfig';
+import { resolveThemeColor } from '../../utils/theme-colors';
+import { attachDrawListeners } from '../../utils/draw-pointer-events';
 
 const WriteMode = ({ paths, strokeData, crossMatrix, onNext, onPracticeComplete, canvasSize, commonSidebar, onRecordPerfect, isStacked }) => {
   const guideRef = useRef(null); const inkRef = useRef(null); const writeRef = useRef(null);
@@ -35,7 +37,7 @@ const WriteMode = ({ paths, strokeData, crossMatrix, onNext, onPracticeComplete,
   const drawInk = useCallback(() => {
     const iCtx = inkRef.current?.getContext('2d'); if (!iCtx || !paths.length) return;
     iCtx.clearRect(0, 0, canvasSize, canvasSize);
-    if (count < 2) { iCtx.save(); iCtx.scale(canvasSize / 109, canvasSize / 109); iCtx.strokeStyle = "var(--text)"; iCtx.lineWidth = 6; iCtx.lineCap = 'round'; iCtx.lineJoin = 'round'; for (let i = 0; i < currentStroke; i++) iCtx.stroke(new Path2D(paths[i])); iCtx.restore(); } else { iCtx.save(); iCtx.lineCap = 'round'; iCtx.lineJoin = 'round'; iCtx.strokeStyle = "var(--text)"; iCtx.lineWidth = canvasSize * 0.08; userStrokes.forEach(stroke => { if (stroke.length === 0) return; iCtx.beginPath(); iCtx.moveTo(stroke[0].x, stroke[0].y); stroke.forEach(pt => iCtx.lineTo(pt.x, pt.y)); iCtx.stroke(); }); iCtx.restore(); }
+    if (count < 2) { iCtx.save(); iCtx.scale(canvasSize / 109, canvasSize / 109); iCtx.strokeStyle = resolveThemeColor('--text'); iCtx.lineWidth = 6; iCtx.lineCap = 'round'; iCtx.lineJoin = 'round'; for (let i = 0; i < currentStroke; i++) iCtx.stroke(new Path2D(paths[i])); iCtx.restore(); } else { iCtx.save(); iCtx.lineCap = 'round'; iCtx.lineJoin = 'round'; iCtx.strokeStyle = resolveThemeColor('--text'); iCtx.lineWidth = canvasSize * 0.08; userStrokes.forEach(stroke => { if (stroke.length === 0) return; iCtx.beginPath(); iCtx.moveTo(stroke[0].x, stroke[0].y); stroke.forEach(pt => iCtx.lineTo(pt.x, pt.y)); iCtx.stroke(); }); iCtx.restore(); }
   }, [paths, currentStroke, count, userStrokes, canvasSize]);
 
   useEffect(() => { drawGuide(); drawInk(); }, [drawGuide, drawInk]);
@@ -56,7 +58,7 @@ const WriteMode = ({ paths, strokeData, crossMatrix, onNext, onPracticeComplete,
     const { x, y } = getCoords(e); const target = strokeData[currentStrokeRef.current].s;
     if (Math.hypot(x / canvasSize - target.x, y / canvasSize - target.y) > STROKE_THRESHOLDS.START_POINT) { setStatusMsg("かきはじめが ちがうよ💦"); audioCtrl.playSE('stamp_bad'); return; }
     setStatusMsg(`${currentStrokeRef.current + 1}かくめ なぞり中...`); setIsDrawing(true); lastPos.current = { x, y }; currentPathRef.current = [{ x, y, time: Date.now() }];
-    const ctx = writeRef.current.getContext('2d'); ctx.lineCap = 'round'; ctx.lineJoin = 'round'; ctx.lineWidth = canvasSize * 0.08; ctx.strokeStyle = "var(--secondary)"; ctx.beginPath(); ctx.moveTo(x, y); ctx.lineTo(x, y); ctx.stroke();
+    const ctx = writeRef.current.getContext('2d'); ctx.lineCap = 'round'; ctx.lineJoin = 'round'; ctx.lineWidth = canvasSize * 0.08; ctx.strokeStyle = resolveThemeColor('--secondary'); ctx.beginPath(); ctx.moveTo(x, y); ctx.lineTo(x, y); ctx.stroke();
   };
   const handleMove = (e) => {
     e.preventDefault(); if (!isDrawingRef.current) return;
@@ -96,13 +98,11 @@ const WriteMode = ({ paths, strokeData, crossMatrix, onNext, onPracticeComplete,
   handleStartRef.current = handleStart; handleMoveRef.current = handleMove; handleEndRef.current = handleEnd;
   useEffect(() => {
     const canvas = writeRef.current; if (!canvas) return;
-    const onStart = (e) => handleStartRef.current(e);
-    const onMove = (e) => handleMoveRef.current(e);
-    const onEnd = (e) => handleEndRef.current(e);
-    canvas.addEventListener('touchstart', onStart, { passive: false });
-    canvas.addEventListener('touchmove', onMove, { passive: false });
-    canvas.addEventListener('touchend', onEnd, { passive: false });
-    return () => { canvas.removeEventListener('touchstart', onStart); canvas.removeEventListener('touchmove', onMove); canvas.removeEventListener('touchend', onEnd); };
+    return attachDrawListeners(canvas, {
+      onStart: (e) => handleStartRef.current(e),
+      onMove: (e) => handleMoveRef.current(e),
+      onEnd: (e) => handleEndRef.current(e),
+    });
   }, []);
 
   const main = (
@@ -110,7 +110,7 @@ const WriteMode = ({ paths, strokeData, crossMatrix, onNext, onPracticeComplete,
       <Confetti active={showConfetti} />
       <AnimatePresence>{floatingTexts.map(ft => (<motion.div key={ft.id} initial={{ opacity: 1, y: ft.y, x: ft.x, scale: 0.5 * ft.scale }} animate={{ opacity: 0, y: ft.y - 40 * ft.scale, scale: 1.2 * ft.scale }} exit={{ opacity: 0 }} transition={{ duration: 0.8, ease: "easeOut" }} className="absolute z-50 font-black pointer-events-none drop-shadow-md whitespace-nowrap -translate-x-1/2 -translate-y-1/2" style={{ color: ft.color, fontSize: '24px' }}>{ft.text}</motion.div>))}</AnimatePresence>
       <div className="absolute top-0 left-1/2 w-0 h-full border-l-4 border-dashed border-[var(--text)] opacity-10 -translate-x-1/2 pointer-events-none" /><div className="absolute top-1/2 left-0 w-full h-0 border-t-4 border-dashed border-[var(--text)] opacity-10 -translate-y-1/2 pointer-events-none" />
-      <canvas ref={guideRef} className="absolute inset-0 z-0 pointer-events-none w-full h-full" /><canvas ref={inkRef} className="absolute inset-0 z-10 pointer-events-none w-full h-full" /><canvas ref={writeRef} onMouseDown={handleStart} onMouseMove={handleMove} onMouseUp={handleEnd} onMouseLeave={handleEnd} className="absolute inset-0 z-20 cursor-crosshair w-full h-full" />
+      <canvas ref={guideRef} className="absolute inset-0 z-0 pointer-events-none w-full h-full" /><canvas ref={inkRef} className="absolute inset-0 z-10 pointer-events-none w-full h-full" /><canvas ref={writeRef} className="absolute inset-0 z-20 cursor-crosshair w-full h-full touch-none" />
     </div>
   );
 

--- a/src/components/town/DraggableTownMap.jsx
+++ b/src/components/town/DraggableTownMap.jsx
@@ -566,15 +566,17 @@ const DraggableTownMap = ({ mapData, isDanger, isEditing, onCellTap, reviewCount
       className={`w-full h-full rounded-[16px] overflow-hidden transition-all duration-1000 ${isDanger && !isEditing ? 'bg-slate-900' : 'bg-sky-200'} border-[3px] border-[var(--text)] shadow-inner relative touch-none`}
       style={{ opacity: initialFitDone ? 1 : 0 }}>
       {/* --- 時間帯レイヤー（オーバーレイ） --- */}
-      <div 
-        className="absolute inset-0 z-20 pointer-events-none transition-colors duration-[3000ms]"
-        style={{
-          backgroundColor: timeOfDay === 'evening' ? 'rgba(234, 88, 12, 0.2)' : 
-                           timeOfDay === 'night'   ? 'rgba(15, 23, 42, 0.45)' : 
-                           'transparent',
-          mixBlendMode: timeOfDay === 'evening' ? 'overlay' : 'multiply'
-        }}
-      />
+      {/* 昼間は描画しない: 透明でもmix-blend-modeがあるとマップ全体の
+          オフスクリーン合成が常時走り、タブレットGPUの白飛びの一因になる */}
+      {timeOfDay !== 'day' && (
+        <div
+          className="absolute inset-0 z-20 pointer-events-none transition-colors duration-[3000ms]"
+          style={{
+            backgroundColor: timeOfDay === 'evening' ? 'rgba(234, 88, 12, 0.2)' : 'rgba(15, 23, 42, 0.45)',
+            mixBlendMode: timeOfDay === 'evening' ? 'overlay' : 'multiply'
+          }}
+        />
+      )}
       {/* --------------------------------- */}
 
       {/* 天候アイコン */}

--- a/src/components/town/TownEditorView.jsx
+++ b/src/components/town/TownEditorView.jsx
@@ -396,6 +396,9 @@ const TownEditorView = ({ setView, stats, setStats, onCraft, onPlace }) => {
 
   return (
     <div className="relative w-full h-full overflow-hidden bg-[var(--bg)]">
+      {/* 注: この画面ではbackdrop-blur(backdrop-filter)を使わない。
+          巨大なマップ合成レイヤーと重なると一部AndroidタブレットのGPUで
+          画面全体が白飛びすることがある */}
       {/* === フルスクリーンマップ === */}
       <div className="absolute inset-0" style={{ bottom: 72 }}>
         <DraggableTownMap mapData={localMap} isDanger={false} isEditing={true} onCellTap={handleCellTap} reviewCount={0} villagers={stats.villagers || []} exploredRadius={stats.exploredRadius || 3} />
@@ -408,17 +411,17 @@ const TownEditorView = ({ setView, stats, setStats, onCraft, onPlace }) => {
       {/* === ヘッダーバー（オーバーレイ） === */}
       <div className="absolute top-0 left-0 right-0 z-40 flex items-center justify-between p-2 pointer-events-none">
         <div className="flex items-center gap-2 pointer-events-auto">
-          <button onClick={() => setView('home')} aria-label="ホームに戻る" className="bg-[var(--panel)]/90 backdrop-blur text-[var(--text)] p-2.5 rounded-full border-[2px] border-[var(--text)] shadow-md hover:scale-105 transition-transform min-w-[44px] min-h-[44px] flex items-center justify-center"><ArrowLeft size={20} /></button>
+          <button onClick={() => setView('home')} aria-label="ホームに戻る" className="bg-[var(--panel)] text-[var(--text)] p-2.5 rounded-full border-[2px] border-[var(--text)] shadow-md hover:scale-105 transition-transform min-w-[44px] min-h-[44px] flex items-center justify-center"><ArrowLeft size={20} /></button>
         </div>
         <div className="flex items-center gap-2 pointer-events-auto">
-          <span className="flex items-center gap-1 bg-[var(--accent)]/90 backdrop-blur px-3 py-1.5 rounded-full text-[var(--text)] border-[2px] border-[var(--text)] font-black text-sm shadow-md"><Coins size={14} />{stats.coins}</span>
-          <button onClick={handleUndo} disabled={historyIdx <= 0} aria-label="元に戻す" className={`bg-[var(--panel)]/90 backdrop-blur p-2 rounded-full border-[2px] border-[var(--text)] shadow-md min-w-[40px] min-h-[40px] flex items-center justify-center transition-all ${historyIdx <= 0 ? 'opacity-30' : 'hover:scale-105'}`}><Undo2 size={16} /></button>
-          <MotionButton variant="success" onClick={handleSave} className="px-4 py-2 text-sm border-[2px] border-[var(--text)] shadow-[0_2px_0_#065f46] backdrop-blur min-h-[40px]">保存</MotionButton>
+          <span className="flex items-center gap-1 bg-[var(--accent)] px-3 py-1.5 rounded-full text-[var(--text)] border-[2px] border-[var(--text)] font-black text-sm shadow-md"><Coins size={14} />{stats.coins}</span>
+          <button onClick={handleUndo} disabled={historyIdx <= 0} aria-label="元に戻す" className={`bg-[var(--panel)] p-2 rounded-full border-[2px] border-[var(--text)] shadow-md min-w-[40px] min-h-[40px] flex items-center justify-center transition-all ${historyIdx <= 0 ? 'opacity-30' : 'hover:scale-105'}`}><Undo2 size={16} /></button>
+          <MotionButton variant="success" onClick={handleSave} className="px-4 py-2 text-sm border-[2px] border-[var(--text)] shadow-[0_2px_0_#065f46] min-h-[40px]">保存</MotionButton>
         </div>
       </div>
 
       {/* === 情報オーバーレイ === */}
-      <div className="absolute top-16 left-2 bg-[var(--panel)]/90 backdrop-blur border-[2px] border-[var(--text)] rounded-xl px-3 py-1.5 text-xs font-bold text-[var(--text)] pointer-events-none z-40">
+      <div className="absolute top-16 left-2 bg-[var(--panel)]/95 border-[2px] border-[var(--text)] rounded-xl px-3 py-1.5 text-xs font-bold text-[var(--text)] pointer-events-none z-40">
         {F("地形","ちけい")}タップで{F("開拓","かいたく")}　👥{stats.population || 0}{F("人","にん")}　{satLabel.emoji}{satisfaction}
       </div>
 
@@ -435,7 +438,7 @@ const TownEditorView = ({ setView, stats, setStats, onCraft, onPlace }) => {
           <motion.div initial={{ y: 20, opacity: 0 }} animate={{ y: 0, opacity: 1 }} exit={{ y: 20, opacity: 0 }}
             className="absolute z-40 left-1/2 -translate-x-1/2 pointer-events-none"
             style={{ bottom: 84 }}>
-            <div className="bg-[var(--panel)]/90 backdrop-blur border-[2px] border-[var(--text)] rounded-full px-4 py-1.5 shadow-md font-bold text-xs flex items-center gap-1.5 whitespace-nowrap text-[var(--text)] opacity-90">
+            <div className="bg-[var(--panel)]/95 border-[2px] border-[var(--text)] rounded-full px-4 py-1.5 shadow-md font-bold text-xs flex items-center gap-1.5 whitespace-nowrap text-[var(--text)] opacity-90">
               💡 アイテムをタップして{F("移動","いどう")}・{F("再配置","さいはいち")}
             </div>
           </motion.div>
@@ -448,7 +451,7 @@ const TownEditorView = ({ setView, stats, setStats, onCraft, onPlace }) => {
           <motion.div initial={{ y: 20, opacity: 0 }} animate={{ y: 0, opacity: 1 }} exit={{ y: 20, opacity: 0 }}
             className="absolute z-40 left-1/2 -translate-x-1/2"
             style={{ bottom: dockOpen ? 'calc(50% + 44px)' : 84 }}>
-            <div className="bg-[var(--panel)]/95 backdrop-blur border-[3px] border-[var(--text)] rounded-full px-4 py-2 shadow-lg font-bold text-sm flex items-center gap-2 whitespace-nowrap">
+            <div className="bg-[var(--panel)] border-[3px] border-[var(--text)] rounded-full px-4 py-2 shadow-lg font-bold text-sm flex items-center gap-2 whitespace-nowrap">
               {selectedItem === 'eraser' ? <><Eraser size={16} /> けしゴムモード</> : <>{TOWN_ITEMS.find(i => i.id === selectedItem)?.name} を{F("配置中","はいちちゅう")}</>}
               <button onClick={() => setSelectedItem(null)} aria-label="選択解除" className="ml-1 text-[var(--text)] opacity-50 hover:opacity-100 text-lg leading-none w-6 h-6 flex items-center justify-center">✕</button>
             </div>
@@ -511,7 +514,7 @@ const TownEditorView = ({ setView, stats, setStats, onCraft, onPlace }) => {
 
       {/* === ボトムドック（マイクラ風ホットバー） === */}
       <div className="absolute bottom-0 left-0 right-0 z-50 flex items-end justify-center pb-3 px-4 pointer-events-none">
-        <div className="pointer-events-auto flex items-center gap-3 bg-[var(--panel)]/95 backdrop-blur border-[4px] border-[var(--text)] rounded-[20px] px-4 py-2 shadow-[4px_4px_0_var(--text)]">
+        <div className="pointer-events-auto flex items-center gap-3 bg-[var(--panel)] border-[4px] border-[var(--text)] rounded-[20px] px-4 py-2 shadow-[4px_4px_0_var(--text)]">
           <button onClick={() => toggleDock('items')}
             className={`flex flex-col items-center gap-0.5 px-4 py-2 rounded-xl transition-all min-w-[64px] ${dockOpen === 'items' ? 'bg-[var(--accent)] scale-110 shadow-lg' : 'hover:bg-[var(--bg)] hover:scale-105'}`}>
             <Package size={24} className="text-[var(--text)]" />

--- a/src/components/training/BossBattleView.jsx
+++ b/src/components/training/BossBattleView.jsx
@@ -7,6 +7,7 @@ import { FormatKun, F } from '../ui/FormatKun';
 import { gradeStrokes } from '../../systems/strokeGrader';
 import { fetchKanjiVg } from '../../systems/kanjiVg';
 import { RefreshCw, Swords, Shield } from 'lucide-react';
+import { attachDrawListeners } from '../../utils/draw-pointer-events';
 
 const PLAYER_MAX_HP = 3;
 const BOSS_MAX_HP = 10;
@@ -114,13 +115,11 @@ const BossBattleCanvas = ({ strokeData, paths, canvasSize, onSubmit, disabled })
   handleStartRef.current = handleStart; handleMoveRef.current = handleMove; handleEndRef.current = handleEnd;
   useEffect(() => {
     const canvas = writeRef.current; if (!canvas) return;
-    const onStart = (e) => handleStartRef.current(e);
-    const onMove = (e) => handleMoveRef.current(e);
-    const onEnd = (e) => handleEndRef.current(e);
-    canvas.addEventListener('touchstart', onStart, { passive: false });
-    canvas.addEventListener('touchmove', onMove, { passive: false });
-    canvas.addEventListener('touchend', onEnd, { passive: false });
-    return () => { canvas.removeEventListener('touchstart', onStart); canvas.removeEventListener('touchmove', onMove); canvas.removeEventListener('touchend', onEnd); };
+    return attachDrawListeners(canvas, {
+      onStart: (e) => handleStartRef.current(e),
+      onMove: (e) => handleMoveRef.current(e),
+      onEnd: (e) => handleEndRef.current(e),
+    });
   }, []);
 
   const handleClear = () => {
@@ -143,7 +142,7 @@ const BossBattleCanvas = ({ strokeData, paths, canvasSize, onSubmit, disabled })
         <div className="absolute top-0 left-1/2 w-0 h-full border-l-2 border-dashed border-slate-700 -translate-x-1/2 pointer-events-none" />
         <div className="absolute top-1/2 left-0 w-full h-0 border-t-2 border-dashed border-slate-700 -translate-y-1/2 pointer-events-none" />
         <canvas ref={inkRef} className="absolute inset-0 z-10 pointer-events-none w-full h-full" />
-        <canvas ref={writeRef} onMouseDown={handleStart} onMouseMove={handleMove} onMouseUp={handleEnd} onMouseLeave={handleEnd} className="absolute inset-0 z-20 cursor-crosshair w-full h-full" />
+        <canvas ref={writeRef} className="absolute inset-0 z-20 cursor-crosshair w-full h-full touch-none" />
         {disabled && (
           <div className="absolute inset-0 z-30 bg-black/50 flex items-center justify-center">
             <span className="text-white font-black text-lg">{F("判定中","はんていちゅう")}...</span>

--- a/src/components/training/DrillTestView.jsx
+++ b/src/components/training/DrillTestView.jsx
@@ -8,6 +8,8 @@ import { gradeStrokes } from '../../systems/strokeGrader';
 import { fetchKanjiVg } from '../../systems/kanjiVg';
 import { TEST } from '../../constants/gameConfig';
 import { getSatisfactionMultiplier, calculateSatisfaction } from '../../systems/residents';
+import { resolveThemeColor } from '../../utils/theme-colors';
+import { attachDrawListeners } from '../../utils/draw-pointer-events';
 
 const WRITING_SKILLS = { skills: ['writing', 'stroke'] };
 
@@ -43,7 +45,7 @@ const TestCanvas = ({ strokeData, canvasSize, onSubmit, disabled }) => {
     ctx.clearRect(0, 0, canvasSize, canvasSize);
     ctx.lineCap = 'round';
     ctx.lineJoin = 'round';
-    ctx.strokeStyle = 'var(--text, #292f36)';
+    ctx.strokeStyle = resolveThemeColor('--text');
     ctx.lineWidth = canvasSize * 0.07;
     strokes.forEach(stroke => {
       if (stroke.length === 0) return;
@@ -79,7 +81,7 @@ const TestCanvas = ({ strokeData, canvasSize, onSubmit, disabled }) => {
     ctx.lineCap = 'round';
     ctx.lineJoin = 'round';
     ctx.lineWidth = canvasSize * 0.07;
-    ctx.strokeStyle = 'var(--text, #292f36)';
+    ctx.strokeStyle = resolveThemeColor('--text');
     ctx.beginPath();
     ctx.moveTo(x, y);
     ctx.lineTo(x, y);
@@ -117,13 +119,11 @@ const TestCanvas = ({ strokeData, canvasSize, onSubmit, disabled }) => {
   useEffect(() => {
     const canvas = writeRef.current;
     if (!canvas) return;
-    const onStart = (e) => handleStartRef.current(e);
-    const onMove = (e) => handleMoveRef.current(e);
-    const onEnd = (e) => handleEndRef.current(e);
-    canvas.addEventListener('touchstart', onStart, { passive: false });
-    canvas.addEventListener('touchmove', onMove, { passive: false });
-    canvas.addEventListener('touchend', onEnd, { passive: false });
-    return () => { canvas.removeEventListener('touchstart', onStart); canvas.removeEventListener('touchmove', onMove); canvas.removeEventListener('touchend', onEnd); };
+    return attachDrawListeners(canvas, {
+      onStart: (e) => handleStartRef.current(e),
+      onMove: (e) => handleMoveRef.current(e),
+      onEnd: (e) => handleEndRef.current(e),
+    });
   }, []);
 
   const handleClear = () => {
@@ -158,7 +158,7 @@ const TestCanvas = ({ strokeData, canvasSize, onSubmit, disabled }) => {
         <div className="absolute top-0 left-1/2 w-0 h-full border-l-2 border-dashed border-[var(--text)] opacity-10 -translate-x-1/2 pointer-events-none" />
         <div className="absolute top-1/2 left-0 w-full h-0 border-t-2 border-dashed border-[var(--text)] opacity-10 -translate-y-1/2 pointer-events-none" />
         <canvas ref={inkRef} className="absolute inset-0 z-10 pointer-events-none w-full h-full" />
-        <canvas ref={writeRef} onMouseDown={handleStart} onMouseMove={handleMove} onMouseUp={handleEnd} onMouseLeave={handleEnd} className="absolute inset-0 z-20 cursor-crosshair w-full h-full" />
+        <canvas ref={writeRef} className="absolute inset-0 z-20 cursor-crosshair w-full h-full touch-none" />
         {disabled && <div className="absolute inset-0 z-30 bg-black/30 flex items-center justify-center" />}
       </div>
 

--- a/src/components/training/SurvivalView.jsx
+++ b/src/components/training/SurvivalView.jsx
@@ -6,6 +6,8 @@ import { audioCtrl } from '../../systems/audio';
 import { F, SurvivalRubyText, FormatKun } from '../ui/FormatKun';
 import { gradeStrokes } from '../../systems/strokeGrader';
 import { fetchKanjiVg } from '../../systems/kanjiVg';
+import { resolveThemeColor } from '../../utils/theme-colors';
+import { attachDrawListeners } from '../../utils/draw-pointer-events';
 
 const WAVE_SIZE = 10;
 const INITIAL_TIME = 45;
@@ -55,7 +57,7 @@ const SurvivalCanvas = ({ strokeData, canvasSize, onSubmit, disabled }) => {
     ctx.clearRect(0, 0, canvasSize, canvasSize);
     ctx.lineCap = 'round';
     ctx.lineJoin = 'round';
-    ctx.strokeStyle = 'var(--text, #292f36)';
+    ctx.strokeStyle = resolveThemeColor('--text');
     ctx.lineWidth = canvasSize * 0.07;
     strokes.forEach(stroke => {
       if (stroke.length === 0) return;
@@ -89,7 +91,7 @@ const SurvivalCanvas = ({ strokeData, canvasSize, onSubmit, disabled }) => {
     ctx.lineCap = 'round';
     ctx.lineJoin = 'round';
     ctx.lineWidth = canvasSize * 0.07;
-    ctx.strokeStyle = 'var(--text, #292f36)';
+    ctx.strokeStyle = resolveThemeColor('--text');
     ctx.beginPath();
     ctx.moveTo(x, y);
     ctx.lineTo(x, y);
@@ -123,13 +125,11 @@ const SurvivalCanvas = ({ strokeData, canvasSize, onSubmit, disabled }) => {
   handleStartRef.current = handleStart; handleMoveRef.current = handleMove; handleEndRef.current = handleEnd;
   useEffect(() => {
     const canvas = writeRef.current; if (!canvas) return;
-    const onStart = (e) => handleStartRef.current(e);
-    const onMove = (e) => handleMoveRef.current(e);
-    const onEnd = (e) => handleEndRef.current(e);
-    canvas.addEventListener('touchstart', onStart, { passive: false });
-    canvas.addEventListener('touchmove', onMove, { passive: false });
-    canvas.addEventListener('touchend', onEnd, { passive: false });
-    return () => { canvas.removeEventListener('touchstart', onStart); canvas.removeEventListener('touchmove', onMove); canvas.removeEventListener('touchend', onEnd); };
+    return attachDrawListeners(canvas, {
+      onStart: (e) => handleStartRef.current(e),
+      onMove: (e) => handleMoveRef.current(e),
+      onEnd: (e) => handleEndRef.current(e),
+    });
   }, []);
 
   const handleClear = () => {
@@ -167,7 +167,7 @@ const SurvivalCanvas = ({ strokeData, canvasSize, onSubmit, disabled }) => {
         <div className="absolute top-0 left-1/2 w-0 h-full border-l-2 border-dashed border-[var(--text)] opacity-10 -translate-x-1/2 pointer-events-none" />
         <div className="absolute top-1/2 left-0 w-full h-0 border-t-2 border-dashed border-[var(--text)] opacity-10 -translate-y-1/2 pointer-events-none" />
         <canvas ref={inkRef} className="absolute inset-0 z-10 pointer-events-none w-full h-full" />
-        <canvas ref={writeRef} onMouseDown={handleStart} onMouseMove={handleMove} onMouseUp={handleEnd} onMouseLeave={handleEnd} className="absolute inset-0 z-20 cursor-crosshair w-full h-full" />
+        <canvas ref={writeRef} className="absolute inset-0 z-20 cursor-crosshair w-full h-full touch-none" />
         {disabled && (
           <div className="absolute inset-0 z-30 bg-black/30 flex items-center justify-center" />
         )}

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,9 @@
 @import "tailwindcss";
 
 :root {
+  /* 端末の強制ダークモード（自動暗色化）を無効化。
+     暗色化されるとキャンバスの手書き線やSVGの書き順線が背景に沈んで見えなくなる */
+  color-scheme: only light;
   --bg: #fdfbf7;
   --primary: #ef4444;
   --secondary: #10b981;

--- a/src/utils/draw-pointer-events.js
+++ b/src/utils/draw-pointer-events.js
@@ -1,0 +1,61 @@
+/**
+ * 手書きキャンバスへ入力リスナーを取り付ける。
+ *
+ * Pointer Events対応環境ではペン・指・マウスを統一して扱う。
+ * 一部のAndroidタブレット（スタイラス入力）はtouchイベントを発火しないため、
+ * touch/mouseイベントだけに頼ると線が一切描けなくなる。
+ * 非対応の古い環境ではtouch+mouseへフォールバックする。
+ *
+ * @param {HTMLCanvasElement} canvas
+ * @param {{ onStart: Function, onMove: Function, onEnd: Function }} handlers
+ * @returns {() => void} リスナー解除関数
+ */
+export function attachDrawListeners(canvas, { onStart, onMove, onEnd }) {
+  if (typeof window !== 'undefined' && window.PointerEvent) {
+    // 描画中のポインターIDを記録し、2本目以降の指や別ポインターを無視する
+    let activePointerId = null;
+    const handleDown = (e) => {
+      if (activePointerId !== null) return;
+      activePointerId = e.pointerId;
+      // キャンバス外へはみ出してもストロークを追跡し続ける
+      try { canvas.setPointerCapture(e.pointerId); } catch { /* 非対応環境は無視 */ }
+      onStart(e);
+    };
+    const handleMove = (e) => {
+      if (e.pointerId !== activePointerId) return;
+      onMove(e);
+    };
+    const handleUp = (e) => {
+      if (e.pointerId !== activePointerId) return;
+      activePointerId = null;
+      onEnd(e);
+    };
+    canvas.addEventListener('pointerdown', handleDown);
+    canvas.addEventListener('pointermove', handleMove);
+    canvas.addEventListener('pointerup', handleUp);
+    canvas.addEventListener('pointercancel', handleUp);
+    return () => {
+      canvas.removeEventListener('pointerdown', handleDown);
+      canvas.removeEventListener('pointermove', handleMove);
+      canvas.removeEventListener('pointerup', handleUp);
+      canvas.removeEventListener('pointercancel', handleUp);
+    };
+  }
+
+  canvas.addEventListener('touchstart', onStart, { passive: false });
+  canvas.addEventListener('touchmove', onMove, { passive: false });
+  canvas.addEventListener('touchend', onEnd, { passive: false });
+  canvas.addEventListener('mousedown', onStart);
+  canvas.addEventListener('mousemove', onMove);
+  canvas.addEventListener('mouseup', onEnd);
+  canvas.addEventListener('mouseleave', onEnd);
+  return () => {
+    canvas.removeEventListener('touchstart', onStart);
+    canvas.removeEventListener('touchmove', onMove);
+    canvas.removeEventListener('touchend', onEnd);
+    canvas.removeEventListener('mousedown', onStart);
+    canvas.removeEventListener('mousemove', onMove);
+    canvas.removeEventListener('mouseup', onEnd);
+    canvas.removeEventListener('mouseleave', onEnd);
+  };
+}

--- a/src/utils/theme-colors.js
+++ b/src/utils/theme-colors.js
@@ -1,0 +1,29 @@
+// Canvas 2D API は "var(--text)" のようなCSS変数を色として解釈できず、
+// 無効な色指定は無視されて直前の色（既定は黒）のまま描画される。
+// キャンバスに描く前に必ずここで実際の色文字列へ解決する。
+const THEME_COLOR_FALLBACKS = {
+  '--bg': '#fdfbf7',
+  '--primary': '#ef4444',
+  '--secondary': '#10b981',
+  '--accent': '#fbbf24',
+  '--text': '#292f36',
+  '--panel': '#ffffff',
+};
+
+/**
+ * CSS変数名（例: '--text'）をキャンバスで使える具体的な色文字列に解決する
+ * @param {string} variableName - CSS変数名
+ * @returns {string} 色文字列
+ */
+export function resolveThemeColor(variableName) {
+  const fallback = THEME_COLOR_FALLBACKS[variableName] || '#292f36';
+  if (typeof document === 'undefined') return fallback;
+  try {
+    const value = getComputedStyle(document.documentElement)
+      .getPropertyValue(variableName)
+      .trim();
+    return value || fallback;
+  } catch {
+    return fallback;
+  }
+}

--- a/test/theme-colors.test.js
+++ b/test/theme-colors.test.js
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveThemeColor } from '../src/utils/theme-colors.js';
+
+test('DOMがない環境では既定のテーマ色にフォールバックする', () => {
+  assert.equal(resolveThemeColor('--text'), '#292f36');
+  assert.equal(resolveThemeColor('--secondary'), '#10b981');
+  assert.equal(resolveThemeColor('--bg'), '#fdfbf7');
+});
+
+test('未知の変数名でもキャンバスで使える色を返す', () => {
+  assert.equal(resolveThemeColor('--unknown-variable'), '#292f36');
+});


### PR DESCRIPTION
- キャンバス描画色にCSS変数(var(--text)等)を直接指定していたため、
  Canvas 2D APIでは無効値となり意図した色で描けていなかった。
  getComputedStyleで実際の色へ解決するresolveThemeColorを導入
- touch/mouseイベントのみの手書き入力をPointer Eventsへ移行。
  スタイラス入力がtouchイベントを発火しないAndroidタブレットでも
  なぞり書き・テスト・サバイバル・ボスバトル・ドリルで描けるように
  (attachDrawListenersに共通化、ポインターキャプチャと多点タッチ抑止付き)
- color-scheme: light を宣言し、端末の強制ダークモードによる
  自動反転で線が背景に沈むのを防止
- マップ画面のbackdrop-blurを除去し、昼間の時間帯オーバーレイの
  mix-blend-mode常時合成をやめてGPU負荷を軽減
  (一部AndroidタブレットのGPUで画面全体が白飛びする既知パターン対策)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FQDnupugmyYZUvaK6HRbx1