### PR TITLE
lazyビュー読み込み時のホワイトアウトを修正

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo, useRef, lazy, Suspense } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, useRef, lazy } from 'react';
 import { AnimatePresence, MotionConfig } from 'framer-motion';
 import { PenTool, Volume2, VolumeX, Settings, Users } from 'lucide-react';
 import { useOnlineStatus } from './hooks/useOnlineStatus';
@@ -66,16 +66,6 @@ import TutorialOverlay from './components/tutorial/TutorialOverlay';
 import LoginBonusPopup from './components/tutorial/LoginBonusPopup';
 import ResidentCollectionPopup from './components/tutorial/ResidentCollectionPopup';
 import FeatureHint from './components/tutorial/FeatureHint';
-
-// ローディングスピナー
-const LazyFallback = () => (
-  <div className="flex items-center justify-center h-full" role="status" aria-label="読み込み中">
-    <div className="text-center">
-      <div className="w-10 h-10 border-4 border-[var(--primary)] border-t-transparent rounded-full animate-spin mx-auto mb-3" aria-hidden="true" />
-      <div className="text-sm font-bold text-[var(--text)] opacity-50">よみこみ中...</div>
-    </div>
-  </div>
-);
 
 // テーマ別CSS変数（コンポーネント外に定義して再マウントを防ぐ）
 const THEME_VARS = {
@@ -804,7 +794,9 @@ export default function App() {
       )}
 
       <main className="flex-grow relative overflow-hidden p-0 md:p-4 min-h-0">
-        <Suspense fallback={<LazyFallback />}>
+        {/* Suspense境界はPageWrapper/FullScreenWrapper内部にある。
+            AnimatePresenceの外側でサスペンドを捕捉するとツリー全体が
+            非表示化されて遷移状態が壊れ、ホワイトアウトするため。 */}
         <AnimatePresence mode="wait">
           {view === 'home' && <PageWrapper key="home" wide><ErrorBoundary onReset={() => setView('home')}><HomeView setView={setView} stats={stats} setStats={setStats} startSession={startSession} startFlashcard={startFlashcard} startSurvival={startSurvival} startBossBattle={startBossBattle} levelInfo={levelInfo} dailyMissions={dailyMissions} onClaimMission={handleClaimMission} isMobile={isMobile} /></ErrorBoundary></PageWrapper>}
           {view === 'dictionary' && <PageWrapper key="dict" wide><ErrorBoundary onReset={() => setView('home')}><FeatureHint featureKey="dictionary" seenHints={seenHints} onDismiss={handleDismissHint} /><DictionaryView kanjiStats={stats.kanjiStats} onBack={() => setView('home')} onSelectKanji={startSingleSession} /></ErrorBoundary></PageWrapper>}
@@ -844,7 +836,6 @@ export default function App() {
           {view === 'drillTest' && <FullScreenWrapper key="drillTest"><ErrorBoundary onReset={() => setView('home')}><DrillTestView queue={sessionData.queue} stats={stats} onUpdateStat={handleUpdateStat} onFinish={handleFinishSession} startDrillSession={startDrillSession} setView={setView} setSessionData={setSessionData} createInitialSessionData={createInitialSessionData} /></ErrorBoundary></FullScreenWrapper>}
           {view === 'result' && <PageWrapper key="result"><ErrorBoundary onReset={() => setView('home')}><ResultView sessionMetrics={sessionData} oldExp={sessionData.oldExp} setView={setView} stats={stats} setStats={setStats} onContinueLearning={() => startSession(stats.targetGrade || 1)} /></ErrorBoundary></PageWrapper>}
         </AnimatePresence>
-        </Suspense>
       </main>
       {/* モバイルボトムナビ（ホーム画面のみ表示） */}
       {isMobile && view === 'home' && (

--- a/src/components/ui/PageWrapper.jsx
+++ b/src/components/ui/PageWrapper.jsx
@@ -1,6 +1,20 @@
+import { Suspense } from 'react';
 import { motion } from 'framer-motion';
 
-const PageWrapper = ({ children, keyName, wide }) => (<motion.div key={keyName} initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: -20 }} transition={{ duration: 0.25 }} className={`absolute inset-0 flex flex-col overflow-y-auto overflow-x-hidden p-2 md:p-4 no-scrollbar ${wide ? '' : ''}`}><div className={`m-auto w-full h-full ${wide ? 'max-w-7xl' : 'max-w-lg'}`}>{children}</div></motion.div>);
-const FullScreenWrapper = ({ children, keyName }) => (<motion.div key={keyName} initial={{ opacity: 0, scale: 0.98 }} animate={{ opacity: 1, scale: 1 }} exit={{ opacity: 0, scale: 0.98 }} transition={{ duration: 0.25 }} className="absolute inset-0 flex flex-col p-0 md:p-6 overflow-hidden safe-area-screen"><div className="w-full h-full max-w-7xl mx-auto flex flex-col">{children}</div></motion.div>);
+// lazyビューの読み込み中スピナー
+const LazyFallback = () => (
+  <div className="flex items-center justify-center h-full" role="status" aria-label="読み込み中">
+    <div className="text-center">
+      <div className="w-10 h-10 border-4 border-[var(--primary)] border-t-transparent rounded-full animate-spin mx-auto mb-3" aria-hidden="true" />
+      <div className="text-sm font-bold text-[var(--text)] opacity-50">よみこみ中...</div>
+    </div>
+  </div>
+);
+
+// Suspense境界はmotion.divの内側に置く。外側(AnimatePresenceの上)に置くと、
+// lazyビューのサスペンド時にAnimatePresenceのツリーごと非表示化され、
+// exit追跡が壊れて読み込み後も画面が白いままになる（ホワイトアウト）。
+const PageWrapper = ({ children, keyName, wide }) => (<motion.div key={keyName} initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: -20 }} transition={{ duration: 0.25 }} className={`absolute inset-0 flex flex-col overflow-y-auto overflow-x-hidden p-2 md:p-4 no-scrollbar ${wide ? '' : ''}`}><div className={`m-auto w-full h-full ${wide ? 'max-w-7xl' : 'max-w-lg'}`}><Suspense fallback={<LazyFallback />}>{children}</Suspense></div></motion.div>);
+const FullScreenWrapper = ({ children, keyName }) => (<motion.div key={keyName} initial={{ opacity: 0, scale: 0.98 }} animate={{ opacity: 1, scale: 1 }} exit={{ opacity: 0, scale: 0.98 }} transition={{ duration: 0.25 }} className="absolute inset-0 flex flex-col p-0 md:p-6 overflow-hidden safe-area-screen"><div className="w-full h-full max-w-7xl mx-auto flex flex-col"><Suspense fallback={<LazyFallback />}>{children}</Suspense></div></motion.div>);
 
 export { PageWrapper, FullScreenWrapper };


### PR DESCRIPTION
ガチャ・まち編集などのlazyビューへ遷移して「よみこみ中」になると、
画面が白いまま固まることがあった。

原因: SuspenseがAnimatePresence(mode=wait)の外側にあったため、
チャンク読み込みでサスペンドするとAnimatePresenceのツリーごと
非表示化され、退場アニメーションの完了追跡が壊れていた。
その結果、
- 前の画面(ホーム)がopacity:0のまま残り、画面が実質白紙になる
- 読み込み中のタップ(設定・ホーム等)がすべて無視される
- 通信が遅い/失敗する端末では白画面のまま復帰しない

修正: Suspense境界をPageWrapper/FullScreenWrapperのmotion.div内側へ
移動。サスペンドがアニメーション対象の外へ漏れなくなり、
- 読み込み中もスピナーが画面内に表示され、他ボタンも即座に反応
- チャンク取得失敗時はErrorBoundaryの再試行画面が表示される
ことをPlaywrightで遅延・404・読み込み中の割り込み操作を含めて確認。

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XDnYQkgnR33PGpesU9a19i