### PR TITLE
スマホ・タブレットの戻る操作をアプリ内の階層移動に割り当て

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,8 @@ import { AnimatePresence, MotionConfig } from 'framer-motion';
 import { PenTool, Volume2, VolumeX, Settings, Users } from 'lucide-react';
 import { useOnlineStatus } from './hooks/useOnlineStatus';
 import { useIsMobile } from './hooks/useIsMobile';
+import { useViewNavigation } from './hooks/useViewNavigation';
+import { EXIT_CONFIRM_WINDOW, isLearningView } from './systems/view-navigation';
 import { usePrefetchKanji } from './hooks/usePrefetchKanji';
 import { useCloudSync } from './hooks/useCloudSync';
 import OfflineBanner from './components/ui/OfflineBanner';
@@ -29,7 +31,7 @@ import { getMotionPreference, shouldReduceMotion } from './utils/motion-preferen
 import { recordSkillEvidence } from './systems/mastery';
 
 // UI
-import { PageWrapper, FullScreenWrapper, ErrorBoundary, Footer } from './components/ui';
+import { PageWrapper, FullScreenWrapper, ErrorBoundary, Footer, BackExitHint, LeaveLearningDialog } from './components/ui';
 import { F } from './components/ui/FormatKun';
 
 // Pages - HomeViewは常にロード、他はlazy
@@ -140,7 +142,18 @@ export default function App() {
     return { loadedStats, restoredSession };
   });
 
-  const [view, setView] = useState(connectParam ? 'peerClient' : initialAppState.restoredSession ? 'session' : 'home');
+  const initialView = connectParam ? 'peerClient' : initialAppState.restoredSession ? 'session' : 'home';
+  // 端末の「戻る」操作でアプリが終了しないよう、いつ横取りするかを保持する
+  const backInterceptorRef = useRef(null);
+  const [exitHintAt, setExitHintAt] = useState(0);
+  const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
+  const handleBeforeBack = useCallback((currentView) => Boolean(backInterceptorRef.current?.(currentView)), []);
+  const handleExitBlocked = useCallback(() => setExitHintAt(Date.now()), []);
+  // 画面下のナビゲーションバーや端からのスワイプによる戻る操作を、アプリ内の1つ前の画面へ割り当てる
+  const { view, navigate: setView } = useViewNavigation(initialView, {
+    onBeforeBack: handleBeforeBack,
+    onExitBlocked: handleExitBlocked,
+  });
   const [isMuted, setIsMuted] = useState(audioCtrl.muted);
   const [stats, setStats] = useState(initialAppState.loadedStats);
   const cloudSync = useCloudSync({ stats, setStats });
@@ -376,7 +389,40 @@ export default function App() {
     StorageAPI.clearActiveSession();
     setIsResumedSession(false);
     setView('home');
-  }, []);
+  }, [setView]);
+
+  // 戻る操作の横取り。オーバーレイ表示中と学習中は、画面を離れる前に受け止める
+  useEffect(() => {
+    backInterceptorRef.current = (currentView) => {
+      if (showTutorial || showLoginBonus) return true; // 進行が必要な案内中は戻る操作を無効化
+      if (showResidentCollection) {
+        setShowResidentCollection(false);
+        audioCtrl.playSE('click');
+        return true;
+      }
+      if (showLeaveConfirm) {
+        setShowLeaveConfirm(false);
+        return true;
+      }
+      if (isLearningView(currentView)) {
+        setShowLeaveConfirm(true); // 誤操作で学習が終わらないよう確認する
+        return true;
+      }
+      return false;
+    };
+  });
+
+  // 「もう1回でアプリを閉じます」の案内は一定時間で消す
+  useEffect(() => {
+    if (!exitHintAt) return undefined;
+    const timer = setTimeout(() => setExitHintAt(0), EXIT_CONFIRM_WINDOW);
+    return () => clearTimeout(timer);
+  }, [exitHintAt]);
+
+  const handleLeaveLearning = useCallback(() => {
+    setShowLeaveConfirm(false);
+    abandonLearningSession();
+  }, [abandonLearningSession]);
 
   const startSession = (selectedGrade) => {
     audioCtrl.init();
@@ -774,6 +820,21 @@ export default function App() {
             }}
           />
         )}
+      </AnimatePresence>
+
+      {/* 学習中の戻る操作の確認 */}
+      <AnimatePresence>
+        {showLeaveConfirm && (
+          <LeaveLearningDialog
+            onCancel={() => setShowLeaveConfirm(false)}
+            onLeave={handleLeaveLearning}
+          />
+        )}
+      </AnimatePresence>
+
+      {/* ホームでの戻る操作の案内（1回目ではアプリを閉じない） */}
+      <AnimatePresence>
+        {exitHintAt > 0 && <BackExitHint />}
       </AnimatePresence>
 
       {view !== 'session' && view !== 'townEditor' && view !== 'flashcard' && view !== 'survival' && view !== 'boss' && view !== 'drillTest' && (

--- a/src/components/ui/BackExitHint.jsx
+++ b/src/components/ui/BackExitHint.jsx
@@ -1,0 +1,24 @@
+import { motion } from 'framer-motion';
+import { F } from './FormatKun';
+
+/**
+ * ホームで戻る操作をしたときのヒント。
+ * 1回目の戻る操作ではアプリを閉じずに、この案内だけを出す。
+ */
+const BackExitHint = () => (
+  <div className="fixed inset-x-0 bottom-20 z-[120] flex justify-center px-4 pointer-events-none safe-area-bottom">
+    <motion.div
+      initial={{ opacity: 0, y: 16 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: 16 }}
+      transition={{ duration: 0.2 }}
+      className="bg-[var(--text)] text-[var(--panel)] text-xs font-bold rounded-full px-4 py-2.5 shadow-[0_4px_0_rgba(0,0,0,0.25)] border-2 border-[var(--panel)]"
+      role="status"
+      aria-live="polite"
+    >
+      もう1{F("回", "かい")}「もどる」でアプリを{F("閉", "と")}じます
+    </motion.div>
+  </div>
+);
+
+export default BackExitHint;

--- a/src/components/ui/LeaveLearningDialog.jsx
+++ b/src/components/ui/LeaveLearningDialog.jsx
@@ -1,0 +1,42 @@
+import { motion } from 'framer-motion';
+import MotionButton from './MotionButton';
+import { F } from './FormatKun';
+
+/**
+ * 学習中に戻る操作をしたときの確認ダイアログ。
+ * 端からのスワイプなどの誤操作で、いきなり学習が終わらないようにする。
+ */
+const LeaveLearningDialog = ({ onCancel, onLeave }) => (
+  <motion.div
+    initial={{ opacity: 0 }}
+    animate={{ opacity: 1 }}
+    exit={{ opacity: 0 }}
+    className="fixed inset-0 z-[110] bg-black/60 flex items-center justify-center p-4"
+    role="dialog"
+    aria-modal="true"
+    aria-label="学習をやめるかの確認"
+  >
+    <motion.div
+      initial={{ scale: 0.8, y: 20 }}
+      animate={{ scale: 1, y: 0 }}
+      transition={{ type: 'spring', stiffness: 300, damping: 25 }}
+      className="bg-[var(--panel)] border-[4px] border-[var(--text)] rounded-[24px] shadow-[6px_6px_0_var(--text)] p-6 max-w-xs w-full text-center"
+    >
+      <div className="text-5xl mb-3" aria-hidden="true">🤔</div>
+      <h2 className="text-lg font-black text-[var(--text)] mb-1">{F("学習", "がくしゅう")}をやめる？</h2>
+      <p className="text-xs text-[var(--text)] opacity-60 mb-5">
+        いまの{F("問題", "もんだい")}のとちゅうまでは{F("記録", "きろく")}されるよ。
+      </p>
+      <div className="flex flex-col gap-2">
+        <MotionButton variant="primary" onClick={onCancel} className="w-full py-3 text-base border-[3px] border-[var(--text)]">
+          つづける
+        </MotionButton>
+        <MotionButton variant="secondary" onClick={onLeave} className="w-full py-3 text-base border-[3px] border-[var(--text)]">
+          やめて{F("町", "まち")}にもどる
+        </MotionButton>
+      </div>
+    </motion.div>
+  </motion.div>
+);
+
+export default LeaveLearningDialog;

--- a/src/components/ui/index.js
+++ b/src/components/ui/index.js
@@ -9,3 +9,5 @@ export { R, FormatKun } from './FormatKun';
 export { default as OfflineBanner } from './OfflineBanner';
 export { default as StorageErrorBanner } from './StorageErrorBanner';
 export { default as MobileBottomNav } from './MobileBottomNav';
+export { default as BackExitHint } from './BackExitHint';
+export { default as LeaveLearningDialog } from './LeaveLearningDialog';

--- a/src/hooks/useViewNavigation.js
+++ b/src/hooks/useViewNavigation.js
@@ -1,0 +1,135 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  createViewStack,
+  getCurrentView,
+  isExitConfirmed,
+  resolveBackNavigation,
+  resolveHistoryIndex,
+  resolveViewChange,
+} from '../systems/view-navigation';
+
+// 履歴エントリに埋め込むスタック位置。他のstate（?connect=除去時のreplaceState等）は保持する
+const HISTORY_KEY = 'kanjiTownViewIndex';
+
+const readIndex = (state) => (
+  state && Number.isInteger(state[HISTORY_KEY]) ? state[HISTORY_KEY] : null
+);
+
+const buildHistoryState = (index) => ({ ...(window.history.state || {}), [HISTORY_KEY]: index });
+
+/**
+ * 画面遷移をブラウザ履歴へ写し、端末の「戻る」操作をアプリ内の階層移動に変える。
+ *
+ * 履歴の並び: [ガード(-1)] [画面0] [画面1] ...
+ * ガードを1つ余分に積んでおくことで、ホームでの戻る操作がページ離脱
+ * （＝アプリ終了・ブラウザの戻る）にならず、アプリ側で受け止められる。
+ *
+ * @param {string} initialView 起動時の画面
+ * @param {{onBeforeBack?: (view: string) => boolean, onExitBlocked?: () => void}} handlers
+ *   onBeforeBack: 戻る操作を横取りしたい場合にtrueを返す（オーバーレイを閉じる・確認を出す等）
+ *   onExitBlocked: ホームでの戻る操作でアプリ終了を止めたときの通知
+ */
+export function useViewNavigation(initialView, { onBeforeBack, onExitBlocked } = {}) {
+  const [stack, setStack] = useState(() => createViewStack(initialView));
+  const stackRef = useRef(stack);
+  const lastBackAtRef = useRef(0);
+  const handlersRef = useRef({ onBeforeBack, onExitBlocked });
+  handlersRef.current = { onBeforeBack, onExitBlocked };
+
+  const applyStack = useCallback((nextStack) => {
+    stackRef.current = nextStack;
+    setStack(nextStack);
+  }, []);
+
+  // 現在の画面の履歴エントリを積み直す（戻る操作を取り消して、その場に留まる）
+  const restoreCurrentEntry = useCallback(() => {
+    window.history.pushState(buildHistoryState(stackRef.current.length - 1), '');
+  }, []);
+
+  // 起動時にガード＋現在のスタック分の履歴を用意する
+  useEffect(() => {
+    const depth = stackRef.current.length;
+    // StrictModeの二重実行やSW更新後の再マウントで履歴を重ねない
+    if (readIndex(window.history.state) === depth - 1) return;
+    window.history.replaceState(buildHistoryState(-1), '');
+    for (let i = 0; i < depth; i += 1) {
+      window.history.pushState(buildHistoryState(i), '');
+    }
+  }, []);
+
+  useEffect(() => {
+    const handlePopState = (event) => {
+      const result = resolveHistoryIndex(stackRef.current, readIndex(event.state));
+      if (result.type === 'sync') return;
+      if (result.type === 'resync') {
+        // 「進む」で戻ってきた画面は既に破棄済み。履歴位置だけ現在地へ戻す
+        window.history.go(result.steps);
+        return;
+      }
+
+      const { onBeforeBack, onExitBlocked } = handlersRef.current;
+      if (onBeforeBack?.(getCurrentView(stackRef.current))) {
+        restoreCurrentEntry();
+        return;
+      }
+
+      if (result.type === 'exit') {
+        const now = Date.now();
+        if (isExitConfirmed(lastBackAtRef.current, now)) {
+          lastBackAtRef.current = 0;
+          window.history.back(); // 2回続けての戻る操作なので離脱を許可する
+          // 直接開かれたタブなど、戻る先が無く離脱できなかった場合はガードを積み直す
+          window.setTimeout(() => {
+            if (readIndex(window.history.state) !== stackRef.current.length - 1) restoreCurrentEntry();
+          }, 300);
+          return;
+        }
+        lastBackAtRef.current = now;
+        restoreCurrentEntry();
+        onExitBlocked?.();
+        return;
+      }
+
+      lastBackAtRef.current = 0;
+      applyStack(result.stack);
+    };
+
+    window.addEventListener('popstate', handlePopState);
+    return () => window.removeEventListener('popstate', handlePopState);
+  }, [applyStack, restoreCurrentEntry]);
+
+  /** setViewの置き換え。文字列でも更新関数でも受け取れる */
+  const navigate = useCallback((update) => {
+    const currentStack = stackRef.current;
+    const nextView = typeof update === 'function' ? update(getCurrentView(currentStack)) : update;
+    const result = resolveViewChange(currentStack, nextView);
+    if (result.type === 'none') return;
+    lastBackAtRef.current = 0;
+    applyStack(result.stack);
+    if (result.type === 'push') {
+      window.history.pushState(buildHistoryState(result.stack.length - 1), '');
+      return;
+    }
+    if (result.type === 'replace') {
+      // 履歴の位置は変えず、その場の画面だけ差し替える
+      window.history.replaceState(buildHistoryState(result.stack.length - 1), '');
+      return;
+    }
+    if (result.steps > 0) window.history.go(-result.steps);
+  }, [applyStack]);
+
+  /** アプリ内の「戻る」ボタン用。端末の戻る操作と同じ動きをする */
+  const goBack = useCallback(() => {
+    const result = resolveBackNavigation(stackRef.current);
+    if (result.type !== 'back') return;
+    applyStack(result.stack);
+    window.history.go(-result.steps);
+  }, [applyStack]);
+
+  return {
+    view: getCurrentView(stack),
+    navigate,
+    goBack,
+    canGoBack: stack.length > 1,
+  };
+}

--- a/src/systems/view-navigation.js
+++ b/src/systems/view-navigation.js
@@ -1,0 +1,82 @@
+// 画面遷移スタック — マイ漢字タウン
+// スマホ・タブレットの「戻る」操作（画面下のナビゲーションバー／端からのスワイプ）を
+// ブラウザの戻る＝アプリ終了ではなく、アプリ内の1つ前の画面に割り当てるための純粋ロジック。
+// 副作用（history API）はuseViewNavigationフックが担当する。
+
+export const HOME_VIEW = 'home';
+
+/** 中断すると学習の進みが失われる画面（戻る操作の前に確認する） */
+export const LEARNING_VIEWS = Object.freeze(['session', 'flashcard', 'survival', 'boss', 'drillTest']);
+
+/** ホームで戻る操作をしてから、次の戻る操作でアプリを閉じるまでの猶予(ms) */
+export const EXIT_CONFIRM_WINDOW = 2500;
+
+/** 一度離れたら戻っても意味が無い（＝履歴に残さない）画面 */
+export const REPLACE_ON_LEAVE_VIEWS = Object.freeze([...LEARNING_VIEWS, 'result']);
+
+export function isLearningView(view) {
+  return LEARNING_VIEWS.includes(view);
+}
+
+/**
+ * 起動時の画面スタックを作る。
+ * QRコードからの起動や学習の再開で最初の画面がホーム以外でも、
+ * 必ずホームを土台に置き「戻る」でホームへ帰れるようにする。
+ */
+export function createViewStack(initialView) {
+  if (!initialView || initialView === HOME_VIEW) return [HOME_VIEW];
+  return [HOME_VIEW, initialView];
+}
+
+export function getCurrentView(stack) {
+  return stack[stack.length - 1];
+}
+
+/**
+ * setView相当の画面切り替えを、新しいスタックと履歴操作へ変換する。
+ * - 既にスタックにある画面へ移る場合は「戻る」として扱い、履歴が無限に伸びるのを防ぐ
+ * - 終わった学習画面やリザルト画面は置き換えて、戻る操作で再入場しないようにする
+ */
+export function resolveViewChange(stack, nextView) {
+  const current = getCurrentView(stack);
+  if (!nextView || nextView === current) {
+    return { type: 'none', stack, steps: 0 };
+  }
+  const index = stack.lastIndexOf(nextView);
+  if (index >= 0) {
+    return { type: 'back', stack: stack.slice(0, index + 1), steps: stack.length - 1 - index };
+  }
+  if (REPLACE_ON_LEAVE_VIEWS.includes(current) && stack.length > 1) {
+    return { type: 'replace', stack: [...stack.slice(0, -1), nextView], steps: 0 };
+  }
+  return { type: 'push', stack: [...stack, nextView], steps: 1 };
+}
+
+/** 戻る操作（ナビゲーションバー／スワイプ／アプリ内の戻るボタン）の結果 */
+export function resolveBackNavigation(stack) {
+  if (stack.length <= 1) return { type: 'exit', stack, steps: 0 };
+  return { type: 'back', stack: stack.slice(0, -1), steps: 1 };
+}
+
+/**
+ * popstateで通知された履歴位置を、あるべきスタックへ変換する。
+ * - sync   : 自前の履歴操作の反響。状態は反映済みなので何もしない
+ * - resync : 「進む」操作。行き先の画面は破棄済みなので履歴位置だけ戻す
+ * - exit   : スタックの底（ホーム）での戻る操作
+ */
+export function resolveHistoryIndex(stack, index) {
+  const currentIndex = stack.length - 1;
+  if (!Number.isInteger(index) || index < 0) return { type: 'exit', stack, steps: 0 };
+  if (index === currentIndex) return { type: 'sync', stack, steps: 0 };
+  if (index > currentIndex) return { type: 'resync', stack, steps: currentIndex - index };
+  return { type: 'back', stack: stack.slice(0, index + 1), steps: currentIndex - index };
+}
+
+/**
+ * ホームでの戻る操作でアプリを閉じてよいか判定する。
+ * 直前にも戻る操作をしていた場合（＝閉じる意思がある場合）だけtrue。
+ */
+export function isExitConfirmed(lastBackAt, now, window = EXIT_CONFIRM_WINDOW) {
+  if (!Number.isFinite(lastBackAt) || lastBackAt <= 0) return false;
+  return now - lastBackAt <= window;
+}

--- a/test/view-navigation.test.js
+++ b/test/view-navigation.test.js
@@ -1,0 +1,96 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  EXIT_CONFIRM_WINDOW,
+  createViewStack,
+  getCurrentView,
+  isExitConfirmed,
+  isLearningView,
+  resolveBackNavigation,
+  resolveHistoryIndex,
+  resolveViewChange,
+} from '../src/systems/view-navigation.js';
+
+test('起動時のスタックは必ずホームを土台にする', () => {
+  assert.deepEqual(createViewStack('home'), ['home']);
+  assert.deepEqual(createViewStack(), ['home']);
+  // QRコード起動や学習の再開でも、戻る操作でホームへ帰れるようにする
+  assert.deepEqual(createViewStack('peerClient'), ['home', 'peerClient']);
+  assert.deepEqual(createViewStack('session'), ['home', 'session']);
+});
+
+test('新しい画面は積み上げ、同じ画面への遷移は何もしない', () => {
+  const pushed = resolveViewChange(['home'], 'dictionary');
+  assert.equal(pushed.type, 'push');
+  assert.deepEqual(pushed.stack, ['home', 'dictionary']);
+  assert.equal(getCurrentView(pushed.stack), 'dictionary');
+
+  assert.equal(resolveViewChange(['home', 'dictionary'], 'dictionary').type, 'none');
+  assert.equal(resolveViewChange(['home'], null).type, 'none');
+});
+
+test('スタックにある画面へ戻るときは履歴も戻して伸び続けないようにする', () => {
+  const result = resolveViewChange(['home', 'myDrills', 'drillEditor'], 'myDrills');
+  assert.equal(result.type, 'back');
+  assert.equal(result.steps, 1);
+  assert.deepEqual(result.stack, ['home', 'myDrills']);
+
+  const toHome = resolveViewChange(['home', 'myDrills', 'drillEditor'], 'home');
+  assert.equal(toHome.type, 'back');
+  assert.equal(toHome.steps, 2);
+  assert.deepEqual(toHome.stack, ['home']);
+});
+
+test('終わった学習画面・リザルト画面は置き換えて戻る操作で再入場させない', () => {
+  const toResult = resolveViewChange(['home', 'session'], 'result');
+  assert.equal(toResult.type, 'replace');
+  assert.deepEqual(toResult.stack, ['home', 'result']);
+
+  // リザルトから続けて学習した場合もリザルトは残さない
+  const again = resolveViewChange(toResult.stack, 'session');
+  assert.equal(again.type, 'replace');
+  assert.deepEqual(again.stack, ['home', 'session']);
+
+  // 学習→リザルト→ホームは1回の戻る操作でホームに着く
+  const back = resolveBackNavigation(again.stack);
+  assert.equal(back.type, 'back');
+  assert.deepEqual(back.stack, ['home']);
+});
+
+test('ホームでの戻る操作はアプリ終了ではなく終了確認になる', () => {
+  assert.equal(resolveBackNavigation(['home']).type, 'exit');
+  assert.equal(resolveBackNavigation(['home', 'stats']).type, 'back');
+});
+
+test('popstateの履歴位置からスタックを復元する', () => {
+  const stack = ['home', 'myDrills', 'drillEditor'];
+  // 1つ前の階層へ
+  const back = resolveHistoryIndex(stack, 1);
+  assert.equal(back.type, 'back');
+  assert.deepEqual(back.stack, ['home', 'myDrills']);
+  // 一気に2階層戻る（スワイプの連続操作など）
+  assert.deepEqual(resolveHistoryIndex(stack, 0).stack, ['home']);
+  // 自前の履歴操作の反響は無視する
+  assert.equal(resolveHistoryIndex(stack, 2).type, 'sync');
+  // 「進む」は破棄済みの画面なので履歴位置だけ戻す
+  const forward = resolveHistoryIndex(stack, 4);
+  assert.equal(forward.type, 'resync');
+  assert.equal(forward.steps, -2);
+  // ガード（アプリ終了側）へ抜けた場合
+  assert.equal(resolveHistoryIndex(['home'], -1).type, 'exit');
+  assert.equal(resolveHistoryIndex(['home'], null).type, 'exit');
+});
+
+test('2回続けて戻る操作をしたときだけアプリを閉じる', () => {
+  const now = 10_000;
+  assert.equal(isExitConfirmed(0, now), false);
+  assert.equal(isExitConfirmed(now - 500, now), true);
+  assert.equal(isExitConfirmed(now - (EXIT_CONFIRM_WINDOW + 1), now), false);
+});
+
+test('学習中の画面を判定できる', () => {
+  assert.equal(isLearningView('session'), true);
+  assert.equal(isLearningView('boss'), true);
+  assert.equal(isLearningView('home'), false);
+  assert.equal(isLearningView('result'), false);
+});


### PR DESCRIPTION
画面下のナビゲーションバーや画面端からのスワイプによる「戻る」操作で、
アプリが終了したりブラウザが前のページへ離脱したりせず、
1つ前の画面へ戻るようにした。

- 画面遷移をスタックとして持ち、ブラウザ履歴へ写すuseViewNavigationを追加
- 履歴にガードを1つ余分に積み、ホームでの戻る操作を受け止める
  （1回目は案内を出すだけ、続けてもう1回でアプリを閉じる）
- 学習中の戻る操作は確認ダイアログで受け止め、誤操作での中断を防ぐ
- 終わった学習画面・リザルト画面は履歴に残さず、戻って再入場しないようにする
- 案内やオーバーレイの表示中は戻る操作で画面を離れない

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EhsEisoGKtKwfLwfEvuoYo