### PR TITLE
items が200件を超えるセッションで attempted と items.length を一致させる

### DIFF
--- a/docs/study-log.md
+++ b/docs/study-log.md
@@ -1,6 +1,6 @@
 # 学習ログ（study.v1）の実装メモ — 漢字タウン
 
-本アプリの学習ログは「学習ログ共通スキーマ仕様書 `study.v1`」（版 1.3）に準拠する。
+本アプリの学習ログは「学習ログ共通スキーマ仕様書 `study.v1`」（版 1.5）に準拠する。
 仕様書が唯一の正であり、このメモは漢字タウン固有の割り当てだけを記録する。
 
 ## 基本方針
@@ -27,6 +27,19 @@
 - `items[].q`: 漢字ID（例 `k1_1`）。`skill` に `reading` / `writing` を付す
 - `ext`: `buildLearningReport()`（`src/systems/learning-report.js`）から生成。
   4技能スコア・SRS状況・弱点漢字ID・連続学習日数
+
+## `items` の切り詰め（§2.7）
+
+`items` は1レコード200件が上限で、`studyLog.js` が201件目以降を捨てる。
+サバイバル・ボスバトルは制限時間まで出題が続くため、学習済み漢字が多い児童では
+実際に200種類を超えうる。組み立て側で何もしないと `attempted > items.length` となり、
+`summary` から出す正答率と設問層から出す正答率が食い違ったまま蓄積される。
+
+`studySession.js` の `finalize()` で先に切り詰め、`summary` は切り詰め後の `items` から数える。
+
+- `summary.attempted` / `firstTryCorrect` / `correct` … 残した200件から算出（`attempted === items.length`）
+- `summary.count` … 切り詰め前の解答実績のまま（サバイバル・ボスは実際に出した数が出題数）
+- `ext.itemsTruncated` … 切り詰めが起きたときだけ `{ attempted, firstTryCorrect }` を付け、真の値を残す
 
 ## 中断の扱い（§5.4）
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vite build && node scripts/check-bundle-budget.mjs && cp dist/index.html dist/404.html",
     "check:bundle": "node scripts/check-bundle-budget.mjs",
     "preview": "vite preview",
-    "test": "node --test"
+    "test": "node --test --experimental-test-module-mocks"
   },
   "dependencies": {
     "framer-motion": "^12.36.0",

--- a/src/systems/studySession.js
+++ b/src/systems/studySession.js
@@ -13,6 +13,7 @@ export const STUDY_APP_ID = 'kanji-town';
 const HIDDEN_ABORT_MS = 5 * 60 * 1000;
 const IDLE_STOP_MS = 60 * 1000;
 const TICK_MS = 1000;
+const STUDY_ITEMS_MAX = 200;         // 1レコードの設問数の上限。studyLog.js と同じ値（§2.10）
 
 let session = null;
 // タブ破棄（pagehide）で確定した後、bfcache 復帰時に残り分の新レコードを開始するための控え
@@ -171,6 +172,16 @@ function finalize(status, endMsOverride) {
   // 固定キューでは開始時（中断復帰後は残り分）の出題数を用いる。
   const count = s.meta.fixedCount === null ? attempted : Math.max(s.count, attempted);
 
+  // items は1レコード200件まで（studyLog.js が超過分を切り捨てる）。
+  // 集計側は正答率の分母を items から数えるため、summary は切り詰めたあとの
+  // items から算出し、`attempted === items.length` を必ず守る（§2.7）。
+  // 切り捨てが起きたときは、実際の解答実績を ext に残して失わないようにする。
+  // count は切り詰め前の attempted のままとする（出題数は実際に出した数）
+  const kept = items.slice(0, STUDY_ITEMS_MAX);
+  const truncated = items.length > kept.length
+    ? { attempted: items.length, firstTryCorrect: items.filter((it) => it.firstTry).length }
+    : null;
+
   saveStudyRecord({
     appId: STUDY_APP_ID,
     appVersion: APP_VERSION,
@@ -189,12 +200,12 @@ function finalize(status, endMsOverride) {
     status,
     summary: {
       count,
-      attempted,
-      firstTryCorrect: items.filter((it) => it.firstTry).length,
-      correct: items.filter((it) => it.ok).length,
+      attempted: kept.length,
+      firstTryCorrect: kept.filter((it) => it.firstTry).length,
+      correct: kept.filter((it) => it.ok).length,
     },
-    items,
-    ext: buildStudyExt(),
+    items: kept,
+    ext: { ...buildStudyExt(), ...(truncated ? { itemsTruncated: truncated } : {}) },
   });
 }
 

--- a/test/study-session.test.js
+++ b/test/study-session.test.js
@@ -1,0 +1,92 @@
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+
+const STUDY_LOG_KEY = 'study.records.v1';
+
+// studySession.js は storage.js 経由で .jsx を取り込むため、node からは直接読めない。
+// レコードの組み立てだけを見たいので、依存する3モジュールを差し替えて読み込む。
+mock.module(new URL('../src/systems/storage.js', import.meta.url).href, {
+  namedExports: { StorageAPI: { getStats: () => ({}) } },
+});
+mock.module(new URL('../src/systems/learning-report.js', import.meta.url).href, {
+  namedExports: {
+    buildLearningReport: () => ({
+      mastery: { reading: 50, meaning: 50, writing: 50, stroke: 50 },
+      progress: { learned: 300, mastered: 40 },
+      support: { overdueReviews: 3, weekReviews: 10, weakKanjiIds: ['k1_1'] },
+      habit: { streak: 4 },
+    }),
+  },
+});
+mock.module(new URL('../src/systems/diagnostics.js', import.meta.url).href, {
+  namedExports: { APP_VERSION: '0.2.0', recordDiagnosticEvent: () => {} },
+});
+
+const { buildStudyMeta, beginStudySession, recordStudyAttempt, markStudySessionCompleted, finishStudySession } =
+  await import('../src/systems/studySession.js');
+
+function installBrowserGlobals() {
+  const values = new Map();
+  globalThis.localStorage = {
+    getItem: (key) => (values.has(key) ? values.get(key) : null),
+    setItem: (key, value) => values.set(key, String(value)),
+    removeItem: (key) => values.delete(key),
+  };
+  globalThis.document = { hidden: false, addEventListener() {}, removeEventListener() {} };
+  globalThis.window = { addEventListener() {}, removeEventListener() {} };
+  return values;
+}
+
+const readRecord = () => JSON.parse(globalThis.localStorage.getItem(STUDY_LOG_KEY)).at(-1);
+
+/** サバイバルで n 種類の漢字に解答する。firstTry は n 問ごとに1問だけ落とす。 */
+function playSurvival(n) {
+  beginStudySession(buildStudyMeta('survival', { queue: [] }));
+  for (let i = 0; i < n; i++) {
+    const q = `k-${String(i).padStart(4, '0')}`;
+    const firstTryOk = i % 5 !== 0;
+    recordStudyAttempt(q, { ok: firstTryOk, skill: 'reading' });
+    if (!firstTryOk) recordStudyAttempt(q, { ok: true, skill: 'reading' });
+  }
+  markStudySessionCompleted();
+  finishStudySession();
+}
+
+test('items が200件を超えたら切り詰め、summary を切り詰め後の items から算出する', () => {
+  installBrowserGlobals();
+  playSurvival(250);
+
+  const rec = readRecord();
+  assert.equal(rec.items.length, 200);
+  // 分母が items と食い違うと、教師側で正答率が定まらなくなる（§2.7）
+  assert.equal(rec.summary.attempted, rec.items.length);
+  assert.equal(rec.summary.firstTryCorrect, rec.items.filter((it) => it.firstTry).length);
+  assert.equal(rec.summary.correct, rec.items.filter((it) => it.ok).length);
+  // 切り詰めるのは後半。先頭200件が残る
+  assert.equal(rec.items[0].q, 'k-0000');
+  assert.equal(rec.items.at(-1).q, 'k-0199');
+});
+
+test('切り詰め前の実際の解答実績は count と ext.itemsTruncated に残る', () => {
+  installBrowserGlobals();
+  playSurvival(250);
+
+  const rec = readRecord();
+  // サバイバルの出題数は解答実績。切り詰め後の値に合わせると出題数が過少になる（§3.3.1）
+  assert.equal(rec.summary.count, 250);
+  assert.equal(rec.ext.itemsTruncated.attempted, 250);
+  assert.equal(rec.ext.itemsTruncated.firstTryCorrect, 200);
+  // ext の他の項目は残っている
+  assert.equal(rec.ext.srs.learned, 300);
+});
+
+test('200件以下のセッションには itemsTruncated を付けない', () => {
+  installBrowserGlobals();
+  playSurvival(200);
+
+  const rec = readRecord();
+  assert.equal(rec.items.length, 200);
+  assert.equal(rec.summary.attempted, 200);
+  assert.equal(rec.summary.count, 200);
+  assert.equal('itemsTruncated' in rec.ext, false);
+});


### PR DESCRIPTION
サバイバル・ボスバトルは制限時間まで出題が続くため、学習済み漢字の多い児童では
1レコードの items が200件（studyLog.js の上限）を超えうる。これまでは組み立て側で
何もしていなかったため、studyLog.js が201件目以降を捨てたあとも summary.attempted は
切り詰め前の値のままとなり、仕様 §2.7 の `attempted === items.length` が破れていた。
検証は通ってしまうので、summary から出す正答率と設問層から出す正答率が食い違ったまま
気づかれずに蓄積される。

Qalc と同じ形に揃え、finalize() で先に items を200件へ切り詰めてから summary を
その200件から算出する。切り詰めが起きたときは実際の解答実績を ext.itemsTruncated に
残すため、どちらの数字も失われない。summary.count は切り詰め前の解答実績のままとする
（サバイバル・ボスの出題数は実際に出した数であり、切り詰め後に合わせると過少になる）。

studySession.js は storage.js 経由で .jsx を取り込むため node から直接読めない。
組み立て層の回帰テストを置けるよう、依存3モジュールを差し替える module mocking を
使い、test スクリプトに --experimental-test-module-mocks を追加した。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XxLj2t75BQZ2ss49vgJu8K