### PR TITLE
マイドリルのテスト結果画面で採点理由を見せ、間違いだけ復習できるようにする

### DIFF
--- a/docs/stroke-grading.md
+++ b/docs/stroke-grading.md
@@ -89,6 +89,24 @@ KanjiVG の各 `<path>` は `kvg:type` に CJK Strokes ブロックの文字で�
 外接枠の中心のずれを `GLOBAL_SHIFT_MAX`（0.06）まで打ち消してから比較する。
 それを超えるずれは減点として残る。
 
+## 採点結果の返し方（結果画面での説明）
+
+`gradeStrokes` は合計点のほかに、児童へ理由を示すための材料も返す。
+
+| フィールド | 内容 |
+| --- | --- |
+| `breakdown` | 項目ごとの `{ key, points, max, evaluated }`。按分後の満点込みなので、画面側で配点を再計算しなくてよい |
+| `strokeFeedback` | 画ごとの `{ matched, inOrder, shape, reversed, ending }` |
+| `details` | 児童向けの講評文 |
+| `strokeCountMatch` / `orderMatch` / `crossMatch` | 合否を分ける3条件 |
+
+`evaluated: false` の項目（例：手本に筆画種が無く終筆を採点できない）は `max` も0にしてあり、
+「0点を取った」のか「採点対象外だった」のかを画面で区別できる。
+画数が違うときは採点そのものを行わないので `breakdown` は空配列になる。
+
+マイドリルのテスト結果画面（`DrillTestView`）は、この内訳と `strokeFeedback` を使って
+「どの画で」「どの観点で」点を落としたかを、書いた線の色分けと番号で示している。
+
 ## KanjiVG キャッシュの形式
 
 `kvg:type` を持たせるため、IndexedDB のキャッシュは `string[]`（d属性のみ）から

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -791,6 +791,26 @@ export default function App() {
     setView('result');
   };
 
+  // テスト結果から、間違えた漢字だけの学習セッションへ移る。
+  // テストの成績を確定してから続けて始めるので、リザルト画面は挟まない。
+  const startMistakeReview = (kanjiList) => {
+    if (!Array.isArray(kanjiList) || kanjiList.length === 0) return;
+    const finishedSession = sessionDataRef.current;
+    const earnedExp = finishedSession.earnedExp || 0;
+    const studyUnit = finishedSession.studyUnit;
+    handleFinishSession();
+    const expMultiplier = getSatisfactionMultiplier(calculateSatisfaction(stats));
+    beginSession('session', {
+      queue: kanjiList,
+      // テストで得たEXPを反映した位置から、復習セッションの獲得量を数える
+      oldExp: (stats.totalExp || 0) + earnedExp,
+      expMultiplier,
+      // 出題元は同じマイドリルなので、学習ログの単元もテストから引き継ぐ
+      isDrill: true,
+      studyUnit,
+    });
+  };
+
   // ボスバトル敗北処理
   const handleBossDefeat = (defeatResults = {}) => {
     // 失敗した漢字を復習リストに追加（nextReviewを即時に設定）
@@ -934,7 +954,7 @@ export default function App() {
           {view === 'flashcard' && <FullScreenWrapper key="flashcard"><ErrorBoundary onReset={() => setView('home')}><FlashcardView queue={sessionData.queue} stats={stats} setStats={setStats} onFinish={handleFinishSession} /></ErrorBoundary></FullScreenWrapper>}
           {view === 'survival' && <FullScreenWrapper key="survival"><ErrorBoundary onReset={() => setView('home')}><SurvivalView queue={sessionData.queue} onUpdateStat={handleUpdateStat} onFinish={handleFinishSession} /></ErrorBoundary></FullScreenWrapper>}
           {view === 'boss' && <FullScreenWrapper key="boss"><ErrorBoundary onReset={() => setView('home')}><BossBattleView queue={sessionData.queue} onUpdateStat={handleUpdateStat} onFinish={handleFinishSession} onBossDefeat={handleBossDefeat} /></ErrorBoundary></FullScreenWrapper>}
-          {view === 'drillTest' && <FullScreenWrapper key="drillTest"><ErrorBoundary onReset={() => setView('home')}><DrillTestView queue={sessionData.queue} stats={stats} onUpdateStat={handleUpdateStat} onFinish={handleFinishSession} startDrillSession={startDrillSession} setView={setView} setSessionData={setSessionData} createInitialSessionData={createInitialSessionData} /></ErrorBoundary></FullScreenWrapper>}
+          {view === 'drillTest' && <FullScreenWrapper key="drillTest"><ErrorBoundary onReset={() => setView('home')}><DrillTestView queue={sessionData.queue} onUpdateStat={handleUpdateStat} onFinish={handleFinishSession} onReviewMistakes={startMistakeReview} /></ErrorBoundary></FullScreenWrapper>}
           {view === 'result' && <PageWrapper key="result"><ErrorBoundary onReset={() => setView('home')}><ResultView sessionMetrics={sessionData} oldExp={sessionData.oldExp} setView={setView} stats={stats} setStats={setStats} onContinueLearning={() => startSession(stats.targetGrade || 1)} /></ErrorBoundary></PageWrapper>}
         </AnimatePresence>
       </main>

--- a/src/components/training/DrillTestView.jsx
+++ b/src/components/training/DrillTestView.jsx
@@ -1,18 +1,31 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { ChevronRight, RefreshCw, CheckCircle, XCircle, RotateCcw, LogOut } from 'lucide-react';
+import { ChevronRight, ChevronLeft, RefreshCw, CheckCircle, XCircle, RotateCcw, LogOut, X, Search, Pencil } from 'lucide-react';
 import MotionButton from '../ui/MotionButton';
 import { audioCtrl } from '../../systems/audio';
 import { F, SurvivalRubyText, FormatKun } from '../ui/FormatKun';
-import { gradeStrokes } from '../../systems/strokeGrader';
+import { gradeStrokes, getGradeLabel } from '../../systems/strokeGrader';
 import { fetchKanjiVg } from '../../systems/kanjiVg';
-import { TEST } from '../../constants/gameConfig';
-import { getSatisfactionMultiplier, calculateSatisfaction } from '../../systems/residents';
+import { TEST, GRADING } from '../../constants/gameConfig';
 import { resolveThemeColor } from '../../utils/theme-colors';
 import { attachDrawListeners } from '../../utils/draw-pointer-events';
 import { useLearningViewport } from '../../hooks/useLearningViewport';
 
 const WRITING_SKILLS = { skills: ['writing', 'stroke'] };
+
+/** 画ごとの出来ばえ(0-1)を色にする。キャンバス描画なのでCSS変数は使えない */
+const STROKE_COLORS = { good: '#10b981', fair: '#f59e0b', poor: '#f43f5e' };
+const strokeTone = (ratio) => (ratio >= 0.75 ? 'good' : ratio >= 0.45 ? 'fair' : 'poor');
+
+/** 採点内訳の表示定義（strokeGrader の breakdown.key と対応） */
+const SCORE_ROWS = [
+  { key: 'shape', label: <>{F('字形', 'じけい')}</>, desc: 'かたちが おてほんに にているか' },
+  { key: 'order', label: <>{F('書', 'か')}きじゅん</>, desc: 'かく じゅんばん' },
+  { key: 'ending', label: <>とめ・はね・はらい</>, desc: 'さいごの しまつ' },
+  { key: 'cross', label: <>つきぬけ</>, desc: 'せんの まじわりかた' },
+  { key: 'start', label: <>{F('書', 'か')}きはじめ</>, desc: 'スタートの いち' },
+  { key: 'end', label: <>{F('書', 'か')}きおわり</>, desc: 'ゴールの いち' },
+];
 
 // --- テスト専用キャンバス ---
 const TestCanvas = ({ strokeData, canvasSize, onSubmit, disabled }) => {
@@ -176,7 +189,9 @@ const TestCanvas = ({ strokeData, canvasSize, onSubmit, disabled }) => {
 };
 
 // --- ストローク再描画コンポーネント ---
-const StrokeReplay = ({ userStrokes, canvasSize, displaySize = 80 }) => {
+// feedback を渡すと、画ごとの出来ばえで色分けし、書いた順の番号を打つ。
+// 「どの画で点を落としたか」「どの順で書いたか」が一目で分かるようにするため。
+const StrokeReplay = ({ userStrokes, canvasSize, displaySize = 80, feedback = null, showNumbers = false }) => {
   const canvasRef = useRef(null);
 
   useEffect(() => {
@@ -189,32 +204,319 @@ const StrokeReplay = ({ userStrokes, canvasSize, displaySize = 80 }) => {
     ctx.scale(2, 2);
     ctx.clearRect(0, 0, displaySize, displaySize);
     const scale = displaySize / canvasSize;
+    const inkColor = resolveThemeColor('--text');
     ctx.lineCap = 'round';
     ctx.lineJoin = 'round';
     ctx.lineWidth = displaySize * 0.07;
-    ctx.strokeStyle = '#292f36';
-    userStrokes.forEach(stroke => {
+    userStrokes.forEach((stroke, i) => {
       if (!stroke || stroke.length === 0) return;
+      const fb = feedback?.[i];
+      ctx.strokeStyle = fb ? STROKE_COLORS[strokeTone(fb.shape)] : inkColor;
       ctx.beginPath();
       ctx.moveTo(stroke[0].x * scale, stroke[0].y * scale);
       stroke.forEach(pt => ctx.lineTo(pt.x * scale, pt.y * scale));
       ctx.stroke();
     });
-  }, [userStrokes, canvasSize, displaySize]);
+    if (!showNumbers) return;
+    const r = displaySize * 0.085;
+    ctx.font = `900 ${displaySize * 0.1}px sans-serif`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    userStrokes.forEach((stroke, i) => {
+      if (!stroke || stroke.length === 0) return;
+      const x = stroke[0].x * scale;
+      const y = stroke[0].y * scale;
+      const fb = feedback?.[i];
+      ctx.beginPath();
+      ctx.arc(x, y, r, 0, Math.PI * 2);
+      ctx.fillStyle = resolveThemeColor('--panel');
+      ctx.fill();
+      ctx.lineWidth = Math.max(1.5, displaySize * 0.012);
+      ctx.strokeStyle = fb && !fb.inOrder ? STROKE_COLORS.poor : inkColor;
+      ctx.stroke();
+      ctx.fillStyle = fb && !fb.inOrder ? STROKE_COLORS.poor : inkColor;
+      ctx.fillText(String(i + 1), x, y + displaySize * 0.005);
+    });
+  }, [userStrokes, canvasSize, displaySize, feedback, showNumbers]);
 
   return <canvas ref={canvasRef} style={{ width: displaySize, height: displaySize }} className="rounded-lg" />;
 };
 
+// --- お手本（KanjiVG）表示 ---
+// 筆順データを取れなかったとき（オフラインなど）は、字だけでも見せる
+const ModelKanji = ({ paths, strokeStarts, char, size = 140 }) => (
+  <div className="relative border-[3px] border-[var(--primary)] rounded-2xl bg-[var(--bg)] overflow-hidden shrink-0" style={{ width: size, height: size }}>
+    <div className="absolute top-0 left-1/2 w-0 h-full border-l-2 border-dashed border-[var(--primary)] opacity-20 -translate-x-1/2" />
+    <div className="absolute top-1/2 left-0 w-full h-0 border-t-2 border-dashed border-[var(--primary)] opacity-20 -translate-y-1/2" />
+    {!paths?.length && (
+      <svg viewBox="0 0 100 100" className="absolute inset-0 w-full h-full z-10">
+        <text x="50" y="53" dominantBaseline="middle" textAnchor="middle" fontSize="72" fontWeight="900" fill="var(--text)" fontFamily="'Klee One', serif">{char}</text>
+      </svg>
+    )}
+    <svg viewBox="0 0 109 109" className="w-full h-full relative z-10">
+      {paths?.map((d, i) => (
+        <path key={i} d={d} fill="none" stroke="var(--text)" strokeWidth="5" strokeLinecap="round" strokeLinejoin="round" />
+      ))}
+      {strokeStarts?.map((s, i) => (
+        <g key={`n${i}`}>
+          <circle cx={s.x * 109} cy={s.y * 109} r="6" fill="var(--panel)" stroke="var(--primary)" strokeWidth="1.5" />
+          <text x={s.x * 109} y={s.y * 109 + 0.5} dominantBaseline="central" textAnchor="middle" fontSize="7" fontWeight="bold" fill="var(--primary)">{i + 1}</text>
+        </g>
+      ))}
+    </svg>
+  </div>
+);
+
+/** なぜこの点数になったのかを、まず一言で伝える */
+function buildVerdict(answer) {
+  const g = answer.gradeResult;
+  const actual = answer.userStrokes?.length ?? 0;
+  const expected = answer.expectedStrokeCount ?? 0;
+  if (expected === 0) {
+    return {
+      tone: 'bad',
+      title: <>おてほんを よみこめなかったよ</>,
+      body: <>つうしんが うまく いかなくて、{F('採点', 'さいてん')}できなかったよ。あとで もういちど ためしてね。</>,
+    };
+  }
+  if (!g.strokeCountMatch) {
+    return {
+      tone: 'bad',
+      title: <>{F('画数', 'かくすう')}が ちがったよ</>,
+      body: <>おてほんは {expected}かく、きみは {actual}かく {F('書', 'か')}いたよ。ちがう{F('字', 'じ')}に なってしまうので 0{F('点', 'てん')}だよ。</>,
+    };
+  }
+  if (g.orderMatch === false) {
+    return {
+      tone: 'bad',
+      title: <>{F('書', 'か')}きじゅんが ちがったよ</>,
+      body: <>かたちが よくても、{F('書', 'か')}きじゅんが ちがうと {GRADING.ORDER_FAIL_CAP}{F('点', 'てん')}までに なるよ。ばんごうを くらべてみよう。</>,
+    };
+  }
+  if (g.crossMatch === false) {
+    return {
+      tone: 'bad',
+      title: <>せんの つきぬけかたが ちがったよ</>,
+      body: <>つきぬける ところと、とめる ところを おてほんで たしかめよう。</>,
+    };
+  }
+  if (answer.passed) {
+    return {
+      tone: 'good',
+      title: <>ごうかく！よく {F('書', 'か')}けたね</>,
+      body: <>{TEST.PASS_THRESHOLD}{F('点', 'てん')}いじょうで ごうかくだよ。{g.total}{F('点', 'てん')}だったよ。</>,
+    };
+  }
+  return {
+    tone: 'bad',
+    title: <>あと {TEST.PASS_THRESHOLD - g.total}{F('点', 'てん')}で ごうかくだったよ</>,
+    body: <>したの うちわけで、{F('点', 'てん')}が へった ところを みてみよう。</>,
+  };
+}
+
+/** 採点のうちわけ1行 */
+const ScoreRow = ({ label, desc, points, max }) => {
+  const ratio = max > 0 ? points / max : 0;
+  const tone = strokeTone(ratio);
+  return (
+    <div className="flex items-center gap-2">
+      <div className="w-28 shrink-0">
+        <div className="text-xs font-black text-[var(--text)] leading-tight">{label}</div>
+        <div className="text-[9px] font-bold text-[var(--text)] opacity-40 leading-tight">{desc}</div>
+      </div>
+      <div className="flex-1 h-3 rounded-full bg-[var(--text)]/10 overflow-hidden">
+        <div className="h-full rounded-full transition-all duration-500" style={{ width: `${Math.round(ratio * 100)}%`, backgroundColor: STROKE_COLORS[tone] }} />
+      </div>
+      <div className="w-14 text-right text-xs font-black shrink-0" style={{ color: STROKE_COLORS[tone] }}>
+        {points}<span className="opacity-50 font-bold">/{max}</span>
+      </div>
+    </div>
+  );
+};
+
+// --- 回答カードの詳細（なぜこの点数になったのか）---
+const AnswerDetailSheet = ({ answer, index, total, onPrev, onNext, onClose, onPractice }) => {
+  useEffect(() => {
+    const onKey = (e) => {
+      if (e.key === 'Escape') onClose();
+      if (e.key === 'ArrowLeft' && index > 0) onPrev();
+      if (e.key === 'ArrowRight' && index < total - 1) onNext();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose, onPrev, onNext, index, total]);
+
+  const g = answer.gradeResult;
+  const verdict = buildVerdict(answer);
+  const gradeLabel = getGradeLabel(g.total);
+  const actualCount = answer.userStrokes?.length ?? 0;
+  const expectedCount = answer.expectedStrokeCount ?? 0;
+  const rows = SCORE_ROWS
+    .map(row => ({ ...row, score: g.breakdown?.find(b => b.key === row.key) }))
+    .filter(row => row.score?.evaluated);
+
+  return (
+    <motion.div
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/50 p-0 sm:p-4"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label={`${answer.kanji.char} のけっか`}
+    >
+      <motion.div
+        className="bg-[var(--panel)] border-[4px] border-[var(--text)] rounded-t-3xl sm:rounded-3xl w-full max-w-lg max-h-[92vh] overflow-y-auto no-scrollbar shadow-[6px_6px_0_var(--text)]"
+        initial={{ y: 40, scale: 0.96, opacity: 0 }}
+        animate={{ y: 0, scale: 1, opacity: 1 }}
+        exit={{ y: 40, opacity: 0 }}
+        transition={{ type: 'spring', stiffness: 320, damping: 28 }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* ヘッダー */}
+        <div className="sticky top-0 z-20 flex items-center gap-3 px-4 py-3 bg-[var(--panel)] border-b-[3px] border-[var(--text)]">
+          <div className={`text-4xl font-black leading-none ${answer.passed ? 'text-emerald-600' : 'text-rose-600'}`}>{answer.kanji.char}</div>
+          <div className="flex-1 min-w-0">
+            <div className="flex items-baseline gap-1">
+              <span className={`text-2xl font-black ${answer.passed ? 'text-emerald-600' : 'text-rose-600'}`}>{g.total}</span>
+              <span className="text-xs font-black text-[var(--text)] opacity-60">{F('点', 'てん')}</span>
+              <span className="text-xs font-bold text-[var(--text)] opacity-70 truncate">{gradeLabel.label}</span>
+            </div>
+            <div className="text-[10px] font-bold text-[var(--text)] opacity-40">{index + 1} / {total} {F('問目', 'もんめ')}</div>
+          </div>
+          <button onClick={onClose} aria-label="とじる" className="shrink-0 w-9 h-9 rounded-full border-[3px] border-[var(--text)] bg-[var(--bg)] flex items-center justify-center">
+            <X size={18} />
+          </button>
+        </div>
+
+        <div className="px-4 py-3 flex flex-col gap-3">
+          {/* なぜこの点数か */}
+          <div className={`rounded-2xl border-[3px] p-3 ${verdict.tone === 'good' ? 'border-emerald-400 bg-emerald-50 dark:bg-emerald-900/20' : 'border-rose-400 bg-rose-50 dark:bg-rose-900/20'}`}>
+            <div className={`text-sm font-black mb-1 ${verdict.tone === 'good' ? 'text-emerald-700 dark:text-emerald-300' : 'text-rose-700 dark:text-rose-300'}`}>
+              {verdict.tone === 'good' ? '🎉 ' : '💡 '}{verdict.title}
+            </div>
+            <div className="text-xs font-bold text-[var(--text)] opacity-80 leading-relaxed">{verdict.body}</div>
+          </div>
+
+          {/* きみの字 と おてほん */}
+          <div className="flex items-start justify-center gap-3">
+            <div className="flex flex-col items-center gap-1">
+              <div className="text-[10px] font-black text-[var(--text)] bg-[var(--accent)] px-3 py-0.5 rounded-full border-2 border-[var(--text)]">きみの{F('字', 'じ')}</div>
+              <div className="border-[3px] border-[var(--text)] rounded-2xl bg-[var(--panel)] overflow-hidden relative" style={{ width: 140, height: 140 }}>
+                <div className="absolute top-0 left-1/2 w-0 h-full border-l-2 border-dashed border-[var(--text)] opacity-10 -translate-x-1/2" />
+                <div className="absolute top-1/2 left-0 w-full h-0 border-t-2 border-dashed border-[var(--text)] opacity-10 -translate-y-1/2" />
+                <StrokeReplay
+                  userStrokes={answer.userStrokes}
+                  canvasSize={answer.canvasSize}
+                  displaySize={140}
+                  feedback={g.strokeFeedback}
+                  showNumbers
+                />
+              </div>
+            </div>
+            <div className="flex flex-col items-center gap-1">
+              <div className="text-[10px] font-black text-[var(--panel)] bg-[var(--primary)] px-3 py-0.5 rounded-full border-2 border-[var(--text)]">おてほん</div>
+              <ModelKanji paths={answer.paths} strokeStarts={answer.strokeStarts} char={answer.kanji.char} size={140} />
+            </div>
+          </div>
+          <div className="flex items-center justify-center gap-3 text-[10px] font-bold text-[var(--text)] opacity-60">
+            <span className="flex items-center gap-1"><span className="w-3 h-1.5 rounded-full inline-block" style={{ backgroundColor: STROKE_COLORS.good }} />よい</span>
+            <span className="flex items-center gap-1"><span className="w-3 h-1.5 rounded-full inline-block" style={{ backgroundColor: STROKE_COLORS.fair }} />もうすこし</span>
+            <span className="flex items-center gap-1"><span className="w-3 h-1.5 rounded-full inline-block" style={{ backgroundColor: STROKE_COLORS.poor }} />なおそう</span>
+            <span>①＝{F('書', 'か')}いた じゅんばん</span>
+          </div>
+
+          {/* 合否のもとになる3つの条件。画数が違うときは他の2つを採点していないので中立表示にする */}
+          <div className="grid grid-cols-3 gap-2">
+            {[
+              { state: expectedCount === 0 ? 'skip' : g.strokeCountMatch ? 'ok' : 'ng', label: <>{F('画数', 'かくすう')}</>, value: `${actualCount}/${expectedCount}` },
+              { state: !g.strokeCountMatch ? 'skip' : g.orderMatch !== false ? 'ok' : 'ng', label: <>{F('書', 'か')}きじゅん</>, value: g.orderMatch !== false ? 'OK' : 'ちがう' },
+              { state: !g.strokeCountMatch ? 'skip' : g.crossMatch !== false ? 'ok' : 'ng', label: <>つきぬけ</>, value: g.crossMatch !== false ? 'OK' : 'ちがう' },
+            ].map((item, i) => (
+              <div
+                key={i}
+                className={`rounded-xl border-2 p-2 text-center ${
+                  item.state === 'ok' ? 'border-emerald-300 bg-emerald-50 dark:bg-emerald-900/20'
+                    : item.state === 'ng' ? 'border-rose-300 bg-rose-50 dark:bg-rose-900/20'
+                      : 'border-[var(--text)]/20 bg-[var(--bg)]'
+                }`}
+              >
+                <div className="text-[10px] font-bold text-[var(--text)] opacity-60">{item.label}</div>
+                <div className={`text-sm font-black ${item.state === 'ok' ? 'text-emerald-600' : item.state === 'ng' ? 'text-rose-600' : 'text-[var(--text)] opacity-40'}`}>
+                  {item.state === 'skip' ? 'ー' : `${item.state === 'ok' ? '✓' : '✗'} ${item.value}`}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* 採点のうちわけ */}
+          {rows.length > 0 && (
+            <div className="rounded-2xl border-[3px] border-[var(--text)] p-3 flex flex-col gap-2">
+              <div className="text-xs font-black text-[var(--text)] opacity-70">{F('点数', 'てんすう')}の うちわけ</div>
+              {rows.map(row => (
+                <ScoreRow key={row.key} label={row.label} desc={row.desc} points={row.score.points} max={row.score.max} />
+              ))}
+              <div className="border-t-2 border-dashed border-[var(--text)] opacity-100 pt-2 flex items-center justify-between">
+                <span className="text-xs font-black text-[var(--text)]">
+                  {F('合計', 'ごうけい')}（ごうかくは {TEST.PASS_THRESHOLD}{F('点', 'てん')}）
+                </span>
+                <span className={`text-lg font-black ${answer.passed ? 'text-emerald-600' : 'text-rose-600'}`}>{g.total}{F('点', 'てん')}</span>
+              </div>
+            </div>
+          )}
+
+          {/* 講評 */}
+          {g.details?.length > 0 && (
+            <div className="rounded-2xl border-[3px] border-[var(--text)] p-3">
+              <div className="text-xs font-black text-[var(--text)] opacity-70 mb-1.5">せんせいから ひとこと</div>
+              <ul className="flex flex-col gap-1">
+                {g.details.map((d, i) => (
+                  <li key={i} className="text-xs font-bold text-[var(--text)] opacity-80 flex gap-1.5">
+                    <span className={d.includes('✓') ? 'text-emerald-500' : 'text-amber-500'}>{d.includes('✓') ? '◎' : '・'}</span>
+                    <span>{d}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+
+        {/* フッター */}
+        <div className="sticky bottom-0 bg-[var(--panel)] border-t-[3px] border-[var(--text)] px-4 py-3 flex flex-col gap-2">
+          <MotionButton
+            variant={answer.passed ? 'secondary' : 'primary'}
+            onClick={() => onPractice(answer.kanji)}
+            className={`w-full py-3 text-sm font-black border-[3px] border-[var(--text)] ${answer.passed ? 'shadow-[0_3px_0_var(--text)]' : 'shadow-[0_3px_0_#9f1239]'}`}
+          >
+            <Pencil size={16} /> この{F('漢字', 'かんじ')}を {F('練習', 'れんしゅう')}する
+          </MotionButton>
+          <div className="flex gap-2">
+            <MotionButton variant="secondary" onClick={onPrev} disabled={index === 0} className="flex-1 py-2 text-xs font-black border-[3px] border-[var(--text)]">
+              <ChevronLeft size={16} /> まえ
+            </MotionButton>
+            <MotionButton variant="secondary" onClick={onNext} disabled={index >= total - 1} className="flex-1 py-2 text-xs font-black border-[3px] border-[var(--text)]">
+              つぎ <ChevronRight size={16} />
+            </MotionButton>
+          </div>
+        </div>
+      </motion.div>
+    </motion.div>
+  );
+};
+
 // --- メインのテストビュー ---
-const DrillTestView = ({ queue, stats, onUpdateStat, onFinish, startDrillSession, setView, setSessionData, createInitialSessionData }) => {
+const DrillTestView = ({ queue, onUpdateStat, onFinish, onReviewMistakes }) => {
   const [phase, setPhase] = useState('testing'); // 'testing' | 'results'
   const [currentIdx, setCurrentIdx] = useState(0);
   const [answers, setAnswers] = useState([]);
+  const [detailIdx, setDetailIdx] = useState(null); // 結果画面で開いている回答カード
   // 画面回転にも追従する。サイズ変更時は TestCanvas 側で書きかけの画が消える(通常モードと同じ挙動)
   const { canvasSize } = useLearningViewport('drillTest');
 
   // KanjiVGデータ
   const [strokeData, setStrokeData] = useState([]);
+  const [paths, setPaths] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
 
   const total = queue.length;
@@ -227,12 +529,14 @@ const DrillTestView = ({ queue, stats, onUpdateStat, onFinish, startDrillSession
     const load = async () => {
       setIsLoading(true);
       try {
-        const { strokeData: data } = await fetchKanjiVg(kanji.char);
+        const { strokeData: data, paths: p } = await fetchKanjiVg(kanji.char);
         if (cancelled) return;
         setStrokeData(data);
+        setPaths(p);
       } catch {
         if (cancelled) return;
         setStrokeData([]);
+        setPaths([]);
       }
       setIsLoading(false);
     };
@@ -256,12 +560,16 @@ const DrillTestView = ({ queue, stats, onUpdateStat, onFinish, startDrillSession
     // EXP累積のためonUpdateStatを呼ぶ
     onUpdateStat(kanji, passed ? 'good' : 'again', WRITING_SKILLS);
 
+    // 結果画面で「なぜこの点数か」を見せるため、お手本も回答といっしょに残す
     const answer = {
       kanji,
       userStrokes,
       canvasSize,
       gradeResult: result,
       passed,
+      paths,
+      strokeStarts: strokeData.map(s => s.s),
+      expectedStrokeCount: strokeData.length,
     };
 
     const newAnswers = [...answers, answer];
@@ -281,23 +589,18 @@ const DrillTestView = ({ queue, stats, onUpdateStat, onFinish, startDrillSession
     onFinish();
   };
 
-  // 結果: 復習
+  // 結果: 間違えた漢字だけを学習モードで復習する
   const handleReview = () => {
-    // テストのEXPを確定
-    onFinish();
-    // 不正解の漢字で新しいドリルセッションを開始
     const failedKanjis = answers.filter(a => !a.passed).map(a => a.kanji);
-    if (failedKanjis.length > 0) {
-      const expMultiplier = getSatisfactionMultiplier(calculateSatisfaction(stats));
-      setSessionData(createInitialSessionData({
-        queue: failedKanjis,
-        oldExp: stats.totalExp,
-        expMultiplier,
-        isDrill: true,
-      }));
-      // 少し遅延してからセッションビューに切り替え（onFinishの処理完了を待つ）
-      setTimeout(() => setView('session'), 50);
-    }
+    if (failedKanjis.length === 0) return;
+    audioCtrl.playSE('click');
+    onReviewMistakes(failedKanjis);
+  };
+
+  // 詳細から: この漢字1文字だけを学習モードで練習する
+  const handlePracticeOne = (kanji) => {
+    audioCtrl.playSE('click');
+    onReviewMistakes([kanji]);
   };
 
   const ex = kanji?.examples?.[Math.floor(Math.random() * (kanji?.examples?.length || 1))];
@@ -311,8 +614,6 @@ const DrillTestView = ({ queue, stats, onUpdateStat, onFinish, startDrillSession
   const currentEx = exRef.current;
 
   if (phase === 'testing') {
-    const correctCount = answers.filter(a => a.passed).length;
-
     return (
       <div className="flex flex-col h-full w-full bg-[var(--bg)] relative overflow-hidden">
         {/* ヘッダー */}
@@ -438,26 +739,57 @@ const DrillTestView = ({ queue, stats, onUpdateStat, onFinish, startDrillSession
 
       {/* 回答一覧 */}
       <div className="flex-1 overflow-auto px-4 pb-4 min-h-0">
+        <div className="flex items-center justify-center gap-1.5 mb-2 text-[11px] font-black text-[var(--text)] opacity-60">
+          <Search size={13} />
+          カードを タップすると、なぜ その{F("点数","てんすう")}か わかるよ
+        </div>
         <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-2">
           {answers.map((answer, i) => (
-            <div key={i} className={`bg-[var(--panel)] border-[3px] rounded-xl p-2 flex flex-col items-center gap-1 ${answer.passed ? 'border-emerald-400' : 'border-rose-400'}`}>
+            <button
+              key={i}
+              type="button"
+              onClick={() => { audioCtrl.playSE('click'); setDetailIdx(i); }}
+              aria-label={`${answer.kanji.char} ${answer.gradeResult.total}点 のくわしいけっかを見る`}
+              className={`bg-[var(--panel)] border-[3px] rounded-xl p-2 flex flex-col items-center gap-1 transition-transform active:scale-95 hover:-translate-y-0.5 cursor-pointer ${answer.passed ? 'border-emerald-400 hover:shadow-[3px_3px_0_#34d399]' : 'border-rose-400 hover:shadow-[3px_3px_0_#fb7185]'}`}
+            >
               <div className="relative">
-                <StrokeReplay userStrokes={answer.userStrokes} canvasSize={answer.canvasSize} displaySize={60} />
+                <StrokeReplay userStrokes={answer.userStrokes} canvasSize={answer.canvasSize} displaySize={60} feedback={answer.gradeResult.strokeFeedback} />
                 <div className={`absolute -top-1 -right-1 ${answer.passed ? 'text-emerald-500' : 'text-rose-500'}`}>
                   {answer.passed ? <CheckCircle size={16} /> : <XCircle size={16} />}
                 </div>
               </div>
               <div className="text-2xl font-black text-[var(--text)]">{answer.kanji.char}</div>
-              <div className={`text-[10px] font-black ${answer.passed ? 'text-emerald-600' : 'text-rose-600'}`}>
+              <div className={`text-[10px] font-black flex items-center gap-0.5 ${answer.passed ? 'text-emerald-600' : 'text-rose-600'}`}>
                 {answer.gradeResult.total}{F("点","てん")}
+                <ChevronRight size={11} className="opacity-60" />
               </div>
-            </div>
+            </button>
           ))}
         </div>
       </div>
 
+      {/* 回答カードの詳細 */}
+      <AnimatePresence>
+        {detailIdx !== null && answers[detailIdx] && (
+          <AnswerDetailSheet
+            answer={answers[detailIdx]}
+            index={detailIdx}
+            total={answers.length}
+            onPrev={() => setDetailIdx(i => Math.max(0, i - 1))}
+            onNext={() => setDetailIdx(i => Math.min(answers.length - 1, i + 1))}
+            onClose={() => setDetailIdx(null)}
+            onPractice={handlePracticeOne}
+          />
+        )}
+      </AnimatePresence>
+
       {/* ボタン */}
       <div className="flex-shrink-0 px-4 py-3 bg-[var(--panel)] border-t-[3px] border-[var(--text)]">
+        {!allCorrect && (
+          <div className="text-center text-[11px] font-bold text-[var(--text)] opacity-60 mb-2">
+            まちがえた{incorrectCount}{F("問","もん")}だけを、{F("書","か")}き{F("順","じゅん")}から{F("練習","れんしゅう")}できるよ
+          </div>
+        )}
         <div className="flex gap-3">
           {!allCorrect && (
             <MotionButton variant="primary" onClick={handleReview} className="flex-1 py-3 text-sm font-black border-[3px] border-[var(--text)] shadow-[0_3px_0_#9f1239]">

--- a/src/systems/strokeGrader.js
+++ b/src/systems/strokeGrader.js
@@ -49,6 +49,7 @@ function emptyResult(details, flags = {}) {
     orderMatch: false,
     assignment: [],
     strokeFeedback: [],
+    breakdown: [],
     details,
   };
 }
@@ -312,10 +313,19 @@ export function gradeStrokes(userStrokes, strokeData, canvasSize) {
   const scale = activeWeight > 0 ? 100 / activeWeight : 0;
 
   const scores = {};
+  // 内訳（結果画面で「なぜこの点数か」を示すため、満点と評価有無も添える）
+  const breakdown = [];
   let total = 0;
   for (const c of components) {
-    const points = c.ratio === null ? 0 : Math.round(clamp01(c.ratio) * c.weight * scale);
+    const evaluated = c.ratio !== null;
+    const points = evaluated ? Math.round(clamp01(c.ratio) * c.weight * scale) : 0;
     scores[c.key] = points;
+    breakdown.push({
+      key: c.key,
+      points,
+      max: evaluated ? Math.round(c.weight * scale) : 0,
+      evaluated,
+    });
     total += points;
   }
   total = Math.max(0, Math.min(100, total));
@@ -375,6 +385,7 @@ export function gradeStrokes(userStrokes, strokeData, canvasSize) {
     orderMatch,
     assignment,
     strokeFeedback,
+    breakdown,
     details,
   };
 }

--- a/test/stroke-grader.test.js
+++ b/test/stroke-grader.test.js
@@ -187,6 +187,45 @@ test('とめ・はねの正解が無いときは、その配点を他項目へ�
   assert.ok(!result.details.some(d => d.includes('とめ・はね')));
 });
 
+test('採点の内訳を返し、合計と満点が一致する（結果画面の説明に使う）', () => {
+  const result = gradeStrokes(sanUser(), SAN, CANVAS);
+  const keys = result.breakdown.map(b => b.key);
+  assert.deepEqual(keys, ['shape', 'order', 'ending', 'cross', 'start', 'end']);
+  // 「三」は交わる画が無いので交差は採点対象外。残りの項目で100点満点になる
+  assert.equal(result.breakdown.find(b => b.key === 'cross').evaluated, false);
+  const evaluatedMax = result.breakdown.filter(b => b.evaluated).reduce((sum, b) => sum + b.max, 0);
+  assert.ok(Math.abs(evaluatedMax - 100) <= 2, `按分後の満点はほぼ100: ${evaluatedMax}`);
+  assert.equal(result.breakdown.reduce((sum, b) => sum + b.points, 0), result.total);
+  // 項目ごとの点数は個別フィールドと一致する
+  const byKey = Object.fromEntries(result.breakdown.map(b => [b.key, b.points]));
+  assert.equal(byKey.shape, result.shape);
+  assert.equal(byKey.order, result.order);
+  assert.equal(byKey.start, result.startPoints);
+  assert.equal(byKey.end, result.endPoints);
+});
+
+test('評価できない項目は内訳でも「対象外」と分かり、満点は他項目へ按分される', () => {
+  const noEnding = SAN.map(s => ({ ...s, endingType: null }));
+  const result = gradeStrokes(sanUser(), noEnding, CANVAS);
+  const ending = result.breakdown.find(b => b.key === 'ending');
+  assert.equal(ending.evaluated, false);
+  assert.equal(ending.max, 0, '採点対象外なので満点も0にして表示から外せる');
+  const evaluatedMax = result.breakdown.filter(b => b.evaluated).reduce((sum, b) => sum + b.max, 0);
+  assert.ok(Math.abs(evaluatedMax - 100) <= 2, `残りの項目で100点満点になる: ${evaluatedMax}`);
+});
+
+test('画数が違うときの内訳は空になる（0点の理由は画数だけ）', () => {
+  const result = gradeStrokes(sanUser([0, 1]), SAN, CANVAS);
+  assert.deepEqual(result.breakdown, []);
+});
+
+test('書き順の誤りで上限に抑えられたときは、内訳の合計より合計点が低くなる', () => {
+  const result = gradeStrokes(sanUser([2, 1, 0]), SAN, CANVAS);
+  const sum = result.breakdown.reduce((s, b) => s + b.points, 0);
+  assert.equal(result.orderMatch, false);
+  assert.ok(result.total <= sum, `上限で抑えられる: 合計${result.total} <= 内訳${sum}`);
+});
+
 test('とめるべきところではねると、褒めずに直し方を伝える', () => {
   const strokes = sanUser();
   // 3画目の終わりで上へ跳ね上げる（速度を落とし、角度変化で「はね」と判定させる）


### PR DESCRIPTION
テスト結果のカードは点数しか出さないため、児童は「なぜ不正解なのか」
「次に何を直せばよいのか」が分からなかった。

- 回答カードをタップすると詳細シートが開く。合否の理由をまず一言で示し、
  自分の字（画ごとに色分け＋書いた順の番号）とお手本（正しい順の番号）を
  並べて比べられるようにした。画数・書き順・つきぬけの合否条件と、
  採点のうちわけ（項目ごとの得点／満点）、講評もそこにまとめた。
- 詳細シートから、その漢字1文字だけを学習モードで練習できるようにした。
- 結果画面の「復習する」は、リザルト画面を挟まず間違えた問題だけの
  学習セッションへ移る。setTimeout でビューを差し替えていた実装をやめ、
  App 側の startMistakeReview に集約してテストの成績を確定してから始める。
- 採点理由を画面側で再計算しなくてよいよう、gradeStrokes が項目ごとの
  得点・満点・評価有無を breakdown として返すようにした。
  採点対象外（例：手本に筆画種が無い）と0点を区別できる。

筆順データを取得できなかったときは、お手本に字だけを表示し、
採点できなかったことを伝える。