### PR TITLE
学習中の漢字の字形を KanjiVG に統一する

### DIFF
--- a/src/components/session/ReadMode.jsx
+++ b/src/components/session/ReadMode.jsx
@@ -3,6 +3,7 @@ import { motion, AnimatePresence, useReducedMotionConfig } from 'framer-motion';
 import { Volume2, ChevronRight, Mic } from 'lucide-react';
 import MotionButton from '../ui/MotionButton';
 import ModeLayout from '../ui/ModeLayout';
+import KanjiGlyph from '../ui/KanjiGlyph';
 import { FormatKun, RubyText, F } from '../ui/FormatKun';
 import { audioCtrl } from '../../systems/audio';
 import { useVoiceCheck } from '../../hooks/useVoiceCheck';
@@ -10,7 +11,7 @@ import { isReadingCheckEnabled, isAutoPlayEnabled } from '../../utils/reading-pr
 import { getLocalJaVoice, onVoicesChanged, speakJa, stopSpeaking, toSpeechText, toKunSpeech } from '../../utils/tts';
 import { READING } from '../../constants/gameConfig';
 
-const ReadMode = ({ kanji, onNext, commonSidebar, isStacked, settings = {}, challengeCleared = false, onChallengeClear }) => {
+const ReadMode = ({ kanji, paths = [], isLoading = false, onNext, commonSidebar, canvasSize, isStacked, settings = {}, challengeCleared = false, onChallengeClear }) => {
   const [exampleIdx, setExampleIdx] = useState(() => Math.floor(Math.random() * kanji.examples.length));
   // キュー前進時は remount されず kanji だけ差し替わるため、範囲外アクセスを防ぐ
   const safeIdx = kanji.examples.length > 0 ? exampleIdx % kanji.examples.length : 0;
@@ -85,7 +86,12 @@ const ReadMode = ({ kanji, onNext, commonSidebar, isStacked, settings = {}, chal
     if (!micActive) audioCtrl.playSE('click');
   };
 
-  const main = (<div className="text-[clamp(10rem,30vmin,22rem)] leading-none font-black text-[var(--text)] drop-shadow-md select-none" style={{ fontFamily: "'Klee One', serif" }}>{kanji.char}</div>);
+  // なぞり書き・書き順と同じ KanjiVG の字形で見せる（モードごとに形が変わらないように）
+  const main = (
+    <div className="select-none shrink-0" style={{ width: canvasSize || 'clamp(10rem,30vmin,22rem)', maxWidth: '100%', maxHeight: '100%', aspectRatio: '1/1' }}>
+      <KanjiGlyph char={kanji.char} paths={paths} loading={isLoading} className="w-full h-full drop-shadow-md" />
+    </div>
+  );
 
   const statusCopy = status === 'requesting'
     ? <>マイクの じゅんびちゅう…</>

--- a/src/components/session/SessionView.jsx
+++ b/src/components/session/SessionView.jsx
@@ -195,10 +195,10 @@ const SessionView = ({ queue: initialQueue, totalCount, stats, settings = {}, on
           </div>
         ) : (
           <>
-            {mode === 'read' && <ReadMode kanji={currentKanji} settings={settings} challengeCleared={voicedKanjiIds.has(currentKanji.id)} onChallengeClear={handleChallengeClear} onNext={() => { recordSkills([{ skill: 'reading', evidence: 'exposed' }, { skill: 'meaning', evidence: 'exposed' }]); setMode('watch'); }} commonSidebar={commonSidebarTop} isStacked={isStacked} />}
+            {mode === 'read' && <ReadMode kanji={currentKanji} paths={paths} isLoading={isLoading} settings={settings} challengeCleared={voicedKanjiIds.has(currentKanji.id)} onChallengeClear={handleChallengeClear} onNext={() => { recordSkills([{ skill: 'reading', evidence: 'exposed' }, { skill: 'meaning', evidence: 'exposed' }]); setMode('watch'); }} canvasSize={canvasSize} commonSidebar={commonSidebarTop} isStacked={isStacked} />}
             {mode === 'watch' && <WatchMode paths={paths} strokeData={strokeData} isLoading={isLoading} onNext={() => { recordSkills([{ skill: 'stroke', evidence: 'exposed' }]); setMode('write'); }} canvasSize={canvasSize} commonSidebar={commonSidebarTop} isStacked={isStacked} />}
             {mode === 'write' && <WriteMode paths={paths} strokeData={strokeData} crossMatrix={crossMatrix} onNext={() => setMode('test')} onPracticeComplete={(evidence) => recordSkills([{ skill: 'writing', evidence }, { skill: 'stroke', evidence }])} canvasSize={canvasSize} commonSidebar={commonSidebarTop} onRecordPerfect={onRecordPerfect} isStacked={isStacked} />}
-            {mode === 'test' && <TestMode kanji={currentKanji} strokeData={strokeData} onEvaluate={handleEvaluation} canvasSize={canvasSize} commonSidebar={commonSidebarTop} isStacked={isStacked} />}
+            {mode === 'test' && <TestMode kanji={currentKanji} paths={paths} isLoading={isLoading} strokeData={strokeData} onEvaluate={handleEvaluation} canvasSize={canvasSize} commonSidebar={commonSidebarTop} isStacked={isStacked} />}
           </>
         )}
       </div>

--- a/src/components/session/TestMode.jsx
+++ b/src/components/session/TestMode.jsx
@@ -3,6 +3,7 @@ import { Eye, RotateCcw, Undo2 } from 'lucide-react';
 import { motion } from 'framer-motion';
 import MotionButton from '../ui/MotionButton';
 import ModeLayout from '../ui/ModeLayout';
+import KanjiGlyph from '../ui/KanjiGlyph';
 import { FormatKun, F } from '../ui/FormatKun';
 import { audioCtrl } from '../../systems/audio';
 import { gradeStrokes } from '../../systems/strokeGrader';
@@ -37,7 +38,7 @@ const EVAL_BUTTONS = [
   { key: 'again', variant: 'danger', label: '忘れた💦', hint: 'もう一度', shadow: 'shadow-[0_4px_0_#334155]' },
 ];
 
-const TestMode = ({ kanji, strokeData, onEvaluate, canvasSize, commonSidebar, isStacked }) => {
+const TestMode = ({ kanji, paths = [], isLoading = false, strokeData, onEvaluate, canvasSize, commonSidebar, isStacked }) => {
   const [showAnswer, setShowAnswer] = useState(false);
   const canvasRef = useRef(null);
   const [isDrawing, setIsDrawing] = useState(false);
@@ -165,7 +166,7 @@ const TestMode = ({ kanji, strokeData, onEvaluate, canvasSize, commonSidebar, is
         <div className="relative border-[4px] border-[var(--primary)] rounded-[20px] bg-[var(--bg)] overflow-hidden flex items-center justify-center transition-all duration-200 shadow-[4px_4px_0_var(--primary)] md:shadow-[8px_8px_0_var(--primary)] animate-in fade-in slide-in-from-left-4 shrink-0" style={{ width: canvasSize, maxWidth: 'calc(50% - 16px)', maxHeight: '100%', aspectRatio: '1/1' }}>
           <div className="absolute top-0 left-1/2 w-0 h-full border-l-4 border-dashed border-[var(--primary)] opacity-20 -translate-x-1/2 pointer-events-none" />
           <div className="absolute top-1/2 left-0 w-full h-0 border-t-4 border-dashed border-[var(--primary)] opacity-20 -translate-y-1/2 pointer-events-none" />
-          <svg viewBox="0 0 100 100" className="w-full h-full relative z-10 pointer-events-none select-none drop-shadow-sm"><text x="50" y="53" dominantBaseline="middle" textAnchor="middle" fontSize="80" fontWeight="900" fill="var(--primary)" fontFamily="'Klee One', serif">{kanji.char}</text></svg>
+          <KanjiGlyph char={kanji.char} paths={paths} loading={isLoading} color="var(--primary)" className="w-full h-full relative z-10 pointer-events-none select-none drop-shadow-sm" />
           <div className="absolute top-3 right-3 bg-[var(--primary)] text-[var(--panel)] text-[10px] md:text-xs font-black px-3 md:px-4 py-1.5 rounded-full border-[3px] border-[var(--text)] shadow-sm z-20">こたえ</div>
         </div>
       )}

--- a/src/components/training/DrillTestView.jsx
+++ b/src/components/training/DrillTestView.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { ChevronRight, ChevronLeft, RefreshCw, CheckCircle, XCircle, RotateCcw, LogOut, X, Search, Pencil } from 'lucide-react';
 import MotionButton from '../ui/MotionButton';
+import KanjiGlyph from '../ui/KanjiGlyph';
 import { audioCtrl } from '../../systems/audio';
 import { F, SurvivalRubyText, FormatKun } from '../ui/FormatKun';
 import { gradeStrokes, getGradeLabel } from '../../systems/strokeGrader';
@@ -248,15 +249,8 @@ const ModelKanji = ({ paths, strokeStarts, char, size = 140 }) => (
   <div className="relative border-[3px] border-[var(--primary)] rounded-2xl bg-[var(--bg)] overflow-hidden shrink-0" style={{ width: size, height: size }}>
     <div className="absolute top-0 left-1/2 w-0 h-full border-l-2 border-dashed border-[var(--primary)] opacity-20 -translate-x-1/2" />
     <div className="absolute top-1/2 left-0 w-full h-0 border-t-2 border-dashed border-[var(--primary)] opacity-20 -translate-y-1/2" />
-    {!paths?.length && (
-      <svg viewBox="0 0 100 100" className="absolute inset-0 w-full h-full z-10">
-        <text x="50" y="53" dominantBaseline="middle" textAnchor="middle" fontSize="72" fontWeight="900" fill="var(--text)" fontFamily="'Klee One', serif">{char}</text>
-      </svg>
-    )}
+    <KanjiGlyph char={char} paths={paths ?? []} strokeWidth={5} className="absolute inset-0 w-full h-full z-10" />
     <svg viewBox="0 0 109 109" className="w-full h-full relative z-10">
-      {paths?.map((d, i) => (
-        <path key={i} d={d} fill="none" stroke="var(--text)" strokeWidth="5" strokeLinecap="round" strokeLinejoin="round" />
-      ))}
       {strokeStarts?.map((s, i) => (
         <g key={`n${i}`}>
           <circle cx={s.x * 109} cy={s.y * 109} r="6" fill="var(--panel)" stroke="var(--primary)" strokeWidth="1.5" />

--- a/src/components/training/FlashcardView.jsx
+++ b/src/components/training/FlashcardView.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Timer } from 'lucide-react';
 import MotionButton from '../ui/MotionButton';
+import KanjiGlyph from '../ui/KanjiGlyph';
 import { audioCtrl } from '../../systems/audio';
 import { F, FormatKun } from '../ui/FormatKun';
 import { migrateCard, calculateNextReview, recordPracticeAttempt } from '../../systems/srs';
@@ -146,10 +147,10 @@ const FlashcardView = ({ queue, stats, setStats, onFinish }) => {
             animate={{ scale: 1, opacity: 1, x: 0 }}
             exit={{ scale: 1.1, opacity: 0, x: -30 }}
             transition={{ type: 'spring', stiffness: 300, damping: 25 }}
-            className="text-[10rem] md:text-[14rem] font-black leading-none"
-            style={{ fontFamily: "'Klee One', serif" }}
+            className="w-[10rem] h-[10rem] md:w-[14rem] md:h-[14rem] max-w-full"
           >
-            {kanji.char}
+            {/* なぞり書きと同じ KanjiVG の字形にそろえる */}
+            <KanjiGlyph char={kanji.char} className="w-full h-full" />
           </motion.div>
         </AnimatePresence>
 

--- a/src/components/ui/KanjiGlyph.jsx
+++ b/src/components/ui/KanjiGlyph.jsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from 'react';
+import { fetchKanjiVgPaths } from '../../systems/kanjiVg';
+
+/** KanjiVG の座標系（なぞり書き・書き順アニメと同じ） */
+const VIEWBOX = 109;
+
+/**
+ * 学習中の漢字を表示するコンポーネント
+ *
+ * 音読・テスト・フラッシュカードなどの表示を、なぞり書きや書き順で使う
+ * KanjiVG の字形に統一する。Webフォント（Klee One）と KanjiVG では
+ * 字形が違うため、同じ漢字なのにモードごとに形が変わって見えてしまう。
+ *
+ * paths を渡した場合は自分で取得しない（すでに読み込み済みのデータを使う）。
+ * 渡さない場合は char から取得する（メモリ/IndexedDB キャッシュが効く）。
+ * 取得できないとき（オフラインなど）だけ Webフォントにフォールバックする。
+ *
+ * @param {object} props
+ * @param {string} props.char - 漢字1文字
+ * @param {string[]} [props.paths] - 読み込み済みの画パス（渡すと自前取得しない）
+ * @param {boolean} [props.loading] - paths を渡すとき、その読み込み中かどうか
+ * @param {string} [props.color] - 字の色
+ * @param {number} [props.strokeWidth] - 線の太さ（viewBox 109 基準）
+ */
+const KanjiGlyph = ({
+  char,
+  paths: providedPaths,
+  loading: providedLoading = false,
+  color = 'var(--text)',
+  strokeWidth = 6,
+  className = 'w-full h-full',
+  style,
+}) => {
+  const isProvided = Array.isArray(providedPaths);
+  const [fetchedPaths, setFetchedPaths] = useState(null);
+  const [selfLoading, setSelfLoading] = useState(!isProvided);
+
+  useEffect(() => {
+    if (isProvided) return undefined;
+    let alive = true;
+    const abortCtrl = new AbortController();
+    setSelfLoading(true);
+    fetchKanjiVgPaths(char, { signal: abortCtrl.signal })
+      .then(p => { if (alive) { setFetchedPaths(p); setSelfLoading(false); } })
+      // 取れなければフォント表示にフォールバックする
+      .catch(() => { if (alive) { setFetchedPaths([]); setSelfLoading(false); } });
+    return () => { alive = false; abortCtrl.abort(); };
+  }, [char, isProvided]);
+
+  const paths = isProvided ? providedPaths : (fetchedPaths ?? []);
+  const loading = isProvided ? providedLoading : selfLoading;
+  const hasPaths = paths.length > 0;
+
+  return (
+    <svg
+      viewBox={`0 0 ${VIEWBOX} ${VIEWBOX}`}
+      className={className}
+      style={style}
+      role="img"
+      aria-label={char}
+    >
+      {hasPaths ? (
+        paths.map((d, i) => (
+          <path key={i} d={d} fill="none" stroke={color} strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" />
+        ))
+      ) : (
+        // 読み込み中は字形が入れ替わって見えないよう、薄いガイドとして出す
+        <text
+          x={VIEWBOX / 2}
+          y={VIEWBOX / 2 + 3}
+          dominantBaseline="middle"
+          textAnchor="middle"
+          fontSize={VIEWBOX * 0.82}
+          fontWeight="900"
+          fill={color}
+          fontFamily="'Klee One', serif"
+          opacity={loading ? 0.15 : 1}
+        >
+          {char}
+        </text>
+      )}
+    </svg>
+  );
+};
+
+export default KanjiGlyph;

--- a/src/components/ui/index.js
+++ b/src/components/ui/index.js
@@ -11,3 +11,4 @@ export { default as StorageErrorBanner } from './StorageErrorBanner';
 export { default as MobileBottomNav } from './MobileBottomNav';
 export { default as BackExitHint } from './BackExitHint';
 export { default as LeaveLearningDialog } from './LeaveLearningDialog';
+export { default as KanjiGlyph } from './KanjiGlyph';

--- a/src/systems/kanjiVg.js
+++ b/src/systems/kanjiVg.js
@@ -144,7 +144,7 @@ function buildStrokeData(strokes) {
 }
 
 /**
- * 漢字のKanjiVGデータを取得する
+ * 漢字の画データ（d属性＋筆画種）を取得する
  *
  * キャッシュ戦略:
  * 1. メモリキャッシュ（即返却）
@@ -154,20 +154,17 @@ function buildStrokeData(strokes) {
  * @param {string} char - 漢字1文字
  * @param {object} [options]
  * @param {AbortSignal} [options.signal] - キャンセル用シグナル
- * @returns {Promise<{ paths: string[], strokeData: Array<{s: {x: number, y: number}, e: {x: number, y: number}, points: Array}> }>}
+ * @returns {Promise<Array<{d: string, type: string|null}>>}
  * @throws {Error} 全リトライ失敗時 or AbortError
  */
-export async function fetchKanjiVg(char, options = {}) {
+async function loadStrokes(char, options = {}) {
   const { signal } = options;
   const hex = char.charCodeAt(0).toString(16).padStart(5, '0');
 
   if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
 
   // 1. メモリキャッシュ
-  if (memoryCache.has(hex)) {
-    const cached = memoryCache.get(hex);
-    return { paths: cached.map(s => s.d), strokeData: buildStrokeData(cached) };
-  }
+  if (memoryCache.has(hex)) return memoryCache.get(hex);
 
   // 2. IndexedDB キャッシュ
   const idbCached = await idbGet(hex);
@@ -178,7 +175,7 @@ export async function fetchKanjiVg(char, options = {}) {
   if (idbCached && !legacyStrokes) {
     const strokes = normalizeCachedStrokes(idbCached);
     memoryCache.set(hex, strokes);
-    return { paths: strokes.map(s => s.d), strokeData: buildStrokeData(strokes) };
+    return strokes;
   }
 
   // 3. ネットワーク取得（リトライ付き）
@@ -194,7 +191,7 @@ export async function fetchKanjiVg(char, options = {}) {
   } catch (e) {
     if (legacyStrokes && !signal?.aborted && e?.name !== 'AbortError') {
       memoryCache.set(hex, legacyStrokes);
-      return { paths: legacyStrokes.map(s => s.d), strokeData: buildStrokeData(legacyStrokes) };
+      return legacyStrokes;
     }
     throw e;
   }
@@ -203,7 +200,35 @@ export async function fetchKanjiVg(char, options = {}) {
   memoryCache.set(hex, strokes);
   idbSet(hex, strokes);
 
+  return strokes;
+}
+
+/**
+ * 漢字のKanjiVGデータ（描画用パス＋採点用の座標列）を取得する
+ *
+ * @param {string} char - 漢字1文字
+ * @param {object} [options]
+ * @param {AbortSignal} [options.signal] - キャンセル用シグナル
+ * @returns {Promise<{ paths: string[], strokeData: Array<{s: {x: number, y: number}, e: {x: number, y: number}, points: Array}> }>}
+ * @throws {Error} 全リトライ失敗時 or AbortError
+ */
+export async function fetchKanjiVg(char, options = {}) {
+  const strokes = await loadStrokes(char, options);
   return { paths: strokes.map(s => s.d), strokeData: buildStrokeData(strokes) };
+}
+
+/**
+ * 表示だけに使う画パスを取得する（採点用の座標列は組み立てない軽量版）
+ *
+ * @param {string} char - 漢字1文字
+ * @param {object} [options]
+ * @param {AbortSignal} [options.signal] - キャンセル用シグナル
+ * @returns {Promise<string[]>} 各画の d 属性
+ * @throws {Error} 全リトライ失敗時 or AbortError
+ */
+export async function fetchKanjiVgPaths(char, options = {}) {
+  const strokes = await loadStrokes(char, options);
+  return strokes.map(s => s.d);
 }
 
 /**


### PR DESCRIPTION
音読モードやフラッシュカードは Webフォント(Klee One)、なぞり書きや
書き順は KanjiVG と、同じ漢字でもモードによって字形が変わっていた。

共通コンポーネント KanjiGlyph を追加し、学習中の漢字は なぞり書き以降と
同じ KanjiVG の筆画で表示するようにそろえる。KanjiVG を取得できないとき
(オフラインなど)だけ、これまで通り Webフォントで表示する。

- KanjiGlyph: 画パスを渡せばそれを使い、渡さなければ char から取得する
- 音読モード: なぞり書きと同じ大きさ・字形で表示（読み込み済みパスを共有）
- テストモードの「こたえ」・フラッシュカードも同じ字形にそろえる
- ドリルテストの「おてほん」を KanjiGlyph に置き換え
- kanjiVg: 表示だけに使う軽量版 fetchKanjiVgPaths を追加

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01V9nF5N6rGh6URq15eCUQft